### PR TITLE
feat(ai-forge): check CLI + generators

### DIFF
--- a/ai-forge/checks/check-node.mjs
+++ b/ai-forge/checks/check-node.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// check-node.mjs — generic deterministic node test. Re-verifies a list of file
+// specs (passed as a JSON arg) against the project root (cwd), reusing the
+// breakout verifier so build-time verification and the team breakout run on ONE
+// engine. Exits non-zero on any failing/zero check so the node never settles.
+
+import { reverifyRecord } from "../../breakout/verifier.mjs";
+
+let specs;
+try {
+  specs = JSON.parse(process.argv[2] || "[]");
+} catch (e) {
+  console.error("check-node: bad specs arg: " + (e?.message || e));
+  process.exit(2);
+}
+
+const result = reverifyRecord({ checks: specs }, process.cwd());
+if (result.reverifiable === 0) {
+  console.error("check-node: no re-verifiable checks");
+  process.exit(1);
+}
+if (!result.allPass) {
+  for (const f of result.failing) console.error("check-node FAIL: " + (f.detail || f.description || f.id));
+  process.exit(1);
+}
+console.log(`check-node: OK (${result.reverifiable} checks verified on disk)`);

--- a/ai-forge/generators.mjs
+++ b/ai-forge/generators.mjs
@@ -1,0 +1,48 @@
+// generator.mjs — the GENERATOR LAYER wired into merkle-dag's dispatch.
+//
+// runBuild calls dispatch(injected) per ready node, where injected is ONLY the
+// node spec { id, requirements, files, test, effective_hash } (Rule 1). A
+// generator dispatch turns that spec into real files and returns the signer;
+// runBuild then runs the node's test (verifyNode) and only settles a signed
+// ledger entry if it passes. The seat never declares "done" — the test does.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { resolveUnder } from "../merkle-dag/vendor.mjs";
+import { workstreamById } from "./pattern.mjs";
+
+async function writeUnder(baseDir, rel, content) {
+  const abs = resolveUnder(baseDir, rel);
+  if (abs === null) throw new Error(`refusing to write outside project root: ${rel}`);
+  await mkdir(path.dirname(abs), { recursive: true });
+  await writeFile(abs, content);
+}
+
+// Wrap a `generateFiles(injected) -> { rel: content }` producer as a dispatch.
+// Live: generateFiles calls a model seat through ai-peer-mcp. Tests: the
+// deterministic team renderers (makePatternGenerators) so the loop runs keyless.
+export function generatorDispatch({ baseDir, generateFiles, signerForTask }) {
+  return async (injected) => {
+    let files;
+    try {
+      files = await generateFiles(injected);
+    } catch (e) {
+      return { ok: false, reason: `${injected.id}: generator threw: ${e?.message || String(e)}` };
+    }
+    if (!files || typeof files !== "object") {
+      return { ok: false, reason: `${injected.id}: generator produced no files` };
+    }
+    for (const rel of injected.files) {
+      if (!(rel in files)) return { ok: false, reason: `${injected.id}: missing required file ${rel}` };
+      await writeUnder(baseDir, rel, files[rel]);
+    }
+    return { ok: true, signer: signerForTask(injected.id) };
+  };
+}
+
+// Pattern-based generators: render workstreams from the pattern registry.
+// Stand-in for live model-seat generation — same dispatch contract, no API keys,
+// so research -> generate -> verify -> gate runs in tests and CI.
+export function makePatternGenerators(pattern, ctx) {
+  return async (injected) => workstreamById(pattern, injected.id).render(ctx);
+}

--- a/ai-forge/package.json
+++ b/ai-forge/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "TELOS ai-forge: a pattern-library-driven forge for AI architectures. Phase A: library substrate + a production-shaped RAG pattern, driven to merge_status:ready over the real gate + Ed25519 ledger + merkle-dag.",
   "scripts": {
-    "check": "node --check pattern.mjs && node --check scripts/test-pattern.mjs",
-    "test": "npm run check && node scripts/test-pattern.mjs"
+    "check": "node --check pattern.mjs && node --check generators.mjs && node --check checks/check-node.mjs && node --check scripts/test-pattern.mjs && node --check scripts/test-generators.mjs",
+    "test": "npm run check && node scripts/test-pattern.mjs && node scripts/test-generators.mjs"
   },
   "engines": { "node": ">=18" }
 }

--- a/ai-forge/scripts/test-generators.mjs
+++ b/ai-forge/scripts/test-generators.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { generatorDispatch, makePatternGenerators } from "../generators.mjs";
+
+const CHECK_NODE = fileURLToPath(new URL("../checks/check-node.mjs", import.meta.url));
+const dir = mkdtempSync(path.join(os.tmpdir(), "aiforge-gen-"));
+
+// generator writes the workstream's files; dispatch returns the signer
+{
+  const pattern = { id: "p", workstreams: [{
+    id: "w1", signer: "codex", lens: "codex", files: ["sub/a.txt"],
+    requirements: "r", render: () => ({ "sub/a.txt": "hello #facts" }),
+    checks: () => [{ type: "file_contains", path: "sub/a.txt", needle: "#facts" }],
+    findingsKey: "k", finding: "f"
+  }] };
+  const dispatch = generatorDispatch({
+    baseDir: dir,
+    generateFiles: makePatternGenerators(pattern, { telos: "t" }),
+    signerForTask: (id) => (id === "w1" ? "codex" : "claude")
+  });
+  const out = await dispatch({ id: "w1", files: ["sub/a.txt"], requirements: "r", test: {}, effective_hash: "x" });
+  assert.equal(out.ok, true);
+  assert.equal(out.signer, "codex");
+  assert.ok(existsSync(path.join(dir, "sub/a.txt")));
+  assert.match(readFileSync(path.join(dir, "sub/a.txt"), "utf8"), /#facts/);
+}
+
+// check-node CLI: passes when checks hold, non-zero when they don't
+{
+  const ok = [{ type: "file_contains", path: "sub/a.txt", needle: "#facts" }];
+  execFileSync("node", [CHECK_NODE, JSON.stringify(ok)], { cwd: dir }); // throws on non-zero
+  let failed = false;
+  try { execFileSync("node", [CHECK_NODE, JSON.stringify([{ type: "file_contains", path: "sub/a.txt", needle: "ABSENT" }])], { cwd: dir, stdio: "ignore" }); }
+  catch { failed = true; }
+  assert.equal(failed, true, "check-node must exit non-zero on a failing check");
+}
+console.log("test-generators.mjs OK");


### PR DESCRIPTION
Task 3. check-node.mjs + generatorDispatch copied verbatim from saas-forge (human-approved duplication); makePatternGenerators added. Reviewed: spec ✅, quality ✅.