### PR TITLE
Agentic teams: autonomous builder composing council + merkle-dag

### DIFF
--- a/build-gate/build-orchestrator.mjs
+++ b/build-gate/build-orchestrator.mjs
@@ -1,0 +1,158 @@
+// build-orchestrator.mjs — the autonomous builder. Composes TELOS's two existing
+// halves into one fail-closed pipeline:
+//
+//   idea+telos --decompose--> tasks[] --compileAndHashPlan--> content-addressed plan
+//     --COUNCIL APPROVAL GATE (runCouncil -> validateRecords)-->   [MUST pass first]
+//     --runBuild: each node dispatched to its OWNING TEAM (team = worker)-->
+//     --Rule-3 defaultVerifyNode re-derives facts--> Ed25519 ledger --done()--> ready
+//
+// The orchestrator adds NO new trust surface: teams are workers behind
+// orchestrate.mjs `dispatch` (Rule 1 — they see only the node spec), verification
+// stays defaultVerifyNode (Rule 3 — re-derive hash + run test), and the
+// controller remains the sole ledger writer. A team's word is never load-bearing.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { runCouncil } from "./council.mjs";
+import { validateRecords } from "./gate.mjs";
+import { planTeams, teamForNode, authorizedSignersFor } from "./teams.mjs";
+import { decompose } from "./decompose.mjs";
+import { compileAndHashPlan } from "../merkle-dag/planner.mjs";
+import { runBuild, defaultVerifyNode } from "../merkle-dag/orchestrate.mjs";
+import { writePlan } from "../merkle-dag/merkle.mjs";
+import { generateKeypair } from "../merkle-dag/crypto.mjs";
+import { resolveUnder } from "../merkle-dag/vendor.mjs";
+
+/**
+ * Build a dispatch(injected) for runBuild that routes each node to its owning
+ * team and lets that team WRITE the node's files. Verification is NOT done here —
+ * it stays in verifyNode (Rule 3), so the team cannot self-certify.
+ *
+ * Routing is by node id, NOT by reading the node spec: Rule 1 (orchestrate.mjs)
+ * injects only {id,requirements,files,test,effective_hash} and compileAndHashPlan
+ * drops the task's `workstream` field, so the owning team is decided BEFORE the
+ * build (from the original tasks) and looked up here via routeFor(id).
+ *   routeFor (id) -> team object   (precomputed in buildProject from the task list)
+ *   callTeam ({ team, node, dossier }) -> { files:[{path,content}] }
+ *            | { ok:false, reason, respec? }
+ *            the team's seats produce the artifacts; for live wiring this is built
+ *            over ai-peer-mcp + teamPrompts, for tests it is a deterministic mock.
+ */
+export function makeTeamDispatch({ routeFor, callTeam, baseDir, dossier }) {
+  return async (injected) => {
+    const team = routeFor(injected.id);
+    let out;
+    try {
+      out = await callTeam({ team, node: injected, dossier });
+    } catch (e) {
+      return { ok: false, reason: `team ${team?.id} threw: ${e?.message || String(e)}` };
+    }
+    if (!out || out.ok === false) {
+      return { ok: false, reason: out?.reason || `team ${team?.id} declined`, respec: out?.respec };
+    }
+    const files = Array.isArray(out.files) ? out.files : [];
+    for (const f of files) {
+      if (!f || typeof f.path !== "string") return { ok: false, reason: `team ${team.id} returned a malformed file` };
+      const resolved = resolveUnder(baseDir, f.path);
+      if (resolved === null) return { ok: false, reason: `team ${team.id} path escapes baseDir: ${f.path}` };
+      mkdirSync(path.dirname(resolved), { recursive: true });
+      writeFileSync(resolved, typeof f.content === "string" ? f.content : String(f.content ?? ""));
+    }
+    // The signer key_id MUST be in plan.authorized_signers or the ledger gate
+    // rejects the settlement — registering a team means registering its key.
+    return { ok: true, signer: team.signer || team.id };
+  };
+}
+
+/**
+ * Generate one Ed25519 keypair per team signer and return both the public
+ * keyring (for authorized_signers) and a signerFor(key_id) -> privatePem. Keys
+ * are ephemeral per run (the controller is the sole signer); persisting them is a
+ * deployment concern, not the orchestrator's. Returns { keyring, signerFor }.
+ */
+export function makeTeamKeyring(teams) {
+  const roster = Array.isArray(teams) && teams.length ? teams : planTeams({});
+  const keyring = {};
+  const privates = {};
+  for (const t of roster) {
+    const keyId = t.signer || t.id;
+    if (keyring[keyId]) continue;
+    const { privatePem, publicJwk } = generateKeypair();
+    keyring[keyId] = publicJwk;
+    privates[keyId] = privatePem;
+  }
+  return { keyring, signerFor: (keyId) => privates[keyId] };
+}
+
+/**
+ * Drive an autonomous build end to end.
+ *   dossier   the build request (build_id, use_case, objective, required_docs,
+ *             write_targets, optional trust_mode/market_bound) — same shape the gate validates.
+ *   telos     the telos statement / intent string (passed to the Planning team).
+ *   tasks     OPTIONAL hand-authored task list; omit to let the Planning team decompose.
+ *   callSeat  council approval seat caller ({model,role,dossier}) -> {packet,provenance}
+ *             (also used by decompose for the Planning team).
+ *   callTeam  build execution caller ({team,node,dossier}) -> {files} | {ok:false,...}.
+ *   keyring   { key_id: publicJwk } for authorized_signers (use makeTeamKeyring).
+ *   signerFor (key_id) -> privatePem (use makeTeamKeyring).
+ *
+ * Returns a phased result: it STOPS at the first failing phase and never advances
+ * to execution unless the council approval gate passed (fail-closed sequencing).
+ *   { phase: "decompose"|"approval"|"plan"|"build", ok, ... }
+ */
+export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, keyring, signerFor, baseDir, telosDir, marketPackets = [], maxRepairRounds = 8, concurrency }) {
+  const teams = planTeams(dossier);
+
+  // 1. Tasks: hand-authored, or proposed by the Planning team (data only).
+  let taskList;
+  try {
+    taskList = Array.isArray(tasks) ? tasks : await decompose({ dossier, telos, callSeat, teams });
+  } catch (e) {
+    return { phase: "decompose", ok: false, blocked: [e?.message || String(e)], teams };
+  }
+
+  // 2. COUNCIL APPROVAL GATE — must pass BEFORE any plan is written or executed.
+  const council = await runCouncil({ callSeat, dossier });
+  const packets = council.filter((r) => r && r.ok && r.packet).map((r) => r.packet);
+  // marketPackets pass straight through to the gate so a market-bound build still
+  // demands real market-readiness evidence (the gate stays load-bearing).
+  const report = validateRecords(dossier, packets, {}, [], marketPackets);
+  if (report.blockers.length > 0) {
+    return { phase: "approval", ok: false, blocked: report.blockers, council: report, teams };
+  }
+
+  // 3. Compile + persist the content-addressed plan (signers pinned into plan_hash).
+  const authorizedSigners = authorizedSignersFor(teams, keyring);
+  const compiled = compileAndHashPlan({ tasks: taskList, authorizedSigners, repoRoot: baseDir });
+  if (compiled.errors) {
+    return { phase: "plan", ok: false, blocked: compiled.errors, advisories: compiled.advisories, teams };
+  }
+  writePlan(telosDir, compiled.plan);
+
+  // Decide each node's owning team NOW, while the task list still carries
+  // `workstream` (Rule 1 strips it from the dispatched spec). Route by id at build time.
+  const nodeTeam = new Map(taskList.map((t) => [t.id, teamForNode(t, teams)]));
+  const routeFor = (id) => nodeTeam.get(id) || teamForNode({}, teams);
+
+  // 4. Execute: teams build, the controller verifies (Rule 3) and settles the ledger.
+  const build = await runBuild({
+    telosDir,
+    baseDir,
+    dispatch: makeTeamDispatch({ routeFor, callTeam, baseDir, dossier }),
+    verifyNode: defaultVerifyNode,
+    signerFor,
+    maxRounds: maxRepairRounds,
+    concurrency
+  });
+
+  return {
+    phase: "build",
+    ok: build.report.merge_status === "ready",
+    report: build.report,
+    trace: build.trace,
+    council: report,
+    plan: compiled.plan,
+    advisories: compiled.advisories,
+    teams
+  };
+}

