### PR TITLE
feat(ai-forge): makeDesignWorkstream factory + DESIGN.md render

### DIFF
--- a/ai-forge/package.json
+++ b/ai-forge/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "TELOS ai-forge: a pattern-library-driven forge for AI architectures. Phase A: library substrate + a production-shaped RAG pattern, driven to merge_status:ready over the real gate + Ed25519 ledger + merkle-dag.",
   "scripts": {
-    "check": "node --check pattern.mjs && node --check generators.mjs && node --check breakouts.mjs && node --check forge.mjs && node --check patterns/rag.mjs && node --check checks/check-node.mjs && node --check scripts/test-pattern.mjs && node --check scripts/test-generators.mjs && node --check scripts/test-breakouts.mjs && node --check scripts/test-forge.mjs && node --check live.mjs && node --check scripts/test-live.mjs && node --check workstreams/design-verify.mjs && node --check scripts/test-design-verify.mjs",
-    "test": "npm run check && node scripts/test-pattern.mjs && node scripts/test-generators.mjs && node scripts/test-breakouts.mjs && node scripts/test-forge.mjs && node scripts/test-live.mjs && node scripts/test-design-verify.mjs"
+    "check": "node --check pattern.mjs && node --check generators.mjs && node --check breakouts.mjs && node --check forge.mjs && node --check patterns/rag.mjs && node --check checks/check-node.mjs && node --check scripts/test-pattern.mjs && node --check scripts/test-generators.mjs && node --check scripts/test-breakouts.mjs && node --check scripts/test-forge.mjs && node --check live.mjs && node --check scripts/test-live.mjs && node --check workstreams/design-verify.mjs && node --check scripts/test-design-verify.mjs && node --check workstreams/design.mjs && node --check scripts/test-design.mjs",
+    "test": "npm run check && node scripts/test-pattern.mjs && node scripts/test-generators.mjs && node scripts/test-breakouts.mjs && node scripts/test-forge.mjs && node scripts/test-live.mjs && node scripts/test-design-verify.mjs && node scripts/test-design.mjs"
   },
   "engines": { "node": ">=18" }
 }

--- a/ai-forge/scripts/test-design.mjs
+++ b/ai-forge/scripts/test-design.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { makeDesignWorkstream } from "../workstreams/design.mjs";
+import { validatePattern } from "../pattern.mjs";
+
+const build = [
+  { id: "alpha", signer: "codex", lens: "codex", dependencies: [], files: ["a/alpha.txt"], requirements: "r", render: () => ({}), checks: () => [], findingsKey: "k", finding: "f" },
+  { id: "beta", signer: "claude", lens: "claude", dependencies: ["alpha"], files: ["b/beta.txt"], requirements: "r", render: () => ({}), checks: () => [], findingsKey: "k", finding: "f" }
+];
+const ws = makeDesignWorkstream(build);
+
+// shape: a valid pattern workstream, design id, claude author, depends on all build ids
+assert.equal(ws.id, "design");
+assert.equal(ws.signer, "claude");
+assert.deepEqual([...ws.dependencies].sort(), ["alpha", "beta"]);
+assert.deepEqual(ws.files, ["docs/DESIGN.md", "docs/design/verify.mjs"]);
+assert.ok(typeof ws.findingsKey === "string" && typeof ws.finding === "string");
+assert.deepEqual(ws.nodeTest, { cmd: "node", args: ["docs/design/verify.mjs"] });
+assert.equal(validatePattern({ id: "p", workstreams: [...build, ws] }).ok, true);
+
+// render: DESIGN.md has a component block matching the build workstreams + mermaid + 5 sections; verify.mjs written
+const out = ws.render({});
+assert.ok(out["docs/DESIGN.md"], "writes DESIGN.md");
+assert.ok(out["docs/design/verify.mjs"] && out["docs/design/verify.mjs"].includes("DESIGN_DRIFT"), "writes the real verify.mjs");
+const md = out["docs/DESIGN.md"];
+const block = JSON.parse(md.match(/```json\s*([\s\S]*?)```/)[1]);
+assert.deepEqual(block.map((c) => c.workstream).sort(), ["alpha", "beta"]);
+assert.equal(block.find((c) => c.workstream === "beta").model, "claude");
+assert.deepEqual(block.find((c) => c.workstream === "beta").depends_on, ["alpha"]);
+assert.equal(block.find((c) => c.workstream === "alpha").artifact, "a/alpha.txt");
+assert.ok(md.includes("```mermaid"), "includes a mermaid diagram");
+for (const h of ["Component boundaries", "Data flow", "Model/infra choices", "Eval plan", "Risks"]) assert.ok(new RegExp("#+\\s*" + h).test(md), "section " + h);
+
+// surface checks include existence + the 5 section headers
+const checks = ws.checks({});
+assert.ok(checks.some((c) => c.type === "file_exists" && c.path === "docs/DESIGN.md"));
+assert.ok(checks.some((c) => c.type === "file_exists" && c.path === "docs/design/verify.mjs"));
+assert.equal(checks.filter((c) => c.type === "file_contains").length, 5);
+
+console.log("test-design.mjs OK");

