### PR TITLE
saas-forge: live wiring — seat-backed generation + council+fact breakout

### DIFF
--- a/saas-forge/breakouts.mjs
+++ b/saas-forge/breakouts.mjs
@@ -14,7 +14,7 @@ import { WORKSTREAMS } from "./workstreams.mjs";
 
 // Fact challenger/builder for one team. `repair` (optional) regenerates failing
 // artifacts in live mode; offline it is a no-op, so unmet checks honestly survive.
-function factBreakout({ checks, baseDir, repair }) {
+export function factBreakout({ checks, baseDir, repair }) {
   return {
     challenge: () => {
       const r = reverifyRecord({ checks }, baseDir);
@@ -32,13 +32,17 @@ function factBreakout({ checks, baseDir, repair }) {
 /**
  * Run every team's breakout against the built project. Returns one record per
  * workstream: { workstream, finalStatus, converged, surviving_blockers, rounds,
- * checks }. `repairFor(id)` optionally returns a live repair fn for that team.
+ * checks }.
+ *   makeFns({ workstream, checks, baseDir }) -> { challenge, revise }
+ *     Default = factBreakout (verdict purely on disk). Live = council+fact (a
+ *     grok adversary on top of the fact checks, with a builder-team revise).
  */
-export async function runTeamBreakouts({ baseDir, architecture, maxRounds = 3, repairFor }) {
+export async function runTeamBreakouts({ baseDir, architecture, maxRounds = 3, makeFns }) {
+  const build = makeFns || (({ checks }) => factBreakout({ checks, baseDir }));
   const records = [];
   for (const ws of WORKSTREAMS) {
     const checks = ws.checks(architecture);
-    const fns = factBreakout({ checks, baseDir, repair: repairFor ? repairFor(ws.id) : undefined });
+    const fns = build({ workstream: ws.id, checks, baseDir });
     const record = await runBreakout(
       { workstream: ws.id, claimedStatus: "meets", goalStatus: "meets",
         evidence: `${ws.id} artifacts: ${ws.files.join(", ")}`, maxRounds },

--- a/saas-forge/forge.mjs
+++ b/saas-forge/forge.mjs
@@ -112,6 +112,7 @@ export async function forge({
   dossierMeta,
   docsFor = offlineDocsFor,
   makeGenerators = makeDemoGenerators,
+  makeBreakoutFns,
   maxCycles = 3
 }) {
   const telosDir = path.join(projectRoot, ".telos");
@@ -142,7 +143,7 @@ export async function forge({
     const built = report.merge_status === "ready";
 
     // Every team is adversarially challenged on its own artifact (verdict-on-facts).
-    teams = built ? await runTeamBreakouts({ baseDir: projectRoot, architecture }) : [];
+    teams = built ? await runTeamBreakouts({ baseDir: projectRoot, architecture, makeFns: makeBreakoutFns }) : [];
     const teamsConverged = built && teams.length > 0 && teams.every((t) => t.converged);
 
     verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams }) : null;

--- a/saas-forge/live.mjs
+++ b/saas-forge/live.mjs
@@ -1,0 +1,105 @@
+// live.mjs — wire the forge to live models through the ai-peer-mcp tools.
+//
+// Two injected boundaries become real here:
+//   1. generation  — each team's artifacts are authored by its model seat
+//      (`<model>_ask`) instead of the deterministic demo renderers.
+//   2. breakout    — each team's claim faces a grok adversary (makeCouncilBreakout)
+//      ON TOP OF the on-disk fact checks: a team converges only when no grok
+//      blocker survives AND every fact check holds. Verdict stays anchored to disk.
+//
+// The transport (`callTool`) is injected, so this module is testable with a stub
+// and no API keys; runForgeLive spawns the real ai-peer-mcp server.
+
+import { spawnMcpClient } from "../breakout/mcp_client.mjs";
+import { makeCouncilBreakout } from "../breakout/breakout.mjs";
+import { forge } from "./forge.mjs";
+import { factBreakout } from "./breakouts.mjs";
+import { workstreamById } from "./workstreams.mjs";
+
+const PNG_1x1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64"
+);
+const isBinary = (rel) => /\.(png|jpe?g|gif|webp|ico)$/i.test(rel);
+
+function parseFileMap(text) {
+  if (typeof text !== "string") return null;
+  const m = text.match(/\{[\s\S]*\}/);
+  if (!m) return null;
+  try {
+    const obj = JSON.parse(m[0]);
+    return obj && typeof obj === "object" ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// Seat-backed generation: each team's builder seat authors its files. Binary
+// assets the text seat can't emit (screenshots) get a non-empty placeholder so
+// the harness — not the model — owns rendering.
+export function liveGenerators({ callTool }) {
+  return (arch) => async (injected) => {
+    const ws = workstreamById(injected.id);
+    const model = (ws && ws.signer) || "claude";
+    const prompt =
+      `You are the builder seat for the "${injected.id}" team of a SaaS product.\n` +
+      `Requirements: ${injected.requirements}\n\n` +
+      `Produce the EXACT files listed. Return ONLY a JSON object mapping each path ` +
+      `to its full file contents as a string. Binary assets (.png) may be omitted.\n` +
+      `TEAM:${injected.id}\nFILES:${JSON.stringify(injected.files)}\n`;
+    const text = await callTool(`${model}_ask`, {
+      system: `You build production-grade ${injected.id} artifacts for a market-ready SaaS.`,
+      prompt
+    });
+    const produced = parseFileMap(text) || {};
+    const out = {};
+    for (const rel of injected.files) {
+      if (typeof produced[rel] === "string") out[rel] = produced[rel];
+      else if (isBinary(rel)) out[rel] = PNG_1x1;
+      else throw new Error(`${injected.id}: seat did not return required file ${rel}`);
+    }
+    return out;
+  };
+}
+
+// Council (grok adversary) layered on the fact checks. A blocker survives if the
+// adversary raises it OR a fact check fails — so the model can never talk a team
+// past missing evidence.
+export function makeCouncilFactFns({ callTool, team, reviewer, challengerTool, challengerModel }) {
+  const council = makeCouncilBreakout({ callTool, team, reviewer, challengerTool, challengerModel });
+  return ({ workstream, checks, baseDir }) => {
+    const facts = factBreakout({ checks, baseDir });
+    return {
+      challenge: async (state) => {
+        const f = facts.challenge();
+        const g = (await council.challenge({ ...state, workstream })) || {};
+        const blockers = [...new Set([...(f.blockers || []), ...((g.blockers) || [])])];
+        return { blockers };
+      },
+      revise: (state, blockers) => council.revise({ ...state, workstream }, blockers)
+    };
+  };
+}
+
+/**
+ * Run the forge against live model seats. Spawns the ai-peer-mcp server, wires
+ * `callTool`, and runs the same forge loop with live generation + council+fact
+ * breakouts. Requires API keys in the server's environment (claude/codex/grok).
+ */
+export async function runForgeLive({
+  projectRoot, telos, dossierMeta, serverPath, docsFor,
+  team, reviewer, maxCycles = 3
+}) {
+  const { client, close } = spawnMcpClient({ serverPath });
+  const callTool = (name, args) => client.callTool(name, args);
+  try {
+    return await forge({
+      projectRoot, telos, dossierMeta, docsFor,
+      makeGenerators: liveGenerators({ callTool }),
+      makeBreakoutFns: makeCouncilFactFns({ callTool, team, reviewer }),
+      maxCycles
+    });
+  } finally {
+    close();
+  }
+}

--- a/saas-forge/package.json
+++ b/saas-forge/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "TELOS SaaS forge: research capabilities (Context7-ready), generate artifacts through merkle-dag dispatch, run an adversarial breakout per team (verdict-on-facts), settle a signed ledger, and gate to market-readiness — cyclically until certified.",
   "scripts": {
-    "check": "node --check research.mjs && node --check workstreams.mjs && node --check generator.mjs && node --check plan.mjs && node --check breakouts.mjs && node --check forge.mjs && node --check checks/check-node.mjs && node --check scripts/test-forge.mjs",
-    "test": "npm run check && node scripts/test-forge.mjs"
+    "check": "node --check research.mjs && node --check workstreams.mjs && node --check generator.mjs && node --check plan.mjs && node --check breakouts.mjs && node --check forge.mjs && node --check live.mjs && node --check checks/check-node.mjs && node --check scripts/test-forge.mjs && node --check scripts/test-live.mjs",
+    "test": "npm run check && node scripts/test-forge.mjs && node scripts/test-live.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/saas-forge/scripts/test-live.mjs
+++ b/saas-forge/scripts/test-live.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// test-live.mjs — exercise the LIVE code path (seat-backed generation + council
+// + fact breakout) with a stubbed callTool and NO API keys. Proves the wiring:
+// the forge drives model seats to author each team's files, a grok adversary
+// challenges on top of the fact checks, and the whole thing still converges +
+// gates. (Live, the same callTool is backed by the ai-peer-mcp server.)
+
+import assert from "node:assert/strict";
+import { mkdtempSync, existsSync, readFileSync, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { forge } from "../forge.mjs";
+import { liveGenerators, makeCouncilFactFns } from "../live.mjs";
+import { researchArchitecture } from "../research.mjs";
+import { workstreamById, WORKSTREAMS } from "../workstreams.mjs";
+
+const ALL = WORKSTREAMS.map((w) => w.id);
+const dossierMeta = {
+  build_id: "saas-forge-live", idea_id: "idea-convergence",
+  use_case: "forge-live", objective: "Forge the convergence demo, live.",
+  required_market_workstreams: ALL
+};
+const telos = "Make the convergence demo market-ready.";
+
+// Stub seat transport: builder calls return the team's files as JSON (text
+// only); the grok adversary finds no holes; the reviewer is never reached
+// because facts pass on round 1.
+function makeStubCallTool(arch) {
+  return async (_name, args) => {
+    const p = (args && args.prompt) || "";
+    const teamMatch = p.match(/TEAM:([\w-]+)/);
+    if (teamMatch) {
+      const ws = workstreamById(teamMatch[1]);
+      const files = ws.render(arch);
+      const textOnly = {};
+      for (const [k, v] of Object.entries(files)) if (typeof v === "string") textOnly[k] = v;
+      return JSON.stringify(textOnly);
+    }
+    if (p.includes("Attack this claim")) return "[]";           // grok: no holes
+    if (p.includes("Team proposals")) return '{"accepted":null,"resolved":[],"evidence":""}';
+    return "{}";
+  };
+}
+
+const arch = await researchArchitecture({ telos, workstreams: ALL });
+const callTool = makeStubCallTool(arch);
+
+const root = mkdtempSync(path.join(os.tmpdir(), "saas-forge-live-"));
+const result = await forge({
+  projectRoot: root, telos, dossierMeta,
+  makeGenerators: liveGenerators({ callTool }),
+  makeBreakoutFns: makeCouncilFactFns({ callTool })
+});
+
+assert.equal(result.converged, true, `live forge must converge; cycles=${JSON.stringify(result.cycles, null, 2)}`);
+assert.equal(result.verdict.gate_status, "pass", "live: market gate passed");
+assert.equal(result.teams.length, ALL.length, "live: a breakout per team");
+for (const t of result.teams) {
+  assert.equal(t.converged, true, `live: ${t.workstream} converged`);
+  assert.ok(t.rounds.length >= 1, `live: ${t.workstream} faced the grok adversary at least once`);
+}
+
+// Seat-authored text artifacts on disk, plus a harness-filled binary placeholder.
+for (const [rel, needle] of [["db/schema.sql", "create policy"], ["web/DESIGN.md", "Figma"], ["web/site/style.css", "#69e7ff"]]) {
+  const fp = path.join(root, rel);
+  assert.ok(existsSync(fp) && readFileSync(fp, "utf8").includes(needle), `live: seat authored ${rel} ("${needle}")`);
+}
+const png = path.join(root, "docs/verification/s03-dynamics-discriminator.png");
+assert.ok(existsSync(png) && statSync(png).size > 0, "live: binary screenshot placeholder filled by harness");
+
+console.log("test-live OK: seat-backed generation + council+fact breakout converged through the live path (stubbed transport)");


### PR DESCRIPTION
## Summary

Makes the forge's injected boundaries real against `ai-peer-mcp`: each team's artifacts are **authored by its model seat**, and each team's claim faces a **grok adversary on top of the on-disk fact checks**. The transport is injected, so the whole live path is tested **keyless** with a stubbed `callTool`.

## Changes (`saas-forge/`)

- **`live.mjs`**
  - `liveGenerators({ callTool })` — each team's builder seat (`<model>_ask`) authors its files; binary assets the text seat can't emit (screenshots) get a non-empty placeholder the harness owns.
  - `makeCouncilFactFns({ callTool })` — layers `makeCouncilBreakout` (grok adversary + builder-team revise) **on top of** `factBreakout`: a team converges only when no adversary blocker survives **AND** every fact check holds. Verdict stays anchored to disk — the model can't talk a team past missing evidence.
  - `runForgeLive({...})` — spawns the ai-peer-mcp server, wires `callTool`, runs the forge, closes.
- **`breakouts.mjs` / `forge.mjs`** — make the breakout fns injectable (`makeFns` / `makeBreakoutFns`), defaulting to the deterministic fact breakout.
- **`scripts/test-live.mjs`** — drives the full live code path with a **stubbed transport (no API keys)**: seats author the artifacts, grok challenges each team, the forge converges and the market gate passes.

## Verification

`saas-forge` suite green (offline `test-forge` + live `test-live`). Live runs need API keys in the ai-peer-mcp server env (claude/codex/grok); the stubbed test proves the wiring without them.

## Relationship to other PRs

- Independent of #8 (gate re-verifies every team) — this branch is off `main`; they don't touch the same files. Both compose: live seats author + breakout, the gate re-verifies every team on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkFCG3ehwNmqhTJHnFxqd)_