--- a/build-gate/build-orchestrator.mjs
+++ b/build-gate/build-orchestrator.mjs
@@ -100,7 +100,7 @@ export function makeTeamKeyring(teams) {
  * to execution unless the council approval gate passed (fail-closed sequencing).
  *   { phase: "decompose"|"approval"|"plan"|"build", ok, ... }
  */
-export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, keyring, signerFor, baseDir, telosDir, marketPackets = [], maxRepairRounds = 8, concurrency }) {
+export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, keyring, signerFor, baseDir, telosDir, marketPackets = [], source, maxRepairRounds = 8, concurrency }) {
   const teams = planTeams(dossier);
 
   // 1. Tasks: hand-authored, or proposed by the Planning team (data only).
@@ -115,8 +115,10 @@ export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, 
   const council = await runCouncil({ callSeat, dossier });
   const packets = council.filter((r) => r && r.ok && r.packet).map((r) => r.packet);
   // marketPackets pass straight through to the gate so a market-bound build still
-  // demands real market-readiness evidence (the gate stays load-bearing).
-  const report = validateRecords(dossier, packets, {}, [], marketPackets);
+  // demands real market-readiness evidence (the gate stays load-bearing). `source`
+  // (e.g. { dossierDir: baseDir }) lets the gate re-verify breakout `meets` checks
+  // against the build workspace rather than process.cwd().
+  const report = validateRecords(dossier, packets, source || {}, [], marketPackets);
   if (report.blockers.length > 0) {
     return { phase: "approval", ok: false, blocked: report.blockers, council: report, teams };
   }

--- a/build-gate/decompose.mjs
+++ b/build-gate/decompose.mjs
@@ -1,0 +1,65 @@
+// decompose.mjs — the Planning team: turn an idea + telos statement into a
+// content-addressed task list for ../merkle-dag/planner.compileAndHashPlan.
+//
+// AUTONOMY WITH A FLOOR: this is the autonomous front-end of the builder, but its
+// output is DATA ONLY. compileAndHashPlan re-hashes every task, the council
+// approval gate must still PASS, and runBuild's Rule-3 verify re-derives every
+// artifact fact. So even a fabricated decomposition cannot reach merge — the
+// Planning team proposes, the deterministic substrate disposes. A human may also
+// hand-author the task list and skip this entirely (buildProject takes `tasks`).
+
+import { planTeams } from "./teams.mjs";
+
+// The minimum a task needs to compile + verify: an id, the files it writes, a
+// requirements string, and a test command the controller can run (Rule 3).
+function validTask(t) {
+  return t && typeof t.id === "string" && t.id.length > 0
+    && Array.isArray(t.writes) && t.writes.length > 0
+    && typeof t.requirements === "string"
+    && t.test && typeof t.test.cmd === "string";
+}
+
+// Normalize a Planning-team-proposed task into the shape planner.compileAndHashPlan
+// expects, carrying the explicit `workstream` field teamForNode routes on.
+function normalizeTask(t) {
+  return {
+    id: t.id,
+    writes: [...t.writes],
+    reads: Array.isArray(t.reads) ? [...t.reads] : [],
+    requirements: t.requirements,
+    test: t.test,
+    workstream: typeof t.workstream === "string" ? t.workstream : "product-architecture",
+    baseDependencies: Array.isArray(t.baseDependencies) ? [...t.baseDependencies] : []
+  };
+}
+
+/**
+ * Convene the Planning team and return a normalized task list.
+ *   callSeat  ({ model, role, dossier, telos, intent }) -> { tasks } | { packet: { tasks } }
+ *             the Planning team's lead seat proposes the decomposition; for live
+ *             wiring this is built over ai-peer-mcp, for tests it is a deterministic mock.
+ * Throws if the team proposes nothing usable (fail-closed: no silent empty plan).
+ */
+export async function decompose({ dossier, telos, callSeat, teams }) {
+  const roster = Array.isArray(teams) && teams.length ? teams : planTeams(dossier);
+  const planning = roster.find((t) => t.id === "planning") || roster[0];
+  const lead = planning && planning.seats[0] ? planning.seats[0].model : "claude";
+
+  const out = (await callSeat({ model: lead, role: "lead", team: "planning", intent: "decompose", dossier, telos })) || {};
+  const raw = Array.isArray(out.tasks) ? out.tasks
+    : (out.packet && Array.isArray(out.packet.tasks) ? out.packet.tasks : []);
+
+  const tasks = raw.filter(validTask).map(normalizeTask);
+  if (tasks.length === 0) {
+    throw new Error("decompose: Planning team produced no valid tasks (need id, writes, requirements, test.cmd)");
+  }
+
+  // Reject duplicate ids early — compileAndHashPlan would otherwise topo-sort an
+  // ambiguous graph. Fail-closed before any plan is written.
+  const ids = new Set();
+  for (const t of tasks) {
+    if (ids.has(t.id)) throw new Error(`decompose: duplicate task id '${t.id}'`);
+    ids.add(t.id);
+  }
+  return tasks;
+}

--- a/build-gate/examples/agentic-teams-market/dossier.json
+++ b/build-gate/examples/agentic-teams-market/dossier.json
@@ -1,0 +1,35 @@
+{
+  "build_id": "agentic-teams-market-demo",
+  "idea_id": "idea-agentic-teams-market-demo",
+  "use_case": "autonomous-market-build",
+  "objective": "Autonomously build a market-ready micro-app via the full agentic-teams fan-out.",
+  "trust_mode": "advisory",
+  "market_bound": true,
+  "user_facing_frontend": true,
+  "required_market_workstreams": [
+    "business-positioning",
+    "product-architecture",
+    "backend-schema",
+    "security-trust",
+    "accuracy-evals",
+    "scale-operations",
+    "frontend-brand-experience"
+  ],
+  "required_docs": [],
+  "write_targets": [
+    "out/schema.mjs",
+    "out/api.mjs",
+    "out/ui.mjs",
+    "out/threat-model.md",
+    "out/runbook.md"
+  ],
+  "affected_directories": [
+    "."
+  ],
+  "protected_paths": [
+    "CHATGPT/",
+    "me/claude-code/",
+    "me/claude-desktop/",
+    "me/gemini/"
+  ]
+}

--- a/build-gate/examples/agentic-teams-market/market/claude.json
+++ b/build-gate/examples/agentic-teams-market/market/claude.json
@@ -1,0 +1,39 @@
+{
+  "build_id": "agentic-teams-market-demo",
+  "idea_id": "idea-agentic-teams-market-demo",
+  "model": "claude",
+  "project_state": "demo",
+  "workstreams_reviewed": [
+    "business-positioning",
+    "product-architecture",
+    "frontend-brand-experience"
+  ],
+  "business_thesis": "An autonomously built, gate-certified micro-app converts trust into adoption.",
+  "target_users": ["technical evaluators", "early buyers"],
+  "architecture_findings": ["Team boundaries map cleanly to the build DAG."],
+  "backend_schema_findings": [],
+  "security_findings": [],
+  "accuracy_eval_findings": [],
+  "scalability_findings": [],
+  "frontend_design_findings": ["Frontend plan meets the LEXI-class standard."],
+  "lexi_class_ui_status": "meets",
+  "go_to_market_blockers": [],
+  "breakout": {
+    "workstream": "frontend-brand-experience",
+    "claimedStatus": "meets",
+    "finalStatus": "meets",
+    "converged": true,
+    "surviving_blockers": [],
+    "go_to_market_blockers": [],
+    "checks": [
+      { "type": "file_exists", "path": "market-evidence/frontend-meets.md" },
+      { "type": "file_contains", "path": "market-evidence/frontend-meets.md", "needle": "agentic-teams-market-demo" }
+    ],
+    "rounds": [
+      { "round": 1, "blockers": ["first-screen value proof not present"], "resolved": ["first-screen value proof not present"] },
+      { "round": 2, "blockers": [], "resolved": [] }
+    ]
+  },
+  "recommendation_to_claude": "Proceed to build.",
+  "timestamp": "2026-06-28T12:00:00-04:00"
+}

--- a/build-gate/examples/agentic-teams-market/market/codex.json
+++ b/build-gate/examples/agentic-teams-market/market/codex.json
@@ -1,0 +1,23 @@
+{
+  "build_id": "agentic-teams-market-demo",
+  "idea_id": "idea-agentic-teams-market-demo",
+  "model": "codex",
+  "project_state": "demo",
+  "workstreams_reviewed": [
+    "backend-schema",
+    "accuracy-evals",
+    "scale-operations"
+  ],
+  "business_thesis": "The backend and operations posture supports a credible demo launch.",
+  "target_users": ["early buyers"],
+  "architecture_findings": [],
+  "backend_schema_findings": ["Schema is content-addressed and migration-safe."],
+  "security_findings": [],
+  "accuracy_eval_findings": ["Acceptance tests gate every node."],
+  "scalability_findings": ["Deploy + rollback runbook is in scope."],
+  "frontend_design_findings": [],
+  "lexi_class_ui_status": "not-applicable",
+  "go_to_market_blockers": [],
+  "recommendation_to_claude": "Proceed; keep the eval suite in CI.",
+  "timestamp": "2026-06-28T12:02:00-04:00"
+}

--- a/build-gate/examples/agentic-teams-market/market/grok.json
+++ b/build-gate/examples/agentic-teams-market/market/grok.json
@@ -1,0 +1,21 @@
+{
+  "build_id": "agentic-teams-market-demo",
+  "idea_id": "idea-agentic-teams-market-demo",
+  "model": "grok",
+  "project_state": "demo",
+  "workstreams_reviewed": [
+    "security-trust"
+  ],
+  "business_thesis": "The market thesis holds after adversarial risk review.",
+  "target_users": ["early buyers"],
+  "architecture_findings": [],
+  "backend_schema_findings": [],
+  "security_findings": ["No unresolved security blockers for the demo scope."],
+  "accuracy_eval_findings": [],
+  "scalability_findings": [],
+  "frontend_design_findings": [],
+  "lexi_class_ui_status": "not-applicable",
+  "go_to_market_blockers": [],
+  "recommendation_to_claude": "Proceed, keeping the threat model load-bearing.",
+  "timestamp": "2026-06-28T12:04:00-04:00"
+}

--- a/build-gate/examples/agentic-teams-market/tasks.json
+++ b/build-gate/examples/agentic-teams-market/tasks.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "schema",
+    "writes": ["out/schema.mjs"],
+    "reads": [],
+    "requirements": "data model + content-addressed record schema",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "backend-schema"
+  },
+  {
+    "id": "api",
+    "writes": ["out/api.mjs"],
+    "reads": ["out/schema.mjs"],
+    "requirements": "service endpoints over the schema",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "backend-schema"
+  },
+  {
+    "id": "ui",
+    "writes": ["out/ui.mjs"],
+    "reads": ["out/api.mjs"],
+    "requirements": "LEXI-class UI calling the api",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "frontend-brand-experience"
+  },
+  {
+    "id": "threat-model",
+    "writes": ["out/threat-model.md"],
+    "reads": ["out/api.mjs"],
+    "requirements": "threat model + abuse cases for the api surface",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "security-trust"
+  },
+  {
+    "id": "runbook",
+    "writes": ["out/runbook.md"],
+    "reads": ["out/ui.mjs"],
+    "requirements": "deploy + rollback runbook",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "scale-operations"
+  }
+]

--- a/build-gate/examples/agentic-teams/dossier.json
+++ b/build-gate/examples/agentic-teams/dossier.json
@@ -1,0 +1,18 @@
+{
+  "build_id": "agentic-teams-demo",
+  "use_case": "autonomous-build",
+  "objective": "Build a tiny content-addressed greeting library autonomously via agentic teams.",
+  "trust_mode": "advisory",
+  "market_bound": false,
+  "required_docs": [],
+  "write_targets": [
+    "out/greet.mjs",
+    "out/index.mjs"
+  ],
+  "protected_paths": [
+    "CHATGPT/",
+    "me/claude-code/",
+    "me/claude-desktop/",
+    "me/gemini/"
+  ]
+}

--- a/build-gate/examples/agentic-teams/tasks.json
+++ b/build-gate/examples/agentic-teams/tasks.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": "greet",
+    "writes": ["out/greet.mjs"],
+    "reads": [],
+    "requirements": "export greet(name) returning a greeting string",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "product-architecture"
+  },
+  {
+    "id": "index",
+    "writes": ["out/index.mjs"],
+    "reads": ["out/greet.mjs"],
+    "requirements": "import greet and print greet('TELOS') as the app entry",
+    "test": { "cmd": "node", "args": ["-e", "process.exit(0)"] },
+    "workstream": "product-architecture"
+  }
+]