--- a/ai-forge/workstreams/design.mjs
+++ b/ai-forge/workstreams/design.mjs
@@ -1,0 +1,57 @@
+// design.mjs — a generic, pattern-agnostic `design` workstream. Authors
+// docs/DESIGN.md (a structured component block + mermaid + 5 narrative sections)
+// derived from the build workstreams, and writes the canonical verifier to
+// docs/design/verify.mjs. The deep design<->plan<->build gate is that verifier
+// (the workstream's nodeTest); checks(ctx) are the surface checks for the breakout.
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const VERIFY_SRC = readFileSync(fileURLToPath(new URL("./design-verify.mjs", import.meta.url)), "utf8");
+const SECTIONS = ["Component boundaries", "Data flow", "Model/infra choices", "Eval plan", "Risks"];
+
+export function makeDesignWorkstream(buildWorkstreams) {
+  const components = buildWorkstreams.map((w) => ({
+    workstream: w.id,
+    model: w.signer,
+    artifact: w.files[0],
+    depends_on: [...(w.dependencies || [])]
+  }));
+
+  function render() {
+    const block = "```json\n" + JSON.stringify(components, null, 2) + "\n```";
+    const edges = components.flatMap((c) => c.depends_on.map((d) => `  ${d} --> ${c.workstream}`));
+    const mermaid = "```mermaid\nflowchart TD\n" + (edges.length ? edges.join("\n") : components.map((c) => `  ${c.workstream}`).join("\n")) + "\n```";
+    const bodies = {
+      "Component boundaries": components.map((c) => `- **${c.workstream}** (${c.model}) owns \`${c.artifact}\`.`).join("\n"),
+      "Data flow": "Build order follows the dependency DAG:\n\n" + mermaid,
+      "Model/infra choices": components.map((c) => `- ${c.workstream}: authored by **${c.model}**.`).join("\n"),
+      "Eval plan": "Each component's node test gates its artifact on disk (Rule 3); this design is itself gated by `docs/design/verify.mjs` against the plan, ledger, and built tree.",
+      "Risks": "Drift between design and build is caught fail-closed by `verify.mjs`; a missing/phantom component, wrong edge, wrong model, or unrealized artifact blocks the run."
+    };
+    let md = "# Architecture Design\n\n" + block + "\n";
+    for (const h of SECTIONS) md += `\n## ${h}\n\n${bodies[h]}\n`;
+    return { "docs/DESIGN.md": md, "docs/design/verify.mjs": VERIFY_SRC };
+  }
+
+  function checks() {
+    return [
+      { type: "file_exists", path: "docs/DESIGN.md" },
+      { type: "file_exists", path: "docs/design/verify.mjs" },
+      ...SECTIONS.map((h) => ({ type: "file_contains", path: "docs/DESIGN.md", needle: h }))
+    ];
+  }
+
+  return {
+    id: "design",
+    signer: "claude",
+    lens: "claude",
+    dependencies: buildWorkstreams.map((w) => w.id),
+    files: ["docs/DESIGN.md", "docs/design/verify.mjs"],
+    requirements: "Author the architecture design and verify it against the plan, ledger, and built artifacts.",
+    render,
+    checks,
+    nodeTest: { cmd: "node", args: ["docs/design/verify.mjs"] },
+    findingsKey: "design_findings",
+    finding: "Design is consistent with the content-addressed plan, signed ledger, and built artifacts."
+  };
+}

--- a/ai-forge/workstreams/design.mjs
+++ b/ai-forge/workstreams/design.mjs
@@ -6,7 +6,6 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-const VERIFY_SRC = readFileSync(fileURLToPath(new URL("./design-verify.mjs", import.meta.url)), "utf8");
 const SECTIONS = ["Component boundaries", "Data flow", "Model/infra choices", "Eval plan", "Risks"];
 
 export function makeDesignWorkstream(buildWorkstreams) {
@@ -18,6 +17,7 @@ export function makeDesignWorkstream(buildWorkstreams) {
   }));
 
   function render() {
+    const verifySrc = readFileSync(fileURLToPath(new URL("./design-verify.mjs", import.meta.url)), "utf8");
     const block = "```json\n" + JSON.stringify(components, null, 2) + "\n```";
     const edges = components.flatMap((c) => c.depends_on.map((d) => `  ${d} --> ${c.workstream}`));
     const mermaid = "```mermaid\nflowchart TD\n" + (edges.length ? edges.join("\n") : components.map((c) => `  ${c.workstream}`).join("\n")) + "\n```";
@@ -30,7 +30,7 @@ export function makeDesignWorkstream(buildWorkstreams) {
     };
     let md = "# Architecture Design\n\n" + block + "\n";
     for (const h of SECTIONS) md += `\n## ${h}\n\n${bodies[h]}\n`;
-    return { "docs/DESIGN.md": md, "docs/design/verify.mjs": VERIFY_SRC };
+    return { "docs/DESIGN.md": md, "docs/design/verify.mjs": verifySrc };
   }
 
   function checks() {


### PR DESCRIPTION
Phase B Task 2. makeDesignWorkstream(buildWorkstreams) authors DESIGN.md (component block + mermaid + 5 ## sections) and writes the verbatim design-verify.mjs; checks(ctx) surface; nodeTest=verify.mjs. Reviewed: spec ✅ ACCEPT; 1 Important (module-load read) fixed in fe13f38; 2 minors deferred.