### PR TITLE
Cancel superseded CI runs via concurrency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: read
 
+# Cancel an in-progress run when a newer commit supersedes it. Grouping by
+# github.ref isolates each PR (refs/pull/N/merge) and the main branch
+# (refs/heads/main), so a push to one never cancels another's run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a workflow-level `concurrency` block to `ci.yml` so that pushing a new commit cancels the prior in-progress CI run for the same ref, instead of letting superseded runs finish.

## Change

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

- Keyed on `github.ref`, which isolates each PR (`refs/pull/N/merge`) and the main branch (`refs/heads/main`) into separate groups — a push to one PR never cancels another PR's or main's run.
- `cancel-in-progress: true` stops the stale run when a newer commit arrives, saving runner minutes and giving faster feedback on the latest commit.

## Notes

- CI-only change; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkFCG3ehwNmqhTJHnFxqd)_