### PR TITLE
saas-forge: real council approvals with provenance (no more rubber-stamp)

### DIFF
--- a/saas-forge/forge.mjs
+++ b/saas-forge/forge.mjs
@@ -61,7 +61,30 @@ function marketPacketFromRecord(record, dossierMeta) {
   return packet;
 }
 
-function runMarketGate({ projectRoot, dossierMeta, teamRecords }) {
+// Synthetic council approvals for the keyless/offline path. Marked honestly:
+// proposal_ref says synthetic and there is NO provenance, so the gate surfaces a
+// provenance warning — a demo can never be mistaken for a real signed council
+// pass. Live runs replace these via councilApprovals (real provenance).
+export function syntheticApprovals(dossierMeta) {
+  return ["claude", "agy", "codex"].map((model) => ({
+    build_id: dossierMeta.build_id,
+    use_case: dossierMeta.use_case,
+    model,
+    role: "builder",
+    docs_reviewed: [],
+    proposal_ref: "synthetic-demo-approval",
+    decision: "approve",
+    required_edits: [],
+    hard_stops: [],
+    confidence: "high",
+    timestamp: TS
+  }));
+}
+
+// The REQUIRED-seat approval packets are produced by the seats (or the synthetic
+// fallback) — NEVER fabricated inside the gate call. A dissenting seat
+// (decision != approve) or absent provenance fails the gate closed.
+function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals }) {
   const dossier = {
     build_id: dossierMeta.build_id,
     idea_id: dossierMeta.idea_id,
@@ -77,23 +100,8 @@ function runMarketGate({ projectRoot, dossierMeta, teamRecords }) {
     required_market_workstreams: dossierMeta.required_market_workstreams
   };
 
-  const approval = (model) => ({
-    build_id: dossierMeta.build_id,
-    use_case: dossierMeta.use_case,
-    model,
-    role: "builder",
-    docs_reviewed: [],
-    proposal_ref: "saas-forge",
-    decision: "approve",
-    required_edits: [],
-    hard_stops: [],
-    confidence: "high",
-    timestamp: TS
-  });
-  const packets = ["claude", "agy", "codex"].map(approval);
   const marketPackets = teamRecords.map((r) => marketPacketFromRecord(r, dossierMeta));
-
-  return validateRecords(dossier, packets, { dossierDir: projectRoot }, [], marketPackets);
+  return validateRecords(dossier, approvals, { dossierDir: projectRoot }, [], marketPackets);
 }
 
 /**
@@ -113,6 +121,7 @@ export async function forge({
   docsFor = offlineDocsFor,
   makeGenerators = makeDemoGenerators,
   makeBreakoutFns,
+  makeApprovals = async ({ dossierMeta: dm }) => syntheticApprovals(dm),
   maxCycles = 3
 }) {
   const telosDir = path.join(projectRoot, ".telos");
@@ -146,7 +155,10 @@ export async function forge({
     teams = built ? await runTeamBreakouts({ baseDir: projectRoot, architecture, makeFns: makeBreakoutFns }) : [];
     const teamsConverged = built && teams.length > 0 && teams.every((t) => t.converged);
 
-    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams }) : null;
+    // Required-seat approvals come from the seats (live) or the synthetic
+    // fallback (offline) — produced here, then handed to the gate.
+    const approvals = teamsConverged ? await makeApprovals({ dossierMeta, architecture }) : [];
+    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams, approvals }) : null;
 
     cycles.push({
       cycle,

--- a/saas-forge/live.mjs
+++ b/saas-forge/live.mjs
@@ -12,9 +12,85 @@
 
 import { spawnMcpClient } from "../breakout/mcp_client.mjs";
 import { makeCouncilBreakout } from "../breakout/breakout.mjs";
+import { runCouncil, liveSeatCaller, agyApprovalPacket } from "../build-gate/council.mjs";
 import { forge } from "./forge.mjs";
 import { factBreakout } from "./breakouts.mjs";
 import { workstreamById } from "./workstreams.mjs";
+
+const APPROVAL_TS = "2026-06-28T00:00:00-04:00";
+const VALID_DECISIONS = new Set(["approve", "revise", "reject", "advisory-note"]);
+const VALID_CONFIDENCE = new Set(["low", "medium", "high"]);
+const APPROVAL_INSTRUCTION =
+  'Return ONLY a JSON approval packet: {"decision":"approve|revise|reject",' +
+  '"confidence":"low|medium|high","required_edits":[],"hard_stops":[],"rationale":"one sentence"}. ' +
+  "No prose outside the JSON.";
+
+function tryJson(text) { try { return JSON.parse(text); } catch { return null; } }
+function extractJsonObject(text) {
+  if (typeof text !== "string") return null;
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  const body = fenced ? fenced[1] : text;
+  const s = body.indexOf("{"), e = body.lastIndexOf("}");
+  if (s === -1 || e === -1 || e < s) return null;
+  try { return JSON.parse(body.slice(s, e + 1)); } catch { return null; }
+}
+
+// Real council approvals: each REQUIRED seat (claude/agy/codex) authors its own
+// approval packet through ai-peer-mcp, and runCouncil stamps it with the seat's
+// REAL provenance (server response_id, or agy's local attestation) — never
+// fabricated by the forge. A dissenting seat returns a non-approve decision and
+// the gate fails closed; absent provenance => response_id:null => the gate blocks
+// under signed mode. signerFor/secrets sign the packet when TELOS_SECRET_* is set.
+export function councilApprovals({ callTool, models = {} }) {
+  return async ({ dossierMeta }) => {
+    const meta = {
+      build_id: dossierMeta.build_id, use_case: dossierMeta.use_case,
+      proposal_ref: "saas-forge-council", timestamp: APPROVAL_TS, docs_reviewed: []
+    };
+    const objective = dossierMeta.objective || "Approve the market-ready build for merge.";
+
+    function promptFor(model) {
+      if (model === "agy") {
+        return { tool: "agy_checkpoint", args: {
+          phase: "merge-gate", scope: "saas-forge",
+          required_packets: ["claude", "codex"], present_packets: ["claude", "codex"],
+          protected_path_check: "pass"
+        } };
+      }
+      return {
+        tool: `${model}_ask`, model: models[model],
+        system: `You are ${model}, a council approver. Judge the objective on the merits. ${APPROVAL_INSTRUCTION}`,
+        prompt: `Objective:\n${objective}\n\n${APPROVAL_INSTRUCTION}`
+      };
+    }
+    function parsePacket(text, model) {
+      const obj = tryJson(text);
+      if (obj && obj.phase_gate_status) return agyApprovalPacket(obj, meta);
+      const m = (obj && !obj.phase_gate_status) ? obj : (extractJsonObject(text) || {});
+      const decision = VALID_DECISIONS.has(m.decision) ? m.decision : "advisory-note";
+      const confidence = VALID_CONFIDENCE.has(m.confidence) ? m.confidence : "medium";
+      return {
+        build_id: meta.build_id, use_case: meta.use_case, model, role: "approver",
+        docs_reviewed: meta.docs_reviewed, proposal_ref: meta.proposal_ref,
+        decision, required_edits: Array.isArray(m.required_edits) ? m.required_edits : [],
+        hard_stops: Array.isArray(m.hard_stops) ? m.hard_stops : [],
+        confidence, timestamp: meta.timestamp
+      };
+    }
+
+    const client = { callTool };
+    const seats = [
+      { model: "claude", role: "approver" },
+      { model: "agy", role: "approver" },
+      { model: "codex", role: "approver" }
+    ];
+    const callSeat = (seatArg) =>
+      liveSeatCaller({ client, promptFor: (model) => promptFor(model), parsePacket: (t) => parsePacket(t, seatArg.model) })(seatArg);
+
+    const results = await runCouncil({ seats, callSeat, dossier: { build_id: dossierMeta.build_id } });
+    return results.filter((r) => r.ok).map((r) => r.packet);
+  };
+}
 
 const PNG_1x1 = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
@@ -97,6 +173,7 @@ export async function runForgeLive({
       projectRoot, telos, dossierMeta, docsFor,
       makeGenerators: liveGenerators({ callTool }),
       makeBreakoutFns: makeCouncilFactFns({ callTool, team, reviewer }),
+      makeApprovals: councilApprovals({ callTool }),
       maxCycles
     });
   } finally {

--- a/saas-forge/scripts/test-live.mjs
+++ b/saas-forge/scripts/test-live.mjs
@@ -10,7 +10,7 @@ import { mkdtempSync, existsSync, readFileSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { forge } from "../forge.mjs";
-import { liveGenerators, makeCouncilFactFns } from "../live.mjs";
+import { liveGenerators, makeCouncilFactFns, councilApprovals } from "../live.mjs";
 import { researchArchitecture } from "../research.mjs";
 import { workstreamById, WORKSTREAMS } from "../workstreams.mjs";
 
@@ -26,8 +26,9 @@ const telos = "Make the convergence demo market-ready.";
 // only); the grok adversary finds no holes; the reviewer is never reached
 // because facts pass on round 1.
 function makeStubCallTool(arch) {
-  return async (_name, args) => {
+  return async (name, args) => {
     const p = (args && args.prompt) || "";
+    // Builder seat: author the team's files.
     const teamMatch = p.match(/TEAM:([\w-]+)/);
     if (teamMatch) {
       const ws = workstreamById(teamMatch[1]);
@@ -36,7 +37,23 @@ function makeStubCallTool(arch) {
       for (const [k, v] of Object.entries(files)) if (typeof v === "string") textOnly[k] = v;
       return JSON.stringify(textOnly);
     }
-    if (p.includes("Attack this claim")) return "[]";           // grok: no holes
+    // agy governance checkpoint approval (structured), with local attestation provenance.
+    if (name === "agy_checkpoint") {
+      return JSON.stringify({
+        phase_gate_status: "advance", blocked_reasons: [],
+        provenance: { model: "agy-checkpoint", source: "ai-peer-mcp", response_id: "agy-stub-1", attestation: "local-deterministic" }
+      });
+    }
+    // Chat council approver: real-provenance envelope { text, provenance }.
+    // ("approval packet" is in the council prompt; "council approver" is system-only.)
+    if (p.includes("approval packet")) {
+      const model = String(name).replace(/_ask$/, "");
+      return JSON.stringify({
+        text: JSON.stringify({ decision: "approve", confidence: "high", required_edits: [], hard_stops: [] }),
+        provenance: { model, source: "ai-peer-mcp", response_id: `${model}-stub-1` }
+      });
+    }
+    if (p.includes("Attack this claim")) return "[]";           // grok adversary: no holes
     if (p.includes("Team proposals")) return '{"accepted":null,"resolved":[],"evidence":""}';
     return "{}";
   };
@@ -49,11 +66,22 @@ const root = mkdtempSync(path.join(os.tmpdir(), "saas-forge-live-"));
 const result = await forge({
   projectRoot: root, telos, dossierMeta,
   makeGenerators: liveGenerators({ callTool }),
-  makeBreakoutFns: makeCouncilFactFns({ callTool })
+  makeBreakoutFns: makeCouncilFactFns({ callTool }),
+  makeApprovals: councilApprovals({ callTool })
 });
 
 assert.equal(result.converged, true, `live forge must converge; cycles=${JSON.stringify(result.cycles, null, 2)}`);
 assert.equal(result.verdict.gate_status, "pass", "live: market gate passed");
+
+// The required-seat approvals carry REAL provenance from the council — not
+// fabricated by the forge. Every required model has a non-null response_id.
+const prov = result.verdict.provenance || [];
+assert.equal(prov.length, 3, "live: provenance for all three required seats");
+for (const pr of prov) {
+  assert.equal(pr.has_provenance, true, `live: ${pr.model} approval carries provenance`);
+  assert.ok(typeof pr.response_id === "string" && pr.response_id.length > 0,
+    `live: ${pr.model} approval has a real response_id (got ${pr.response_id})`);
+}
 assert.equal(result.teams.length, ALL.length, "live: a breakout per team");
 for (const t of result.teams) {
   assert.equal(t.converged, true, `live: ${t.workstream} converged`);


### PR DESCRIPTION
## Summary

Closes the trust hole you flagged at `forge.mjs:87`. The forge was **fabricating** the required `claude`/`agy`/`codex` approval packets with a hard-coded `decision: "approve"` and no provenance — so the gate's required-seat approval check was a **rubber stamp**, violating TELOS's "never from a model's self-report" invariant. Approvals are now produced by the seats with **real provenance**.

## Changes (`saas-forge/`)

- **`forge.mjs`** — approvals are **injected** (`makeApprovals`) and handed to the gate, never built inside the gate call. The default `syntheticApprovals` are marked honestly (`proposal_ref: "synthetic-demo-approval"`, **no provenance**) so the gate surfaces a provenance warning and a demo can't be mistaken for a real signed council pass.
- **`live.mjs`** — `councilApprovals` runs the REQUIRED seats through ai-peer-mcp (`claude_ask` / `codex_ask` + `agy_checkpoint`) via `runCouncil` / `liveSeatCaller`, so each approval binds to the seat's **real provenance** (server `response_id`, or agy's local attestation) and signs under `TELOS_SECRET_*`. A **dissenting seat** (decision ≠ approve) or **null provenance** fails the gate closed. `runForgeLive` wires it in.
- **`scripts/test-live.mjs`** — asserts every required seat's approval carries a **non-null `response_id`** through to the gate verdict (real provenance), via the stubbed transport (keyless).

## Effect

| Path | Required-seat approvals | Provenance |
| --- | --- | --- |
| offline / demo | synthetic, **honestly marked** | none → gate warns |
| live | authored by the seats | **real** `response_id` → gate enforces; fail-closed on dissent/null |

The market gate "pass" now means something for the council half too — not just the breakout/market re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HxkFCG3ehwNmqhTJHnFxqd)_