### PR TITLE
build-gate: re-verify every team's breakout record on facts

### DIFF
--- a/build-gate/gate.mjs
+++ b/build-gate/gate.mjs
@@ -271,7 +271,12 @@ function validateMarketReadinessPackets(dossier, marketPackets, blockers, warnin
       blockers.push(`${packet.model ?? "unknown"} says LEXI-class UI needs-work for a user-facing market-bound build.`);
     }
 
-    if (packet.lexi_class_ui_status === "meets") {
+    // Re-verify a breakout record on ANY market packet that carries one — every
+    // team's claim is checked on facts, not just the UI team's. A lexi 'meets'
+    // packet still REQUIRES a breakout (the missing-record blocker is raised
+    // inside validateBreakoutRecord), preserving prior behavior; packets that
+    // carry no breakout are unaffected (legacy market packets keep passing).
+    if (packet.lexi_class_ui_status === "meets" || (packet.breakout && typeof packet.breakout === "object")) {
       validateBreakoutRecord(packet, blockers, warnings, dossier, source, signed);
     }
 

--- a/build-gate/package.json
+++ b/build-gate/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "Local Codex validator for multi-model build-gate dossiers and approval packets.",
   "scripts": {
-    "check": "node --check gate.mjs && node --check sign.mjs && node --check council.mjs && node --check scripts/test-gate.mjs && node --check scripts/test-sign.mjs && node --check scripts/test-trust.mjs && node --check scripts/test-council-orchestrator.mjs && node --check scripts/stress-test-gate.mjs && node --check scripts/stress-tests.mjs",
-    "test": "npm run check && node scripts/test-gate.mjs && node scripts/test-sign.mjs && node scripts/test-trust.mjs && node scripts/test-council-orchestrator.mjs && node scripts/stress-test-gate.mjs && node scripts/stress-tests.mjs && npm --prefix ../breakout test"
+    "check": "node --check gate.mjs && node --check sign.mjs && node --check council.mjs && node --check scripts/test-gate.mjs && node --check scripts/test-sign.mjs && node --check scripts/test-trust.mjs && node --check scripts/test-council-orchestrator.mjs && node --check scripts/test-breakout-coverage.mjs && node --check scripts/stress-test-gate.mjs && node --check scripts/stress-tests.mjs",
+    "test": "npm run check && node scripts/test-gate.mjs && node scripts/test-sign.mjs && node scripts/test-trust.mjs && node scripts/test-council-orchestrator.mjs && node scripts/test-breakout-coverage.mjs && node scripts/stress-test-gate.mjs && node scripts/stress-tests.mjs && npm --prefix ../breakout test"
   },
   "engines": {
     "node": ">=18"

--- a/build-gate/scripts/test-breakout-coverage.mjs
+++ b/build-gate/scripts/test-breakout-coverage.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// test-breakout-coverage.mjs — the gate re-verifies EVERY team's breakout record
+// on facts, not just the UI team's. A non-UI market packet that carries a
+// breakout has its declarative checks re-run against disk; fabricated/absent
+// facts block even when lexi_class_ui_status is "not-applicable".
+//
+// Runs from the build-gate dir, so file_exists "gate.mjs" resolves to a real file.
+
+import assert from "node:assert/strict";
+import { validateRecords } from "../gate.mjs";
+
+const TS = "2026-06-28T00:00:00-04:00";
+
+const approval = (model) => ({
+  build_id: "bc", use_case: "breakout-coverage", model, role: "builder",
+  docs_reviewed: [], proposal_ref: "x", decision: "approve",
+  required_edits: [], hard_stops: [], confidence: "high", timestamp: TS
+});
+
+function marketPacket(checks, lexi = "not-applicable") {
+  return {
+    build_id: "bc", idea_id: "idea-bc", model: "codex", project_state: "demo",
+    workstreams_reviewed: ["backend-schema"],
+    business_thesis: "Deterministic forensics earns trust.", target_users: ["evaluators"],
+    architecture_findings: [], backend_schema_findings: ["RLS enforced"], security_findings: [],
+    accuracy_eval_findings: [], scalability_findings: [], frontend_design_findings: [],
+    lexi_class_ui_status: lexi, go_to_market_blockers: [],
+    breakout: {
+      workstream: "backend-schema", claimedStatus: "meets", finalStatus: "meets",
+      converged: true, surviving_blockers: [], go_to_market_blockers: [],
+      checks, rounds: [{ round: 1, blockers: [], resolved: [] }]
+    },
+    recommendation_to_claude: "go", timestamp: TS
+  };
+}
+
+// Non-UI (user_facing_frontend:false) so the frontend-meets requirement is off.
+const dossier = {
+  build_id: "bc", idea_id: "idea-bc", use_case: "breakout-coverage", objective: "o",
+  required_docs: [], write_targets: [], protected_paths: [],
+  market_bound: true, user_facing_frontend: false,
+  required_market_workstreams: ["backend-schema"]
+};
+const approvals = ["claude", "agy", "codex"].map(approval);
+
+// 1. A non-UI team's breakout with a check that holds is re-verified -> pass.
+const pass = validateRecords(dossier, approvals, {}, [], [marketPacket([{ type: "file_exists", path: "gate.mjs" }])]);
+assert.equal(pass.gate_status, "pass",
+  "non-UI breakout with a passing check should pass; blockers=" + JSON.stringify(pass.blockers));
+
+// 2. The SAME packet with a check that does NOT hold is now re-verified -> blocked.
+//    (Before this change a 'not-applicable' packet's breakout was never re-run.)
+const blocked = validateRecords(dossier, approvals, {}, [], [marketPacket([{ type: "file_exists", path: "does-not-exist.xyz" }])]);
+assert.equal(blocked.gate_status, "blocked", "non-UI breakout with a failing check must block");
+assert.ok(blocked.blockers.some((b) => b.includes("FAILED gate re-verification")),
+  "should cite re-verification failure; blockers=" + JSON.stringify(blocked.blockers));
+
+console.log("breakout-coverage: OK — every team's breakout record is re-verified on facts");


### PR DESCRIPTION
## Summary

Makes the market gate enforce what the saas-forge already does: **every team's breakout is re-verified on disk, not just the UI team's.**

Previously the gate re-ran a breakout record's declarative checks only when `lexi_class_ui_status === "meets"` (the frontend team). Now it re-verifies **any market packet that carries a breakout record**, regardless of lexi status — so each SaaS team's claim is checked on facts.

## Change (`build-gate/gate.mjs`)

```js
if (packet.lexi_class_ui_status === "meets" || (packet.breakout && typeof packet.breakout === "object")) {
  validateBreakoutRecord(packet, blockers, warnings, dossier, source, signed);
}
```

**Strictly additive — nothing weakens:**
- `lexi "meets"` still *requires* a breakout (the missing-record blocker is raised inside `validateBreakoutRecord`), preserving prior behavior.
- Packets that carry no breakout are unaffected. Every existing fixture with a breakout already declares lexi `meets`, and the `not-applicable` fixtures carry no breakout — so legacy behavior is unchanged (verified: `build-gate` + `saas-forge` suites pass).

## Test

Adds `scripts/test-breakout-coverage.mjs`: a non-UI (`not-applicable`) market packet with a passing check re-verifies to **pass**; the same packet with a check that doesn't hold now **blocks** (it was never re-run before).

## Effect on the forge

The saas-forge emits a breakout record per team; with this change the **gate** independently re-verifies all seven on disk — closing the gap noted in the saas-forge PR (the forge enforced per-team breakouts; now the gate does too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkFCG3ehwNmqhTJHnFxqd)_