### PR TITLE
Test: verify branch protection required checks (do not merge)

### DIFF
--- a/breakout/scripts/test-breakout.mjs
+++ b/breakout/scripts/test-breakout.mjs
@@ -74,3 +74,8 @@ import { runBreakout } from "../breakout.mjs";
 }
 
 console.log("breakout: all tests passed");
+
+// TEMPORARY: deliberate failure to verify branch-protection required checks.
+// This commit lives only on the throwaway claude/verify-branch-protection
+// branch and will be discarded; it must never reach main.
+throw new Error("branch-protection-verification: intentional failing check");

--- a/docs/examples/branch-protection-check.md
+++ b/docs/examples/branch-protection-check.md
@@ -1,0 +1,4 @@
+# Branch protection verification
+
+Throwaway PR to confirm required status checks gate merging on `main`.
+Close without merging.


### PR DESCRIPTION
Throwaway PR to verify that branch protection on `main` requires the CI status checks to pass before merging. **Do not merge — will be closed after verification.**

Opened as a non-draft (not the usual draft) specifically so the mergeable state reflects branch-protection gating rather than draft status.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkFCG3ehwNmqhTJHnFxqd)_