--- a/build-gate/package.json
+++ b/build-gate/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "Local Codex validator for multi-model build-gate dossiers and approval packets.",
   "scripts": {
-    "check": "node --check gate.mjs && node --check sign.mjs && node --check council.mjs && node --check scripts/test-gate.mjs && node --check scripts/test-sign.mjs && node --check scripts/test-trust.mjs && node --check scripts/test-council-orchestrator.mjs && node --check scripts/test-breakout-coverage.mjs && node --check scripts/stress-test-gate.mjs && node --check scripts/stress-tests.mjs",
-    "test": "npm run check && node scripts/test-gate.mjs && node scripts/test-sign.mjs && node scripts/test-trust.mjs && node scripts/test-council-orchestrator.mjs && node scripts/test-breakout-coverage.mjs && node scripts/stress-test-gate.mjs && node scripts/stress-tests.mjs && npm --prefix ../breakout test"
+    "check": "node --check gate.mjs && node --check sign.mjs && node --check council.mjs && node --check teams.mjs && node --check decompose.mjs && node --check build-orchestrator.mjs && node --check teamPrompts.mjs && node --check scripts/test-gate.mjs && node --check scripts/test-sign.mjs && node --check scripts/test-trust.mjs && node --check scripts/test-council-orchestrator.mjs && node --check scripts/test-breakout-coverage.mjs && node --check scripts/test-teams.mjs && node --check scripts/test-decompose.mjs && node --check scripts/test-build-orchestrator.mjs && node --check scripts/test-team-prompts.mjs && node --check scripts/stress-test-gate.mjs && node --check scripts/stress-tests.mjs",
+    "test": "npm run check && node scripts/test-gate.mjs && node scripts/test-sign.mjs && node scripts/test-trust.mjs && node scripts/test-council-orchestrator.mjs && node scripts/test-breakout-coverage.mjs && node scripts/test-teams.mjs && node scripts/test-decompose.mjs && node scripts/test-build-orchestrator.mjs && node scripts/test-team-prompts.mjs && node scripts/stress-test-gate.mjs && node scripts/stress-tests.mjs && npm --prefix ../breakout test"
   },
   "engines": {
     "node": ">=18"

--- a/build-gate/scripts/test-build-orchestrator.mjs
+++ b/build-gate/scripts/test-build-orchestrator.mjs
@@ -5,12 +5,12 @@
 // ledger -> done() ready. No API keys: council + teams are deterministic mocks;
 // the Ed25519 substrate is real.
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { readLedger } from "../../merkle-dag/crypto.mjs";
 import { buildProject, makeTeamDispatch, makeTeamKeyring } from "../build-orchestrator.mjs";
-import { planTeams } from "../teams.mjs";
+import { planTeams, teamForNode } from "../teams.mjs";
 
 // A gate-valid dossier (non-market keeps the council gate to the 3 required seats).
 function makeDossier() {
@@ -24,14 +24,15 @@ function makeDossier() {
 }
 
 // Council seat caller: approves for every model; doubles as the Planning team's
-// decompose source when intent==="decompose".
-function makeCallSeat({ decision = "approve", tasks } = {}) {
+// decompose source when intent==="decompose". Packets bind to the given dossier
+// ids so the gate's build_id/use_case checks pass.
+function makeCallSeat({ decision = "approve", tasks, buildId = "ap1", useCase = "autonomous-build" } = {}) {
   return async ({ model, intent }) => {
     if (intent === "decompose") return { tasks };
     return {
       packet: {
-        build_id: "ap1", use_case: "autonomous-build", model, role: "approver",
-        docs_reviewed: [], proposal_ref: "ap1", decision, required_edits: [],
+        build_id: buildId, use_case: useCase, model, role: "approver",
+        docs_reviewed: [], proposal_ref: buildId, decision, required_edits: [],
         hard_stops: [], confidence: "high", timestamp: "2026-06-28T00:00:00Z"
       },
       provenance: { model: `real-${model}`, source: "mock", response_id: `r_${model}` }
@@ -168,6 +169,121 @@ function fixture() {
   assert.equal(out.ok, false, "decline is a halt");
   assert.deepEqual(out.respec, { requirements: "clarified" }, "respec passes through to runBuild's repair loop");
   console.log("OK: dispatch surfaces respec on decline");
+}
+
+// --- Market-bound full fan-out: nodes route to DISTINCT teams; market-readiness
+// gate (incl. breakout re-verify) stays load-bearing; build reaches ready ---
+{
+  const marketDossier = {
+    build_id: "mk1", idea_id: "idea-mk1", use_case: "autonomous-market-build",
+    objective: "market-bound autonomous build", trust_mode: "advisory",
+    market_bound: true, user_facing_frontend: true,
+    required_market_workstreams: [
+      "business-positioning", "product-architecture", "backend-schema",
+      "security-trust", "accuracy-evals", "scale-operations", "frontend-brand-experience"
+    ],
+    required_docs: [], write_targets: ["out/schema.mjs", "out/ui.mjs", "out/threat.md", "out/runbook.md"],
+    affected_directories: ["."]
+  };
+  const marketTasks = [
+    { id: "schema", writes: ["out/schema.mjs"], reads: [], requirements: "schema", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "backend-schema" },
+    { id: "ui", writes: ["out/ui.mjs"], reads: ["out/schema.mjs"], requirements: "ui", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "frontend-brand-experience" },
+    { id: "threat", writes: ["out/threat.md"], reads: ["out/schema.mjs"], requirements: "threat model", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "security-trust" },
+    { id: "runbook", writes: ["out/runbook.md"], reads: ["out/ui.mjs"], requirements: "runbook", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "scale-operations" }
+  ];
+  const marketPacket = (model, workstreams, extra = {}) => ({
+    build_id: "mk1", idea_id: "idea-mk1", model, project_state: "demo",
+    workstreams_reviewed: workstreams, business_thesis: "thesis", target_users: ["u"],
+    architecture_findings: [], backend_schema_findings: [], security_findings: [],
+    accuracy_eval_findings: [], scalability_findings: [], frontend_design_findings: [],
+    lexi_class_ui_status: "not-applicable", go_to_market_blockers: [],
+    recommendation_to_claude: "proceed", timestamp: "2026-06-28T12:00:00-04:00", ...extra
+  });
+  const marketPackets = [
+    marketPacket("claude", ["business-positioning", "product-architecture", "frontend-brand-experience"], {
+      lexi_class_ui_status: "meets",
+      breakout: {
+        workstream: "frontend-brand-experience", claimedStatus: "meets", finalStatus: "meets",
+        converged: true, surviving_blockers: [], go_to_market_blockers: [],
+        checks: [
+          { type: "file_exists", path: "market-evidence/fe.md" },
+          { type: "file_contains", path: "market-evidence/fe.md", needle: "mk1" }
+        ],
+        rounds: [{ round: 1, blockers: ["x"], resolved: ["x"] }, { round: 2, blockers: [], resolved: [] }]
+      }
+    }),
+    marketPacket("codex", ["backend-schema", "accuracy-evals", "scale-operations"]),
+    marketPacket("grok", ["security-trust"])
+  ];
+
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-mk-"));
+  const telosDir = path.join(baseDir, ".telos");
+  mkdirSync(telosDir, { recursive: true });
+  mkdirSync(path.join(baseDir, "market-evidence"), { recursive: true });
+  writeFileSync(path.join(baseDir, "market-evidence", "fe.md"), "frontend evidence for mk1\n");
+
+  const teams = planTeams(marketDossier);
+  // The market roster fans out to the build/verify teams, not just the backbone.
+  assert.deepEqual(teams.map((t) => t.id).sort(),
+    ["architecture", "backend", "breakout", "business", "evals", "frontend", "ops", "planning", "security"],
+    "market-bound dossier convenes the full team roster");
+
+  const { keyring, signerFor } = makeTeamKeyring(teams);
+  const result = await buildProject({
+    dossier: marketDossier, telos: "x", tasks: marketTasks,
+    callSeat: makeCallSeat({ buildId: "mk1", useCase: "autonomous-market-build" }), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir, marketPackets,
+    source: { dossierDir: baseDir }, maxRepairRounds: 20
+  });
+
+  assert.equal(result.ok, true, "market-bound build reached ready (market gate + breakout re-verify passed)");
+  assert.equal(result.report.merge_status, "ready", "merge_status ready");
+
+  // Nodes routed to DISTINCT teams (the whole point of the fan-out).
+  const used = new Set(marketTasks.map((t) => teamForNode(t, teams).id));
+  assert.deepEqual([...used].sort(), ["backend", "frontend", "ops", "security"], "nodes fan out to distinct build teams");
+
+  // Each node settled under its OWNING team's signer (not one shared signer).
+  const ledger = readLedger(path.join(telosDir, "ledger.jsonl"));
+  const bySigner = new Map(ledger.map((r) => [r.task_id, r.signer]));
+  assert.equal(bySigner.get("schema"), "backend", "schema settled by backend");
+  assert.equal(bySigner.get("ui"), "frontend", "ui settled by frontend");
+  assert.equal(bySigner.get("threat"), "security", "threat settled by security");
+  assert.equal(bySigner.get("runbook"), "ops", "runbook settled by ops");
+  console.log("OK: market-bound full fan-out -> ready, distinct teams + signers");
+}
+
+// --- Market-bound stays fail-closed: a missing required workstream blocks at approval ---
+{
+  const dossier = {
+    build_id: "mk2", idea_id: "idea-mk2", use_case: "u", objective: "o", trust_mode: "advisory",
+    market_bound: true, user_facing_frontend: false,
+    required_market_workstreams: ["backend-schema", "security-trust"],
+    required_docs: [], write_targets: ["out/x.txt"], affected_directories: ["."]
+  };
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-mk2-"));
+  const telosDir = path.join(baseDir, ".telos");
+  mkdirSync(telosDir, { recursive: true });
+  const { keyring, signerFor } = makeTeamKeyring(planTeams(dossier));
+  // Market packet covers only backend-schema, NOT security-trust => gate must block.
+  const marketPackets = [{
+    build_id: "mk2", idea_id: "idea-mk2", model: "codex", project_state: "demo",
+    workstreams_reviewed: ["backend-schema"], business_thesis: "t", target_users: ["u"],
+    architecture_findings: [], backend_schema_findings: [], security_findings: [],
+    accuracy_eval_findings: [], scalability_findings: [], frontend_design_findings: [],
+    lexi_class_ui_status: "not-applicable", go_to_market_blockers: [],
+    recommendation_to_claude: "proceed", timestamp: "2026-06-28T12:00:00-04:00"
+  }];
+  const result = await buildProject({
+    dossier, telos: "x",
+    tasks: [{ id: "x", writes: ["out/x.txt"], reads: [], requirements: "r", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "backend-schema" }],
+    callSeat: makeCallSeat({ buildId: "mk2", useCase: "u" }), callTeam: buildTeam, keyring, signerFor, baseDir, telosDir,
+    marketPackets, source: { dossierDir: baseDir }
+  });
+  assert.equal(result.phase, "approval", "blocked at approval");
+  assert.ok(result.blocked.some((b) => /security-trust/.test(b)), "blocked on the unreviewed required workstream");
+  assert.equal(existsSync(path.join(telosDir, "plan.json")), false, "no plan written when market gate fails");
+  console.log("OK: market-bound fail-closed on missing workstream");
 }
 
 console.log("test-build-orchestrator.mjs OK");

--- a/build-gate/scripts/test-build-orchestrator.mjs
+++ b/build-gate/scripts/test-build-orchestrator.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// test-build-orchestrator.mjs — the autonomous builder end to end, KEYLESS.
+// Proves the composition: decompose -> council approval gate (fail-closed) ->
+// content-addressed plan -> teams build as workers -> Rule-3 verify -> signed
+// ledger -> done() ready. No API keys: council + teams are deterministic mocks;
+// the Ed25519 substrate is real.
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { readLedger } from "../../merkle-dag/crypto.mjs";
+import { buildProject, makeTeamDispatch, makeTeamKeyring } from "../build-orchestrator.mjs";
+import { planTeams } from "../teams.mjs";
+
+// A gate-valid dossier (non-market keeps the council gate to the 3 required seats).
+function makeDossier() {
+  return {
+    build_id: "ap1",
+    use_case: "autonomous-build",
+    objective: "build a tiny project autonomously",
+    required_docs: [],
+    write_targets: []
+  };
+}
+
+// Council seat caller: approves for every model; doubles as the Planning team's
+// decompose source when intent==="decompose".
+function makeCallSeat({ decision = "approve", tasks } = {}) {
+  return async ({ model, intent }) => {
+    if (intent === "decompose") return { tasks };
+    return {
+      packet: {
+        build_id: "ap1", use_case: "autonomous-build", model, role: "approver",
+        docs_reviewed: [], proposal_ref: "ap1", decision, required_edits: [],
+        hard_stops: [], confidence: "high", timestamp: "2026-06-28T00:00:00Z"
+      },
+      provenance: { model: `real-${model}`, source: "mock", response_id: `r_${model}` }
+    };
+  };
+}
+
+// Team build caller: writes the node's declared files (so Rule-3 verify passes).
+const buildTeam = async ({ team, node }) => ({
+  files: node.files.map((p) => ({ path: p, content: `// ${node.id} built by team ${team.id}\n` }))
+});
+
+const tasks = [
+  { id: "core", writes: ["out/core.txt"], reads: [], requirements: "core module", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "product-architecture" },
+  { id: "app", writes: ["out/app.txt"], reads: ["out/core.txt"], requirements: "app on core", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "product-architecture" }
+];
+
+function fixture() {
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-teams-"));
+  const telosDir = path.join(baseDir, ".telos");
+  mkdirSync(telosDir, { recursive: true });
+  const teams = planTeams(makeDossier());
+  const { keyring, signerFor } = makeTeamKeyring(teams);
+  return { baseDir, telosDir, keyring, signerFor };
+}
+
+// --- Happy path: hand-authored tasks build all the way to merge_status:ready ---
+{
+  const { baseDir, telosDir, keyring, signerFor } = fixture();
+  const result = await buildProject({
+    dossier: makeDossier(), telos: "make a tiny project", tasks,
+    callSeat: makeCallSeat(), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir, maxRepairRounds: 20
+  });
+
+  assert.equal(result.phase, "build", "reached the build phase");
+  assert.equal(result.ok, true, "build ok");
+  assert.equal(result.report.merge_status, "ready", "done() gate reports ready");
+  const ledger = readLedger(path.join(telosDir, "ledger.jsonl"));
+  assert.equal(ledger.length, 2, "both nodes settled into the signed ledger");
+  assert.ok(ledger.every((r) => r.sig && r.sig.alg === "Ed25519"), "ledger entries are Ed25519-signed");
+  const settled = result.trace.filter((t) => t.action === "settled").map((t) => t.id).sort();
+  assert.deepEqual(settled, ["app", "core"], "both nodes appear settled in the trace");
+  console.log("OK: happy path -> ready");
+}
+
+// --- Fail-closed sequencing: a council 'revise' blocks at approval; NO plan, NO ledger ---
+{
+  const { baseDir, telosDir, keyring, signerFor } = fixture();
+  const result = await buildProject({
+    dossier: makeDossier(), telos: "x", tasks,
+    callSeat: makeCallSeat({ decision: "revise" }), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir
+  });
+
+  assert.equal(result.phase, "approval", "stopped at the approval phase");
+  assert.equal(result.ok, false, "not ok");
+  assert.ok(result.blocked.some((b) => /decision is 'revise'/.test(b)), "blocked on the revise decision");
+  assert.equal(existsSync(path.join(telosDir, "plan.json")), false, "no plan written when approval fails");
+  assert.equal(existsSync(path.join(telosDir, "ledger.jsonl")), false, "no ledger written when approval fails");
+  console.log("OK: fail-closed — approval blocks before any execution");
+}
+
+// --- Autonomous decompose: omit tasks, the Planning team proposes them, build reaches ready ---
+{
+  const { baseDir, telosDir, keyring, signerFor } = fixture();
+  const result = await buildProject({
+    dossier: makeDossier(), telos: "decompose me",
+    callSeat: makeCallSeat({ tasks }), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir, maxRepairRounds: 20
+  });
+
+  assert.equal(result.ok, true, "autonomous decomposition built to ready");
+  assert.equal(result.report.merge_status, "ready", "Planning-team tasks survived the gate + Rule-3 verify");
+  console.log("OK: autonomous decompose -> ready");
+}
+
+// --- Decompose fail-closed: an empty decomposition stops before approval/plan ---
+{
+  const { baseDir, telosDir, keyring, signerFor } = fixture();
+  const result = await buildProject({
+    dossier: makeDossier(), telos: "nothing",
+    callSeat: makeCallSeat({ tasks: [] }), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir
+  });
+  assert.equal(result.phase, "decompose", "stopped at decompose");
+  assert.equal(result.ok, false, "empty decomposition is fail-closed");
+  console.log("OK: empty decomposition blocks");
+}
+
+// --- A team verify-failure does NOT settle: bad test => node blocked, no ledger entry ---
+{
+  const { baseDir, telosDir, keyring, signerFor } = fixture();
+  const badTasks = [
+    { id: "good", writes: ["out/good.txt"], reads: [], requirements: "ok", test: { cmd: "node", args: ["-e", "process.exit(0)"] }, workstream: "product-architecture" },
+    { id: "bad", writes: ["out/bad.txt"], reads: [], requirements: "fails its own test", test: { cmd: "node", args: ["-e", "process.exit(1)"] }, workstream: "product-architecture" }
+  ];
+  const result = await buildProject({
+    dossier: makeDossier(), telos: "x", tasks: badTasks,
+    callSeat: makeCallSeat(), callTeam: buildTeam,
+    keyring, signerFor, baseDir, telosDir, maxRepairRounds: 5
+  });
+  assert.equal(result.report.merge_status, "blocked", "a failing node blocks the merge (Rule 3 not bypassed)");
+  const ledger = readLedger(path.join(telosDir, "ledger.jsonl"));
+  assert.deepEqual(ledger.map((r) => r.task_id), ["good"], "only the verified node settled; the failing one did not");
+  console.log("OK: Rule-3 verify is load-bearing");
+}
+
+// --- makeTeamDispatch unit: a team writing OUTSIDE baseDir is rejected (path escape) ---
+{
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-disp-"));
+  const team = { id: "rogue", signer: "rogue" };
+  const dispatch = makeTeamDispatch({
+    routeFor: () => team,
+    callTeam: async () => ({ files: [{ path: "../escape.txt", content: "x" }] }),
+    baseDir, dossier: {}
+  });
+  const out = await dispatch({ id: "n", files: ["../escape.txt"] });
+  assert.equal(out.ok, false, "path-escaping write is rejected");
+  assert.match(out.reason, /escapes baseDir/, "reason names the escape");
+  console.log("OK: dispatch rejects path escape");
+}
+
+// --- makeTeamDispatch unit: a team that declines surfaces a respec for the repair loop ---
+{
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-disp2-"));
+  const team = { id: "t", signer: "t" };
+  const dispatch = makeTeamDispatch({
+    routeFor: () => team,
+    callTeam: async () => ({ ok: false, reason: "needs more spec", respec: { requirements: "clarified" } }),
+    baseDir, dossier: {}
+  });
+  const out = await dispatch({ id: "n", files: [] });
+  assert.equal(out.ok, false, "decline is a halt");
+  assert.deepEqual(out.respec, { requirements: "clarified" }, "respec passes through to runBuild's repair loop");
+  console.log("OK: dispatch surfaces respec on decline");
+}
+
+console.log("test-build-orchestrator.mjs OK");

--- a/build-gate/scripts/test-decompose.mjs
+++ b/build-gate/scripts/test-decompose.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// test-decompose.mjs — the Planning team's decomposition contract: extract a usable
+// task list, normalize it for the planner, and fail closed on garbage.
+import assert from "node:assert/strict";
+import { decompose } from "../decompose.mjs";
+
+const dossier = { build_id: "d1", use_case: "u", market_bound: false };
+const seatReturning = (payload) => async () => payload;
+
+// --- extract + normalize: defaults workstream, fills empty reads/baseDependencies ---
+{
+  const tasks = await decompose({
+    dossier, telos: "t",
+    callSeat: seatReturning({ tasks: [
+      { id: "a", writes: ["a.txt"], requirements: "make a", test: { cmd: "node", args: ["-e", ""] } },
+      { id: "b", writes: ["b.txt"], reads: ["a.txt"], requirements: "make b", test: { cmd: "node" }, workstream: "backend-schema", baseDependencies: ["a"] }
+    ] })
+  });
+  assert.equal(tasks.length, 2, "both valid tasks extracted");
+  assert.equal(tasks[0].workstream, "product-architecture", "missing workstream defaults to product-architecture");
+  assert.deepEqual(tasks[0].reads, [], "missing reads normalized to []");
+  assert.deepEqual(tasks[0].baseDependencies, [], "missing baseDependencies normalized to []");
+  assert.equal(tasks[1].workstream, "backend-schema", "explicit workstream preserved");
+  assert.deepEqual(tasks[1].baseDependencies, ["a"], "explicit baseDependencies preserved");
+}
+
+// --- accepts tasks nested under a packet body too ---
+{
+  const tasks = await decompose({
+    dossier, telos: "t",
+    callSeat: seatReturning({ packet: { tasks: [{ id: "x", writes: ["x"], requirements: "r", test: { cmd: "node" } }] } })
+  });
+  assert.equal(tasks.length, 1, "tasks read from packet.tasks");
+}
+
+// --- invalid tasks are filtered; if nothing valid remains, fail closed ---
+{
+  await assert.rejects(
+    decompose({ dossier, telos: "t", callSeat: seatReturning({ tasks: [
+      { id: "no-writes", requirements: "r", test: { cmd: "node" } },
+      { writes: ["y"], requirements: "no id", test: { cmd: "node" } },
+      { id: "no-test", writes: ["z"], requirements: "r" }
+    ] }) }),
+    /produced no valid tasks/,
+    "all-invalid decomposition throws (no silent empty plan)"
+  );
+}
+
+// --- empty proposal fails closed ---
+{
+  await assert.rejects(
+    decompose({ dossier, telos: "t", callSeat: seatReturning({ tasks: [] }) }),
+    /no valid tasks/,
+    "empty task list throws"
+  );
+}
+
+// --- duplicate ids rejected before any plan is built ---
+{
+  await assert.rejects(
+    decompose({ dossier, telos: "t", callSeat: seatReturning({ tasks: [
+      { id: "dup", writes: ["a"], requirements: "r", test: { cmd: "node" } },
+      { id: "dup", writes: ["b"], requirements: "r", test: { cmd: "node" } }
+    ] }) }),
+    /duplicate task id 'dup'/,
+    "duplicate task ids are fail-closed"
+  );
+}
+
+console.log("test-decompose.mjs OK");

--- a/build-gate/scripts/test-team-prompts.mjs
+++ b/build-gate/scripts/test-team-prompts.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// test-team-prompts.mjs — pure (no-network) coverage of the live-wiring helpers:
+// buildable-seat selection, prompt construction, response parsing/clamping, and a
+// fake-client callTeam round-trip.
+import assert from "node:assert/strict";
+import { buildableSeat, promptForTeam, nodeBuildPrompt, parseTeamFiles, makeLiveCallTeam, approvalPromptFor } from "../teamPrompts.mjs";
+
+// --- buildableSeat: skip a structured lead (agy) for the first _ask-capable seat ---
+{
+  assert.equal(buildableSeat({ seats: [{ model: "claude" }, { model: "codex" }] }), "claude", "first ask seat is the lead");
+  assert.equal(buildableSeat({ seats: [{ model: "agy" }, { model: "codex" }] }), "codex", "agy lead falls back to codex builder");
+  assert.equal(buildableSeat({ seats: [{ model: "agy" }] }), "claude", "no ask seat => claude default");
+}
+
+// --- prompts mention the node spec and the strict JSON contract ---
+{
+  const sys = promptForTeam({ id: "backend", mission: "data model" });
+  assert.match(sys, /backend/, "system prompt names the team");
+  assert.match(sys, /\{"files"/, "system prompt states the JSON files contract");
+  const up = nodeBuildPrompt({ id: "n1", requirements: "do x", files: ["a.txt"] });
+  assert.match(up, /n1/, "user prompt carries the node id");
+  assert.match(up, /a\.txt/, "user prompt lists the declared files");
+}
+
+// --- parseTeamFiles: clamps to declared files, drops undeclared/malformed ---
+{
+  const node = { id: "n", files: ["keep.txt"] };
+  const out = parseTeamFiles(JSON.stringify({ files: [
+    { path: "keep.txt", content: "ok" },
+    { path: "sneak.txt", content: "nope" },
+    { path: "keep.txt", content: 123 }
+  ] }), node);
+  assert.deepEqual(out, [{ path: "keep.txt", content: "ok" }], "only declared, string-content files survive");
+
+  // tolerate the {text:"...json..."} envelope shape the ask tools can return
+  const env = parseTeamFiles(JSON.stringify({ text: JSON.stringify({ files: [{ path: "keep.txt", content: "v" }] }) }), node);
+  assert.deepEqual(env, [{ path: "keep.txt", content: "v" }], "unwraps the provenance envelope text");
+
+  assert.deepEqual(parseTeamFiles("not json", node), [], "garbage -> no files (fail-closed)");
+}
+
+// --- makeLiveCallTeam: round-trips through a fake client; empty -> decline ---
+{
+  const node = { id: "n", files: ["out.txt"] };
+  const okClient = { async callTool(tool, args) {
+    assert.equal(tool, "codex_ask", "uses the team's buildable seat tool");
+    assert.equal(args.include_provenance, true, "requests provenance envelope");
+    return JSON.stringify({ files: [{ path: "out.txt", content: "built" }] });
+  } };
+  const callTeam = makeLiveCallTeam({ client: okClient });
+  const res = await callTeam({ team: { id: "backend", seats: [{ model: "codex" }] }, node });
+  assert.deepEqual(res.files, [{ path: "out.txt", content: "built" }], "live callTeam returns clamped files");
+
+  const emptyClient = { async callTool() { return JSON.stringify({ files: [] }); } };
+  const decline = await makeLiveCallTeam({ client: emptyClient })({ team: { id: "backend", seats: [{ model: "codex" }] }, node });
+  assert.equal(decline.ok, false, "no usable files -> fail-closed decline");
+}
+
+// --- approvalPromptFor: agy stays structured; chat seats emit packet instructions ---
+{
+  const promptFor = approvalPromptFor({ build_id: "b", use_case: "u", objective: "o" });
+  const agy = promptFor("agy", "approver");
+  assert.equal(agy.tool, "agy_checkpoint", "agy uses the structured checkpoint tool");
+  const claude = promptFor("claude", "approver");
+  assert.equal(claude.tool, "claude_ask", "chat seats use their ask tool");
+  assert.match(claude.system, /approval packet/, "chat seat is told to emit an approval packet");
+  assert.match(claude.prompt, /build_id: b/, "prompt carries dossier context");
+}
+
+console.log("test-team-prompts.mjs OK");

--- a/build-gate/scripts/test-teams.mjs
+++ b/build-gate/scripts/test-teams.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// test-teams.mjs — the agentic-teams roster: dossier-sized planTeams, deterministic
+// node->team routing, and the authorized_signers collection that pins teams to the ledger.
+import assert from "node:assert/strict";
+import { TEAMS, planTeams, teamForNode, authorizedSignersFor } from "../teams.mjs";
+
+// --- TEAMS shape: every team is well-formed and its signer is usable as a key_id ---
+{
+  assert.ok(Array.isArray(TEAMS) && TEAMS.length >= 5, "TEAMS is a non-trivial roster");
+  const ids = new Set();
+  for (const t of TEAMS) {
+    assert.ok(typeof t.id === "string" && t.id.length > 0, "team has an id");
+    assert.ok(!ids.has(t.id), `team id '${t.id}' is unique`);
+    ids.add(t.id);
+    assert.ok(Array.isArray(t.seats) && t.seats.length > 0, `team '${t.id}' has seats`);
+    assert.ok(t.seats.every((s) => typeof s.model === "string" && typeof s.role === "string"), `team '${t.id}' seats are {model,role}`);
+    assert.ok(["plan", "build", "verify"].includes(t.lifecycle), `team '${t.id}' has a valid lifecycle`);
+    assert.ok(typeof (t.signer || t.id) === "string", `team '${t.id}' has a signer key_id`);
+  }
+}
+
+// --- planTeams: non-market job convenes only the always-on meta backbone ---
+{
+  const roster = planTeams({ build_id: "x" });
+  const got = roster.map((t) => t.id).sort();
+  assert.deepEqual(got, ["architecture", "breakout", "planning"], "non-market job = planning + architecture + breakout");
+}
+
+// --- planTeams: market-bound job adds one team per required workstream, deduped ---
+{
+  const roster = planTeams({
+    build_id: "x",
+    market_bound: true,
+    required_market_workstreams: ["backend-schema", "frontend-brand-experience", "product-architecture"]
+  });
+  const got = roster.map((t) => t.id).sort();
+  // architecture owns product-architecture AND is always-on => must appear exactly once.
+  assert.deepEqual(got, ["architecture", "backend", "breakout", "frontend", "planning"], "market job adds workstream teams, architecture not doubled");
+  assert.equal(got.filter((id) => id === "architecture").length, 1, "architecture deduped");
+}
+
+// --- planTeams: unknown workstream is ignored (no phantom team) ---
+{
+  const roster = planTeams({ build_id: "x", market_bound: true, required_market_workstreams: ["does-not-exist"] });
+  const got = roster.map((t) => t.id).sort();
+  assert.deepEqual(got, ["architecture", "breakout", "planning"], "unknown workstream contributes no team");
+}
+
+// --- teamForNode: explicit workstream routes deterministically ---
+{
+  const roster = planTeams({ build_id: "x", market_bound: true, required_market_workstreams: ["backend-schema", "frontend-brand-experience"] });
+  assert.equal(teamForNode({ id: "n1", workstream: "backend-schema" }, roster).id, "backend", "backend-schema node -> backend team");
+  assert.equal(teamForNode({ id: "n2", workstream: "frontend-brand-experience" }, roster).id, "frontend", "frontend node -> frontend team");
+  // same node routes the same way every time (pure)
+  assert.equal(teamForNode({ id: "n1", workstream: "backend-schema" }, roster).id, "backend", "routing is deterministic");
+}
+
+// --- teamForNode: no/unknown workstream falls back to the first build team ---
+{
+  const roster = planTeams({ build_id: "x" }); // planning, architecture(build), breakout
+  assert.equal(teamForNode({ id: "n3" }, roster).id, "architecture", "missing workstream -> first build team");
+  assert.equal(teamForNode({ id: "n4", workstream: "backend-schema" }, roster).id, "architecture", "absent team -> first build-team fallback");
+}
+
+// --- authorizedSignersFor: only signers present in the keyring are pinned (fail-closed) ---
+{
+  const roster = planTeams({ build_id: "x" }); // signers: planning, architecture, breakout
+  const fullKeyring = { planning: { kty: "OKP" }, architecture: { kty: "OKP" }, breakout: { kty: "OKP" }, unused: { kty: "OKP" } };
+  const signers = authorizedSignersFor(roster, fullKeyring);
+  assert.deepEqual(Object.keys(signers).sort(), ["architecture", "breakout", "planning"], "collects each roster team's signer; ignores unused keys");
+
+  const partial = authorizedSignersFor(roster, { architecture: { kty: "OKP" } });
+  assert.deepEqual(Object.keys(partial), ["architecture"], "a team whose key is absent cannot settle (excluded)");
+
+  assert.deepEqual(authorizedSignersFor(roster, null), {}, "no keyring => no signers (fail-closed)");
+}
+
+console.log("test-teams.mjs OK");

--- a/build-gate/teamPrompts.mjs
+++ b/build-gate/teamPrompts.mjs
@@ -1,0 +1,107 @@
+// teamPrompts.mjs — LIVE wiring for the agentic teams over ai-peer-mcp.
+//
+// The orchestrator (build-orchestrator.mjs) is transport-agnostic: it takes an
+// injected `callSeat` (council approval) and `callTeam` (build execution). This
+// module builds both over a minimal MCP client (../breakout/mcp_client.mjs),
+// giving each team its own system prompt. It is opt-in: nothing here runs without
+// API keys, mirroring the existing `smoke` scripts. The pure prompt/parse helpers
+// are unit-tested without a network.
+
+// Chat seats expose an `<model>_ask` tool; agy is structured (no code generation).
+const ASK_MODELS = new Set(["claude", "grok", "codex"]);
+
+// A team's buildable lead: the first seat whose model has an _ask tool (so e.g.
+// the ops team, led by the structured agy seat, still builds via its codex seat).
+export function buildableSeat(team) {
+  const seats = team && Array.isArray(team.seats) ? team.seats : [];
+  const seat = seats.find((s) => ASK_MODELS.has(s.model));
+  return seat ? seat.model : "claude";
+}
+
+// System prompt for a team: mission + the strict JSON contract the builder parses.
+export function promptForTeam(team) {
+  const mission = team && team.mission ? team.mission : "build the requested node";
+  return [
+    `You are the TELOS "${team?.id ?? "build"}" team. Mission: ${mission}.`,
+    "You implement EXACTLY one task node. You see only its spec — never the wider plan.",
+    "Return ONLY a JSON object of the form {\"files\":[{\"path\":\"<one of the node's declared files>\",\"content\":\"<file contents>\"}]}.",
+    "Write every file the node declares and no others. No prose, no markdown fences."
+  ].join(" ");
+}
+
+// Build the per-node user prompt from the injected spec (Rule 1: spec only).
+export function nodeBuildPrompt(node) {
+  return [
+    `Task id: ${node.id}`,
+    `Requirements: ${node.requirements}`,
+    `Files to write (exactly these): ${JSON.stringify(node.files)}`,
+    "Emit the JSON {files:[...]} now."
+  ].join("\n");
+}
+
+// Parse a team's response into a files array, CLAMPED to the node's declared
+// files (a team cannot write outside its node spec — the orchestrator also
+// re-checks path escapes, and Rule-3 verify re-derives the artifact hash).
+export function parseTeamFiles(text, node) {
+  let parsed;
+  try { parsed = typeof text === "string" ? JSON.parse(text) : text; } catch { return []; }
+  const body = parsed && typeof parsed.text === "string" ? safeJson(parsed.text) : parsed;
+  const files = body && Array.isArray(body.files) ? body.files : [];
+  const declared = new Set(node.files || []);
+  return files
+    .filter((f) => f && typeof f.path === "string" && declared.has(f.path) && typeof f.content === "string")
+    .map((f) => ({ path: f.path, content: f.content }));
+}
+
+function safeJson(text) {
+  try { return JSON.parse(text); } catch { return null; }
+}
+
+/**
+ * Build a live callTeam({team,node,dossier}) over an MCP client. The team's
+ * buildable lead is asked to emit the node's files as JSON; the result is parsed
+ * and clamped. A response with no usable files becomes a fail-closed decline (the
+ * orchestrator turns ok:false into a halt — never a silent empty write).
+ *   client { callTool(name, args) -> Promise<string> }  (../breakout/mcp_client.mjs)
+ */
+export function makeLiveCallTeam({ client }) {
+  return async ({ team, node }) => {
+    const model = buildableSeat(team);
+    const text = await client.callTool(`${model}_ask`, {
+      system: promptForTeam(team),
+      prompt: nodeBuildPrompt(node),
+      include_provenance: true
+    });
+    const files = parseTeamFiles(text, node);
+    if (files.length === 0) {
+      return { ok: false, reason: `team ${team.id} (${model}) returned no usable files for ${node.id}` };
+    }
+    return { files };
+  };
+}
+
+/**
+ * Build a promptFor(model, role, dossier, workstream) for liveSeatCaller
+ * (council.mjs) so the approval council emits gate-valid JSON packets. agy stays
+ * structured (agy_checkpoint args); chat seats get a packet-emitting instruction.
+ */
+export function approvalPromptFor(dossier) {
+  return (model, role, _dossier, workstream) => {
+    if (model === "agy") {
+      return { tool: "agy_checkpoint", args: { phase: "approval", scope: dossier?.use_case ?? "" } };
+    }
+    const system = [
+      `You are the ${model} approval seat (role: ${role}${workstream ? `, workstream: ${workstream}` : ""}).`,
+      "Review the build and return ONLY a JSON approval packet with fields:",
+      "build_id, use_case, model, role, docs_reviewed[], proposal_ref, decision",
+      "(approve|revise|reject), required_edits[], hard_stops[], confidence (low|medium|high), timestamp."
+    ].join(" ");
+    const prompt = [
+      `build_id: ${dossier?.build_id}`,
+      `use_case: ${dossier?.use_case}`,
+      `objective: ${dossier?.objective}`,
+      "Emit the JSON approval packet now."
+    ].join("\n");
+    return { tool: `${model}_ask`, system, prompt };
+  };
+}

--- a/build-gate/teams.mjs
+++ b/build-gate/teams.mjs
@@ -1,0 +1,92 @@
+// teams.mjs — agentic-teams roster for the autonomous builder.
+//
+// TELOS already has two halves: the APPROVAL council (council.mjs -> gate.mjs)
+// and the EXECUTION substrate (../merkle-dag: planner -> orchestrate -> ledger).
+// A "team" is the missing organizing layer that composes them: a named roster of
+// model seats with a lifecycle role and an owned workstream. A build/verify team
+// plugs into runBuild as a worker (orchestrate.mjs `dispatch`), so a team's
+// self-report can never satisfy the gate — the controller re-derives every fact.
+//
+// DYNAMIC SIZING mirrors planSeats(dossier) (council.mjs): the always-on meta
+// teams convene for every job; a market-bound job additionally convenes one
+// build/verify team per required workstream. So the team count is a function of
+// the dossier, not a fixed roster. The roster is DATA (TEAMS below) so a new
+// model seat or team registers without code changes — just add a row + its
+// signer keypair + TELOS_SECRET_*.
+
+// Each team:
+//   id         stable identifier (also the Ed25519 ledger signer key_id)
+//   mission    one line on what the team owns
+//   seats      [{ model, role }] — lead first; role is team-internal (lead/member)
+//   workstream the gate workstream this team owns (null for meta teams)
+//   lifecycle  "plan" | "build" | "verify" (where it plugs into the flow)
+//   signer     ledger key_id used when this team settles a node (defaults to id)
+export const TEAMS = [
+  { id: "planning",     mission: "decompose idea+telos into a content-addressed task DAG", seats: [{ model: "claude", role: "lead" }, { model: "codex", role: "member" }, { model: "agy", role: "member" }], workstream: null,                          lifecycle: "plan",   signer: "planning" },
+  { id: "architecture", mission: "system shape, module boundaries, file footprints",       seats: [{ model: "claude", role: "lead" }, { model: "codex", role: "member" }],                                    workstream: "product-architecture",        lifecycle: "build",  signer: "architecture" },
+  { id: "backend",      mission: "data model, services, migrations",                        seats: [{ model: "codex", role: "lead" }, { model: "agy", role: "member" }],                                       workstream: "backend-schema",              lifecycle: "build",  signer: "backend" },
+  { id: "frontend",     mission: "UI and LEXI-class brand experience",                      seats: [{ model: "claude", role: "lead" }, { model: "codex", role: "member" }],                                    workstream: "frontend-brand-experience",   lifecycle: "build",  signer: "frontend" },
+  { id: "evals",        mission: "acceptance tests that decide a node's `meets` verdict",   seats: [{ model: "claude", role: "lead" }, { model: "codex", role: "member" }],                                    workstream: "accuracy-evals",              lifecycle: "verify", signer: "evals" },
+  { id: "security",     mission: "threat model, secrets hygiene, abuse cases",              seats: [{ model: "grok", role: "lead" }, { model: "codex", role: "member" }],                                      workstream: "security-trust",              lifecycle: "verify", signer: "security" },
+  { id: "ops",          mission: "deploy, scale, rollback readiness",                       seats: [{ model: "agy", role: "lead" }, { model: "codex", role: "member" }],                                       workstream: "scale-operations",            lifecycle: "verify", signer: "ops" },
+  { id: "business",     mission: "thesis, differentiation, market positioning",             seats: [{ model: "claude", role: "lead" }, { model: "grok", role: "member" }],                                     workstream: "business-positioning",        lifecycle: "plan",   signer: "business" },
+  { id: "breakout",     mission: "adversarial verdict-on-facts; gate of last resort",       seats: [{ model: "grok", role: "lead" }, { model: "claude", role: "member" }],                                     workstream: null,                          lifecycle: "verify", signer: "breakout" }
+];
+
+// Always-on teams: the meta backbone plus architecture. Architecture is also a
+// workstream team, so dedupe-by-id below prevents a double convene.
+const ALWAYS_ON = ["planning", "architecture", "breakout"];
+
+const byId = new Map(TEAMS.map((t) => [t.id, t]));
+const byWorkstream = new Map(TEAMS.filter((t) => t.workstream).map((t) => [t.workstream, t]));
+
+/**
+ * Decide the team roster for a job FROM the dossier — the team analogue of
+ * planSeats(dossier) (council.mjs:42-50). Always convene the meta backbone; a
+ * market-bound job additionally convenes one team per required workstream.
+ * Pure; deduped-by-id; returns roster in TEAMS declaration order.
+ */
+export function planTeams(dossier) {
+  const ids = new Set(ALWAYS_ON);
+  if (dossier && dossier.market_bound === true) {
+    const workstreams = Array.isArray(dossier.required_market_workstreams) ? dossier.required_market_workstreams : [];
+    for (const ws of workstreams) {
+      const team = byWorkstream.get(ws);
+      if (team) ids.add(team.id);
+    }
+  }
+  return TEAMS.filter((t) => ids.has(t.id));
+}
+
+/**
+ * Deterministic node -> owning team. Primary key is the node's explicit
+ * `workstream` field (set by the Planning team during decomposition); falls back
+ * to the first build-lifecycle team in the roster, then to the first team. The
+ * mapping is pure data so the same node always routes to the same team.
+ */
+export function teamForNode(node, teams) {
+  const roster = Array.isArray(teams) && teams.length ? teams : TEAMS;
+  const ws = node && typeof node.workstream === "string" ? node.workstream : null;
+  if (ws) {
+    const match = roster.find((t) => t.workstream === ws);
+    if (match) return match;
+  }
+  return roster.find((t) => t.lifecycle === "build") || roster[0];
+}
+
+/**
+ * Collect the Ed25519 authorized_signers map { key_id: publicJwk } that
+ * compileAndHashPlan pins into plan_hash. Only signers present in `keyring`
+ * (a { key_id: publicJwk } map) are included — a team whose signer key is absent
+ * cannot settle a node (fail-closed at the ledger gate). Deduped by signer.
+ */
+export function authorizedSignersFor(teams, keyring) {
+  const roster = Array.isArray(teams) && teams.length ? teams : TEAMS;
+  const signers = {};
+  const ring = keyring && typeof keyring === "object" ? keyring : {};
+  for (const t of roster) {
+    const keyId = t.signer || t.id;
+    if (ring[keyId] && !signers[keyId]) signers[keyId] = ring[keyId];
+  }
+  return signers;
+}

--- a/contracts/Agentic Teams Autonomous Builder.md
+++ b/contracts/Agentic Teams Autonomous Builder.md
@@ -95,7 +95,14 @@ files. As with the council, a seat with no API key fail-closes.
 
 ## Evidence
 
-`docs/runs/agentic-teams/` contains a keyless, reproducible end-to-end run
-(`run-teams.mjs` → `run-summary.json`): deterministic mock seats over the real
-gate, real Ed25519 ledger, and real merkle-dag substrate, reaching
-`merge_status: "ready"`.
+Two keyless, reproducible end-to-end runs (deterministic mock seats over the real
+gate, real Ed25519 ledger, and real merkle-dag substrate), each reaching
+`merge_status: "ready"`:
+
+- `docs/runs/agentic-teams/` (`run-teams.mjs`) — a non-market build (the meta
+  backbone convenes; nodes route to the architecture team).
+- `docs/runs/agentic-teams-market/` (`run-teams-market.mjs`) — a **market-bound**
+  build with the **full multi-team fan-out**: all nine teams convene, nodes route
+  to distinct teams (backend, frontend, security, ops), each settling under its
+  own signer, and the market-readiness gate — including the frontend `meets`
+  breakout re-verify against an on-disk evidence file — stays load-bearing.

--- a/contracts/Agentic Teams Autonomous Builder.md
+++ b/contracts/Agentic Teams Autonomous Builder.md
@@ -1,0 +1,101 @@
+---
+title: "Agentic Teams — Autonomous Builder"
+type: contract
+tags:
+  - topic/agentic-teams
+  - workflow/build-gate
+---
+
+# Agentic Teams — Autonomous Builder
+
+This contract defines how TELOS turns an idea into merged software autonomously,
+by composing its two existing halves — the **approval council** (`build-gate`) and
+the **execution substrate** (`merkle-dag`) — through an **agentic-teams** layer.
+It does **not** introduce a new trust model: every guarantee in the build-gate and
+ledger contracts still holds. A team's self-report is never load-bearing.
+
+## What a team is
+
+A **team** is a named roster of model *seats* with a lifecycle role and an owned
+workstream. A team is the missing organizing layer that says *who* does a unit of
+work. Crucially, a build/verify team is just a **worker behind `runBuild`'s
+`dispatch`** (`merkle-dag/orchestrate.mjs`): it sees only the node spec (Rule 1)
+and its output is independently re-derived (Rule 3). So teams **propose**; the
+deterministic substrate **disposes**.
+
+The roster is data (`build-gate/teams.mjs`, `TEAMS`). Adding a model seat or a
+team is a config edit plus a signer keypair + `TELOS_SECRET_*` — no trust bypass.
+
+| Team | Lifecycle | Workstream | Mission |
+|---|---|---|---|
+| planning | plan | — | decompose idea+telos into a content-addressed task DAG |
+| architecture | build | product-architecture | system shape, boundaries, file footprints |
+| backend | build | backend-schema | data model, services, migrations |
+| frontend | build | frontend-brand-experience | UI / LEXI-class brand experience |
+| evals | verify | accuracy-evals | acceptance tests that decide a node's `meets` verdict |
+| security | verify | security-trust | threat model, secrets hygiene, abuse cases |
+| ops | verify | scale-operations | deploy, scale, rollback readiness |
+| business | plan | business-positioning | thesis, differentiation, market positioning |
+| breakout | verify | — | adversarial verdict-on-facts; gate of last resort |
+
+## Dynamic sizing (from the dossier)
+
+`planTeams(dossier)` is the team analogue of `planSeats(dossier)`:
+
+- The meta backbone — **planning, architecture, breakout** — convenes for every job.
+- A **market-bound** job additionally convenes one team per entry in
+  `required_market_workstreams` (deduped by id).
+
+So the team count is a function of the job, not a fixed roster.
+
+## The lifecycle (fail-closed sequencing)
+
+```
+idea + telos
+  → [planning] decompose() → tasks[] {id,writes,reads,requirements,test,workstream}
+  → compileAndHashPlan() → content-addressed plan (+ authorized_signers); writePlan()
+  → COUNCIL APPROVAL GATE: runCouncil → validateRecords      [MUST pass before execution]
+  → runBuild(): each ready node dispatched to its OWNING TEAM (team = worker)
+        Rule 1 — the team sees only the node spec; it writes the node's files
+  → Rule 3 defaultVerifyNode re-derives the artifact hash + runs node.test
+  → [breakout] reverifyRecord on declarative checks for "meets"-class nodes
+  → settle: the controller (sole writer) signs the Ed25519 ledger record
+  → ledger-gate.verify() done() → merge_status:"ready"
+  → merge
+```
+
+The orchestrator (`build-gate/build-orchestrator.mjs`, `buildProject`) STOPS at the
+first failing phase and **never advances to execution unless the council approval
+gate passed**. The phases it reports: `decompose | approval | plan | build`.
+
+## Invariants (must not weaken)
+
+- **Routing by id, not by reading the node.** Rule 1 strips `workstream` from the
+  dispatched spec, so each node's owning team is decided *before* the build (from
+  the task list) and looked up by id at dispatch time.
+- **Verification stays in `verifyNode`.** The dispatch never certifies its own
+  work; `defaultVerifyNode` re-derives the artifact tree-hash and runs the node
+  test. A team that writes nothing, or fails its test, does not settle.
+- **The controller is the sole ledger writer.** A team's `signer` key_id must be
+  in `plan.authorized_signers` (pinned into `plan_hash`) or the ledger gate
+  rejects the settlement.
+- **Path confinement.** A team may only write its node's declared files, under
+  `baseDir`; escapes are rejected before any write.
+- **Decomposition is non-load-bearing.** The Planning team's task list is
+  re-hashed by the planner and must still survive the approval gate and Rule-3
+  verify — a fabricated decomposition cannot reach merge.
+
+## Live wiring (opt-in)
+
+`build-gate/teamPrompts.mjs` builds the live `callSeat` (approval, via
+`liveSeatCaller` + `approvalPromptFor`) and `callTeam` (execution, via
+`makeLiveCallTeam`) over `ai-peer-mcp`. Each team gets its own system prompt;
+build seats are asked to emit `{files:[...]}` clamped to the node's declared
+files. As with the council, a seat with no API key fail-closes.
+
+## Evidence
+
+`docs/runs/agentic-teams/` contains a keyless, reproducible end-to-end run
+(`run-teams.mjs` → `run-summary.json`): deterministic mock seats over the real
+gate, real Ed25519 ledger, and real merkle-dag substrate, reaching
+`merge_status: "ready"`.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -116,3 +116,42 @@ Verification run from the Codex tree:
 
 1. ~~**Codex** applies `ENGINE.patch` to make signed-mode live in `me/codex/` (`patch -p1` dry-run is clean; `ENGINE-APPLY.md` has steps). Verify with `npm test` in both packages after merge.~~ **DONE** (2026-06-28) — applied and verified in `build-gate`, `breakout`, `connectors/ai-peer-mcp`, and `merkle-dag`.
 2. ~~**Optional, for fully-distinct provenance:** wire a codex (OpenAI) and agy backend so agy/codex packets carry their own model `response_id`.~~ **DONE** (2026-06-27) — codex (OpenAI) + agy (local attestation) backends wired into `ai-peer-mcp` and `council.mjs`; bundled in the same `ENGINE.patch`. To exercise codex's live `response_id`, set `OPENAI_API_KEY` before a run; agy is keyless.
+
+## Agentic Teams — Autonomous Builder (2026-06-28)
+
+TELOS now composes its two halves — the approval council (`build-gate`) and the
+execution substrate (`merkle-dag`) — into an **autonomous builder** driven by
+**agentic teams**. A build/verify team is a `runBuild` worker behind `dispatch`
+(Rule 1: spec-only) whose output is re-derived by `defaultVerifyNode` (Rule 3),
+so the teams layer adds **no new trust surface**.
+
+**Added (`build-gate/`, zero new deps):**
+- `teams.mjs` — `TEAMS` roster (data); `planTeams(dossier)` (dossier-sized, mirrors
+  `planSeats`); `teamForNode` (explicit-`workstream` routing); `authorizedSignersFor`.
+- `decompose.mjs` — the Planning team proposes a validated `tasks[]` (data only,
+  fail-closed).
+- `build-orchestrator.mjs` — `buildProject(...)`: decompose → **council approval
+  gate (must pass first)** → `compileAndHashPlan` + `writePlan` → `runBuild` with
+  team dispatch + the unchanged Rule-3 verify → signed Ed25519 ledger → `done()`.
+- `teamPrompts.mjs` — opt-in live wiring over `ai-peer-mcp` (`approvalPromptFor`,
+  `makeLiveCallTeam`, pure prompt/parse helpers).
+
+**Trust preserved:** routing is by node id (Rule 1 strips `workstream`); a failing
+node never settles; the controller is the sole ledger writer and a team's signer
+key_id must be in `plan.authorized_signers`; teams may only write their node's
+declared files under `baseDir`; a fabricated decomposition is re-hashed and must
+still pass the gate + Rule-3 verify. Market-bound builds still demand
+market-readiness packets (passed through to the gate).
+
+**Tests (all green):** `test-teams.mjs`, `test-decompose.mjs`,
+`test-build-orchestrator.mjs` (keyless end-to-end to `merge_status:"ready"`;
+approval `revise` blocks before execution; Rule-3 verify load-bearing),
+`test-team-prompts.mjs`. `build-gate npm test` exit 0 (now incl. these +
+breakout); `merkle-dag npm test` exit 0 (substrate unchanged).
+
+**Evidence:** `runs/agentic-teams/run-teams.mjs` → `run-summary.json` — keyless,
+reproducible, real gate + real Ed25519 ledger + real merkle-dag, reaching
+`merge_status: "ready"`.
+
+**Docs:** `contracts/Agentic Teams Autonomous Builder.md` (protocol),
+`docs/specs/2026-06-28-agentic-teams-design.md` (design).

--- a/docs/runs/agentic-teams-market/run-summary.json
+++ b/docs/runs/agentic-teams-market/run-summary.json
@@ -1,0 +1,119 @@
+{
+  "generated_for": "agentic-teams-market-demo",
+  "market_bound": true,
+  "keyless": true,
+  "phase": "build",
+  "ok": true,
+  "merge_status": "ready",
+  "teams_convened": [
+    "planning",
+    "architecture",
+    "backend",
+    "frontend",
+    "evals",
+    "security",
+    "ops",
+    "business",
+    "breakout"
+  ],
+  "node_routing": [
+    {
+      "node": "schema",
+      "workstream": "backend-schema",
+      "team": "backend"
+    },
+    {
+      "node": "api",
+      "workstream": "backend-schema",
+      "team": "backend"
+    },
+    {
+      "node": "ui",
+      "workstream": "frontend-brand-experience",
+      "team": "frontend"
+    },
+    {
+      "node": "threat-model",
+      "workstream": "security-trust",
+      "team": "security"
+    },
+    {
+      "node": "runbook",
+      "workstream": "scale-operations",
+      "team": "ops"
+    }
+  ],
+  "distinct_teams_used": [
+    "backend",
+    "frontend",
+    "ops",
+    "security"
+  ],
+  "authorized_signers": [
+    "architecture",
+    "backend",
+    "breakout",
+    "business",
+    "evals",
+    "frontend",
+    "ops",
+    "planning",
+    "security"
+  ],
+  "settled_nodes": [
+    {
+      "id": "api",
+      "signer": "backend"
+    },
+    {
+      "id": "runbook",
+      "signer": "ops"
+    },
+    {
+      "id": "schema",
+      "signer": "backend"
+    },
+    {
+      "id": "threat-model",
+      "signer": "security"
+    },
+    {
+      "id": "ui",
+      "signer": "frontend"
+    }
+  ],
+  "ledger_records": [
+    {
+      "task_id": "api",
+      "signer": "backend",
+      "alg": "Ed25519"
+    },
+    {
+      "task_id": "runbook",
+      "signer": "ops",
+      "alg": "Ed25519"
+    },
+    {
+      "task_id": "schema",
+      "signer": "backend",
+      "alg": "Ed25519"
+    },
+    {
+      "task_id": "threat-model",
+      "signer": "security",
+      "alg": "Ed25519"
+    },
+    {
+      "task_id": "ui",
+      "signer": "frontend",
+      "alg": "Ed25519"
+    }
+  ],
+  "market_packets_seen": [
+    "claude",
+    "codex",
+    "grok"
+  ],
+  "council_pass": true,
+  "note": "Market-bound full fan-out. Deterministic mock seats; real gate (incl. market-readiness + breakout re-verify), real Ed25519 ledger, real merkle-dag. Throwaway temp workspace."
+}

--- a/docs/runs/agentic-teams-market/run-teams-market.mjs
+++ b/docs/runs/agentic-teams-market/run-teams-market.mjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// run-teams-market.mjs — a KEYLESS, reproducible end-to-end run of the autonomous
+// builder on a MARKET-BOUND dossier, exercising the FULL multi-team fan-out.
+//
+// Unlike the non-market demo (every node routes to architecture), a market-bound
+// dossier convenes one team per required workstream, so nodes fan out to distinct
+// teams (backend, frontend, security, ops, ...). The market-readiness gate stays
+// load-bearing: the run supplies real market packets whose frontend "meets"
+// breakout record is RE-VERIFIED against an on-disk evidence file. Mock seats, but
+// the real gate + real Ed25519 ledger + real merkle-dag substrate.
+//
+//   node docs/runs/agentic-teams-market/run-teams-market.mjs
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync, readdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readLedger } from "../../../merkle-dag/crypto.mjs";
+import { buildProject, makeTeamKeyring } from "../../../build-gate/build-orchestrator.mjs";
+import { planTeams, teamForNode } from "../../../build-gate/teams.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.resolve(here, "../../../build-gate/examples/agentic-teams-market");
+const dossier = JSON.parse(readFileSync(path.join(fixture, "dossier.json"), "utf8"));
+const tasks = JSON.parse(readFileSync(path.join(fixture, "tasks.json"), "utf8"));
+const marketDir = path.join(fixture, "market");
+const marketPackets = readdirSync(marketDir).filter((f) => f.endsWith(".json")).map((f) => JSON.parse(readFileSync(path.join(marketDir, f), "utf8")));
+
+// Mock council seat: approves for every model (approval + market-lens seats) and
+// serves the Planning team on intent==="decompose".
+const callSeat = async ({ model, intent }) => {
+  if (intent === "decompose") return { tasks };
+  return {
+    packet: {
+      build_id: dossier.build_id, use_case: dossier.use_case, model, role: "approver",
+      docs_reviewed: [], proposal_ref: dossier.build_id, decision: "approve",
+      required_edits: [], hard_stops: [], confidence: "high", timestamp: "2026-06-28T00:00:00Z"
+    },
+    provenance: { model: `mock-${model}`, source: "run-teams-market-demo", response_id: `mock_${model}` }
+  };
+};
+
+// Mock build team: writes the node's declared files.
+const callTeam = async ({ team, node }) => ({
+  files: node.files.map((p) => ({ path: p, content: `// ${node.id} built by team ${team.id}\nexport const ${node.id.replace(/-/g, "_")} = true;\n` }))
+});
+
+const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-teams-market-"));
+const telosDir = path.join(baseDir, ".telos");
+mkdirSync(telosDir, { recursive: true });
+
+// Pre-build market-readiness evidence: the frontend "meets" breakout record is
+// re-verified against this file by the gate (truth-on-facts, not self-report).
+mkdirSync(path.join(baseDir, "market-evidence"), { recursive: true });
+writeFileSync(
+  path.join(baseDir, "market-evidence", "frontend-meets.md"),
+  `# Frontend LEXI-class evidence\nbuild_id: ${dossier.build_id}\nFirst-screen value proof present.\n`
+);
+
+const teams = planTeams(dossier);
+const { keyring, signerFor } = makeTeamKeyring(teams);
+
+const result = await buildProject({
+  dossier, telos: "Build the market-ready micro-app autonomously.", tasks: undefined,
+  callSeat, callTeam, marketPackets, keyring, signerFor, baseDir, telosDir,
+  // re-verify the breakout `meets` checks against the build workspace
+  source: { dossierDir: baseDir }, maxRepairRounds: 20
+});
+
+const ledger = result.phase === "build" ? readLedger(path.join(telosDir, "ledger.jsonl")) : [];
+
+// Which team owned each node (computed the same way the orchestrator routes).
+const routing = tasks.map((t) => ({ node: t.id, workstream: t.workstream, team: teamForNode(t, teams).id }));
+
+const summary = {
+  generated_for: dossier.build_id,
+  market_bound: true,
+  keyless: true,
+  phase: result.phase,
+  ok: result.ok,
+  merge_status: result.report ? result.report.merge_status : null,
+  teams_convened: teams.map((t) => t.id),
+  node_routing: routing,
+  distinct_teams_used: [...new Set(routing.map((r) => r.team))].sort(),
+  // plan_hash is intentionally omitted: it pins the per-run EPHEMERAL signer
+  // public keys, so it differs every run by design (keeps this evidence stable).
+  authorized_signers: result.plan ? Object.keys(result.plan.authorized_signers || {}).sort() : [],
+  settled_nodes: result.trace ? result.trace.filter((t) => t.action === "settled").map((t) => ({ id: t.id, signer: t.model })).sort((a, b) => (a.id < b.id ? -1 : 1)) : [],
+  ledger_records: ledger.map((r) => ({ task_id: r.task_id, signer: r.signer, alg: r.sig && r.sig.alg })).sort((a, b) => (a.task_id < b.task_id ? -1 : 1)),
+  market_packets_seen: marketPackets.map((p) => p.model).sort(),
+  council_pass: result.council ? result.council.blockers.length === 0 : false,
+  note: "Market-bound full fan-out. Deterministic mock seats; real gate (incl. market-readiness + breakout re-verify), real Ed25519 ledger, real merkle-dag. Throwaway temp workspace."
+};
+
+writeFileSync(path.join(here, "run-summary.json"), JSON.stringify(summary, null, 2) + "\n");
+console.log(JSON.stringify(summary, null, 2));
+console.log(`\nmerge_status=${summary.merge_status} phase=${summary.phase} ok=${summary.ok} teams=${summary.distinct_teams_used.join(",")}`);
+process.exit(summary.ok ? 0 : 1);

--- a/docs/runs/agentic-teams/run-summary.json
+++ b/docs/runs/agentic-teams/run-summary.json
@@ -9,7 +9,6 @@
     "architecture",
     "breakout"
   ],
-  "plan_hash": "sha256:0b78e6497f45cc8d673795540aac11c80c5bfd0899e2904bceac2f039c363ade",
   "authorized_signers": [
     "planning",
     "architecture",

--- a/docs/runs/agentic-teams/run-summary.json
+++ b/docs/runs/agentic-teams/run-summary.json
@@ -1,0 +1,42 @@
+{
+  "generated_for": "agentic-teams-demo",
+  "keyless": true,
+  "phase": "build",
+  "ok": true,
+  "merge_status": "ready",
+  "teams_convened": [
+    "planning",
+    "architecture",
+    "breakout"
+  ],
+  "plan_hash": "sha256:0b78e6497f45cc8d673795540aac11c80c5bfd0899e2904bceac2f039c363ade",
+  "authorized_signers": [
+    "planning",
+    "architecture",
+    "breakout"
+  ],
+  "settled_nodes": [
+    {
+      "id": "greet",
+      "signer": "architecture"
+    },
+    {
+      "id": "index",
+      "signer": "architecture"
+    }
+  ],
+  "ledger_records": [
+    {
+      "task_id": "greet",
+      "signer": "architecture",
+      "alg": "Ed25519"
+    },
+    {
+      "task_id": "index",
+      "signer": "architecture",
+      "alg": "Ed25519"
+    }
+  ],
+  "council_pass": true,
+  "note": "Deterministic mock seats; real Ed25519 ledger, real gate, real merkle-dag. Build workspace was a throwaway temp dir."
+}

--- a/docs/runs/agentic-teams/run-teams.mjs
+++ b/docs/runs/agentic-teams/run-teams.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// run-teams.mjs — a KEYLESS, reproducible end-to-end run of the autonomous
+// builder. It drives buildProject over the examples/agentic-teams fixture using
+// DETERMINISTIC mock seats (no API keys), with a REAL Ed25519 ledger + the real
+// gate + the real merkle-dag substrate. Writes a sanitized run-summary.json next
+// to this file as committable evidence. The build workspace is a throwaway temp
+// dir, so no .telos/ runtime artifacts land in the repo.
+//
+//   node docs/runs/agentic-teams/run-teams.mjs
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readLedger } from "../../../merkle-dag/crypto.mjs";
+import { buildProject, makeTeamKeyring } from "../../../build-gate/build-orchestrator.mjs";
+import { planTeams } from "../../../build-gate/teams.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const fixture = path.resolve(here, "../../../build-gate/examples/agentic-teams");
+const dossier = JSON.parse(readFileSync(path.join(fixture, "dossier.json"), "utf8"));
+const tasks = JSON.parse(readFileSync(path.join(fixture, "tasks.json"), "utf8"));
+
+// Mock council seat: every seat approves; also serves the Planning team on
+// intent==="decompose". A real run swaps this for liveSeatCaller + approvalPromptFor.
+const callSeat = async ({ model, intent }) => {
+  if (intent === "decompose") return { tasks };
+  return {
+    packet: {
+      build_id: dossier.build_id, use_case: dossier.use_case, model, role: "approver",
+      docs_reviewed: [], proposal_ref: dossier.build_id, decision: "approve",
+      required_edits: [], hard_stops: [], confidence: "high", timestamp: "2026-06-28T00:00:00Z"
+    },
+    provenance: { model: `mock-${model}`, source: "run-teams-demo", response_id: `mock_${model}` }
+  };
+};
+
+// Mock build team: writes the node's declared files. A real run swaps this for
+// makeLiveCallTeam({ client }) over ai-peer-mcp.
+const callTeam = async ({ team, node }) => ({
+  files: node.files.map((p) => ({ path: p, content: `// ${node.id} built by team ${team.id}\nexport const built = true;\n` }))
+});
+
+const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-teams-run-"));
+const telosDir = path.join(baseDir, ".telos");
+mkdirSync(telosDir, { recursive: true });
+
+const teams = planTeams(dossier);
+const { keyring, signerFor } = makeTeamKeyring(teams);
+
+const result = await buildProject({
+  dossier, telos: "Build the greeting library autonomously.", tasks: undefined,
+  callSeat, callTeam, keyring, signerFor, baseDir, telosDir, maxRepairRounds: 20
+});
+
+const ledger = result.phase === "build" ? readLedger(path.join(telosDir, "ledger.jsonl")) : [];
+
+// Sanitized, secret-free evidence (no private keys, no env).
+const summary = {
+  generated_for: dossier.build_id,
+  keyless: true,
+  phase: result.phase,
+  ok: result.ok,
+  merge_status: result.report ? result.report.merge_status : null,
+  teams_convened: teams.map((t) => t.id),
+  plan_hash: result.plan ? result.plan.plan_hash : null,
+  authorized_signers: result.plan ? Object.keys(result.plan.authorized_signers || {}) : [],
+  settled_nodes: result.trace ? result.trace.filter((t) => t.action === "settled").map((t) => ({ id: t.id, signer: t.model })) : [],
+  ledger_records: ledger.map((r) => ({ task_id: r.task_id, signer: r.signer, alg: r.sig && r.sig.alg })),
+  council_pass: result.council ? result.council.blockers.length === 0 : false,
+  note: "Deterministic mock seats; real Ed25519 ledger, real gate, real merkle-dag. Build workspace was a throwaway temp dir."
+};
+
+writeFileSync(path.join(here, "run-summary.json"), JSON.stringify(summary, null, 2) + "\n");
+console.log(JSON.stringify(summary, null, 2));
+console.log(`\nmerge_status=${summary.merge_status} phase=${summary.phase} ok=${summary.ok}`);
+process.exit(summary.ok ? 0 : 1);

--- a/docs/runs/agentic-teams/run-teams.mjs
+++ b/docs/runs/agentic-teams/run-teams.mjs
@@ -62,7 +62,8 @@ const summary = {
   ok: result.ok,
   merge_status: result.report ? result.report.merge_status : null,
   teams_convened: teams.map((t) => t.id),
-  plan_hash: result.plan ? result.plan.plan_hash : null,
+  // plan_hash is intentionally omitted: it pins the per-run EPHEMERAL signer
+  // public keys, so it differs every run by design (keeps this evidence stable).
   authorized_signers: result.plan ? Object.keys(result.plan.authorized_signers || {}) : [],
   settled_nodes: result.trace ? result.trace.filter((t) => t.action === "settled").map((t) => ({ id: t.id, signer: t.model })) : [],
   ledger_records: ledger.map((r) => ({ task_id: r.task_id, signer: r.signer, alg: r.sig && r.sig.alg })),

--- a/docs/specs/2026-06-28-agentic-teams-design.md
+++ b/docs/specs/2026-06-28-agentic-teams-design.md
@@ -76,9 +76,14 @@ Reused unchanged: `council.mjs`, `gate.mjs`, `sign.mjs`, all of `merkle-dag/`,
 
 ## Evidence
 
-`docs/runs/agentic-teams/run-teams.mjs` → `run-summary.json`: keyless reproducible
-run over the real gate + real Ed25519 ledger + real merkle-dag, reaching
-`merge_status: "ready"` with both nodes settled and signed.
+- `docs/runs/agentic-teams/run-teams.mjs` → `run-summary.json`: keyless non-market
+  run reaching `merge_status: "ready"` with both nodes settled and signed.
+- `docs/runs/agentic-teams-market/run-teams-market.mjs` → `run-summary.json`:
+  keyless **market-bound full fan-out** — nine teams convened, nodes routed to
+  distinct teams (backend/frontend/security/ops) each settling under its own
+  signer, market-readiness gate + frontend `meets` breakout re-verify passing,
+  reaching `merge_status: "ready"`. Covered hermetically by two cases in
+  `test-build-orchestrator.mjs` (full fan-out → ready; missing-workstream → blocked).
 
 ## Verification
 

--- a/docs/specs/2026-06-28-agentic-teams-design.md
+++ b/docs/specs/2026-06-28-agentic-teams-design.md
@@ -1,0 +1,90 @@
+---
+title: "Agentic Teams — Autonomous Builder (design)"
+author: claude-code
+date: 2026-06-28
+type: spec
+tags:
+  - topic/agentic-teams
+  - workflow/build-gate
+---
+
+# Agentic Teams — Autonomous Builder (design)
+
+## Problem
+
+TELOS had two halves that were never composed: the **approval council**
+(`build-gate/council.mjs` → `gate.mjs`) that only *approves*, and the **execution
+substrate** (`merkle-dag/`) that *executes* anonymous worker nodes. There was no
+notion of *who* builds, and no single pipeline from idea to merged software. Goal:
+an **autonomous builder** driven by **agentic teams**, without weakening any
+fail-closed guarantee.
+
+## Key insight
+
+A build/verify team **is** a `runBuild` worker. `merkle-dag/orchestrate.mjs`
+already injects `dispatch(injected)` where the worker sees only the node spec
+(Rule 1), and `defaultVerifyNode` independently re-derives the artifact tree-hash
+and runs the node test (Rule 3). So the teams layer is a thin **composition**
+module — not a new engine — and a team's self-report cannot satisfy the gate.
+
+## Modules added (all in `build-gate/`, zero new deps, ESM, `node:` stdlib only)
+
+- **`teams.mjs`** — `TEAMS` roster (data); `planTeams(dossier)` (dossier-sized,
+  mirrors `planSeats`); `teamForNode(node, teams)` (explicit-`workstream` routing);
+  `authorizedSignersFor(teams, keyring)` (pins team signers into `plan_hash`).
+- **`decompose.mjs`** — `decompose({dossier, telos, callSeat})`: the Planning team
+  proposes a normalized, validated `tasks[]`. Data only; fail-closed on empty /
+  duplicate / malformed.
+- **`build-orchestrator.mjs`** — `buildProject(...)` composes the two halves with
+  fail-closed sequencing (approval gate before execution); `makeTeamDispatch(...)`
+  routes by id and lets a team write its node's files (verify stays in
+  `verifyNode`); `makeTeamKeyring(teams)` mints per-signer Ed25519 keypairs.
+- **`teamPrompts.mjs`** — opt-in live wiring over `ai-peer-mcp`:
+  `approvalPromptFor` (council packets), `makeLiveCallTeam` (build execution),
+  plus pure prompt/parse helpers (`promptForTeam`, `nodeBuildPrompt`,
+  `parseTeamFiles`, `buildableSeat`).
+
+Reused unchanged: `council.mjs`, `gate.mjs`, `sign.mjs`, all of `merkle-dag/`,
+`breakout/verifier.mjs`.
+
+## Critical design decisions
+
+1. **Route by node id, not by reading the node.** Rule 1 strips `workstream` from
+   the dispatched spec and `compileAndHashPlan` drops it from the persisted node.
+   So `buildProject` precomputes `id → team` from the task list (which still
+   carries `workstream`) and `makeTeamDispatch` looks up by `injected.id`. This
+   preserves the spec-injection boundary.
+2. **Approval gate is on the build, before any plan is written or executed.**
+   `validateRecords(dossier, packets)` must pass first; a `revise`/`reject` leaves
+   no plan and no ledger.
+3. **Market-bound builds still demand market-readiness evidence.** `buildProject`
+   passes `marketPackets` straight to the gate, so the gate stays load-bearing for
+   market-bound jobs (no weakening to make teams "pass").
+4. **Open roster.** Seats are arbitrary model strings; a new seat/team is a `TEAMS`
+   row + a signer keypair + `TELOS_SECRET_*`.
+
+## Tests (all under `build-gate/scripts/`, registered in `package.json`)
+
+- `test-teams.mjs` — roster shape, dossier sizing, deterministic routing, signer
+  collection (fail-closed when a key is absent).
+- `test-decompose.mjs` — extraction/normalization, invalid/empty/duplicate fail-closed.
+- `test-build-orchestrator.mjs` — keyless end-to-end to `merge_status:"ready"`;
+  approval `revise` blocks before execution (no plan/ledger); autonomous decompose
+  path; Rule-3 verify is load-bearing (failing node never settles); dispatch path-
+  escape rejection; respec passthrough.
+- `test-team-prompts.mjs` — pure live-wiring helpers + fake-client `callTeam` round-trip.
+
+## Evidence
+
+`docs/runs/agentic-teams/run-teams.mjs` → `run-summary.json`: keyless reproducible
+run over the real gate + real Ed25519 ledger + real merkle-dag, reaching
+`merge_status: "ready"` with both nodes settled and signed.
+
+## Verification
+
+```
+cd build-gate && npm test     # gate, sign, trust, council, teams, decompose,
+                              # build-orchestrator, team-prompts, stress×2, + breakout
+cd merkle-dag && npm test     # unchanged substrate still green
+node docs/runs/agentic-teams/run-teams.mjs   # end-to-end evidence -> ready
+```


### PR DESCRIPTION
## What & why

TELOS had two halves that were never composed: the **approval council** (`build-gate/council.mjs` → `gate.mjs`) that only *approves*, and the **merkle-dag substrate** that *executes* anonymous worker nodes. There was no notion of *who* builds, and no single pipeline from idea to merged software.

This PR adds an **agentic-teams** layer that composes both into an **autonomous builder** — without weakening any fail-closed guarantee. The key insight: a build/verify team **is** a `runBuild` worker behind `dispatch` (Rule 1: it sees only the node spec) whose output is independently re-derived by `defaultVerifyNode` (Rule 3). So the teams layer is a thin *composition* module, not a new engine, and a team's self-report can never satisfy the gate.

## The lifecycle (fail-closed sequencing)

```
idea + telos
  → [planning] decompose() → tasks[]
  → compileAndHashPlan() → content-addressed plan; writePlan()
  → COUNCIL APPROVAL GATE: runCouncil → validateRecords   [MUST pass before execution]
  → runBuild(): each node dispatched to its owning team (team = worker)
  → Rule-3 defaultVerifyNode re-derives the artifact hash + runs node.test
  → settle: controller (sole writer) signs the Ed25519 ledger
  → ledger-gate.verify() done() → merge_status:"ready"
```

## Added (`build-gate/`, zero new deps, ESM, `node:` stdlib only)

- **`teams.mjs`** — `TEAMS` roster (data); `planTeams(dossier)` (dossier-sized, mirrors `planSeats`); `teamForNode` (explicit-`workstream` routing); `authorizedSignersFor` (pins team signers into `plan_hash`).
- **`decompose.mjs`** — the Planning team proposes a validated `tasks[]` (data only; fail-closed on empty/duplicate/malformed).
- **`build-orchestrator.mjs`** — `buildProject(...)` composes the pipeline above (approval gate before execution; routes by node id since Rule 1 strips `workstream`); `makeTeamDispatch`, `makeTeamKeyring`.
- **`teamPrompts.mjs`** — opt-in live wiring over `ai-peer-mcp` (`approvalPromptFor`, `makeLiveCallTeam`, pure prompt/parse helpers).

Reused unchanged: `council.mjs`, `gate.mjs`, `sign.mjs`, all of `merkle-dag/`, `breakout/verifier.mjs`.

## Trust preserved (no new surface)

- Routing is by node **id**, not by reading the node (Rule 1 boundary intact).
- Verification stays in `verifyNode` — a node that writes nothing, or fails its test, never settles.
- The controller is the sole ledger writer; a team's `signer` key_id must be in `plan.authorized_signers`.
- Teams may only write their node's declared files, under `baseDir` (path escapes rejected).
- A fabricated decomposition is re-hashed and must still pass the gate + Rule-3 verify.
- Market-bound builds still demand market-readiness packets (passed through to the gate).

## Tests (all green)

`test-teams`, `test-decompose`, `test-build-orchestrator` (keyless end-to-end to `merge_status:"ready"`; approval `revise` blocks before execution with no plan/ledger; Rule-3 verify load-bearing), `test-team-prompts`. All registered in `package.json`.

- `cd build-gate && npm test` → exit 0 (gate, sign, trust, council, **teams, decompose, build-orchestrator, team-prompts**, stress×2, + breakout)
- `cd merkle-dag && npm test` → exit 0 (substrate unchanged)
- `node docs/runs/agentic-teams/run-teams.mjs` → `merge_status: "ready"` (keyless, reproducible; real gate + real Ed25519 ledger + real merkle-dag)

## Docs & evidence

- `contracts/Agentic Teams Autonomous Builder.md` (protocol)
- `docs/specs/2026-06-28-agentic-teams-design.md` (design)
- `docs/runs/agentic-teams/` (runnable evidence + sanitized `run-summary.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcL28Z3rdYsTdCQiLAoBdu)_