### PR TITLE
docs(ai-forge): TELOS-pattern run evidence + Phase C close-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ Phase A is complete: `forge({ pattern: ragPattern, ctx: ragContext(), ... })` re
 Phase B is complete: every forge run now also emits a gate-verified `DESIGN.md` via a
 generic `design` workstream — the architecture design is a first-class, fail-closed
 artifact checked against the plan + ledger + built tree (8 workstreams total; all converge).
+Phase C is complete: the catalog now includes the self-similar **TELOS pattern** — ai-forge
+forges a TELOS-like trust system (7 spine-wrapping components + design; 8 workstreams converge;
+see `docs/runs/ai-forge-telos/`).
 
 ## SaaS Forge (`saas-forge/`)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -57,7 +57,7 @@ Each phase is an independent spec → plan → build cycle. Build order A → B 
 - **Depends on:** A (the plan stage may already emit a partial design — B makes it
   first-class and independently checkable).
 
-### Phase C — Library breadth (the TELOS pattern)  🟡 in progress
+### Phase C — Library breadth (the TELOS pattern)  ✅ done
 - **Objective:** grow the catalog; each pattern is mostly **data + fact-checks**.
 - **This phase = the TELOS pattern** (self-similar / meta — the original "TELOS-style
   systems" ask): ai-forge forges a working TELOS-like trust system — 7 forged
@@ -74,16 +74,18 @@ Each phase is an independent spec → plan → build cycle. Build order A → B 
 | --- | --- | --- | --- | --- | --- |
 | A — substrate + RAG | ✅ done | [phase-a-design](specs/2026-06-29-ai-forge-phase-a-design.md) | — | [ai-forge-rag](runs/ai-forge-rag/) | all 7 workstreams converged; PRs #21–28 |
 | B — design stage | ✅ done | [phase-b-design](specs/2026-06-29-ai-forge-phase-b-design.md) | — | [ai-forge-rag](runs/ai-forge-rag/) | design workstream → DESIGN.md verified vs plan+ledger+build; PRs #33–35 |
-| C — TELOS pattern | 🟡 in progress | [phase-c-design](specs/2026-06-29-ai-forge-phase-c-design.md) | — | — | spec written + approved; next: `writing-plans` |
+| C — TELOS pattern | ✅ done | [phase-c-design](specs/2026-06-29-ai-forge-phase-c-design.md) | — | [ai-forge-telos](runs/ai-forge-telos/) | 8 workstreams converge (7 spine-wrapping + design); PRs #38–43 |
 
 Legend: ⬜ not started · 🟡 in progress · ✅ done
 
 ## Next action
 
-**Phase C spec is written + approved** (`docs/specs/2026-06-29-ai-forge-phase-c-design.md`):
-the TELOS pattern — ai-forge forges a TELOS-like trust system (7 spine-wrapping
-components + the generic design workstream, each with a genuine executable check).
-After user review → `superpowers:writing-plans` → build.
+**Phase C is complete.** The TELOS pattern (`ai-forge/patterns/telos.mjs`) converges:
+8 workstreams (7 spine-wrapping components + design), all adversarial breakouts pass,
+gate certifies `merge_status: ready`. Run evidence at `docs/runs/ai-forge-telos/`.
+
+Future work (deferred to Phase C.2+): multi-agent pattern, eval-harness pattern,
+serving+guardrails pattern, composable-workstream-library generalization (issues #30/#37).
 
 ## Decisions log
 
@@ -101,6 +103,10 @@ After user review → `superpowers:writing-plans` → build.
 - **2026-06-29 — Phase B built.** Design workstream → `DESIGN.md` verified vs
   plan + ledger + built tree; RAG pattern now has 8 workstreams (7 build + design),
   all converged; PRs #33–35.
+- **2026-06-29 — Phase C built.** The TELOS pattern → ai-forge forges a TELOS-like
+  trust system; 8 workstreams converge (7 spine-wrapping components: sign · plan ·
+  provenance · gate · council · ledger · breakout + the generic design workstream);
+  PRs #38–43.
 
 ## Out of scope (YAGNI — revisit only if needed)
 

--- a/docs/runs/ai-forge-telos/README.md
+++ b/docs/runs/ai-forge-telos/README.md
@@ -1,0 +1,59 @@
+# ai-forge — TELOS pattern run evidence
+
+**What this run proves:** ai-forge (itself built on the TELOS trust spine) forges a
+working TELOS-like trust system — the self-similar capstone of the ai-forge catalog.
+
+## What converged
+
+8 workstreams, all `converged: true`, `finalStatus: meets`:
+
+| Workstream | What the forge generates | Selftest asserts |
+| --- | --- | --- |
+| `sign` | `telos/sign.mjs` wrapping `build-gate/sign.mjs` | HMAC roundtrip verifies; tamper fails |
+| `plan` | `telos/plan.mjs` wrapping `merkle-dag/merkle.mjs` | plan_hash deterministic; downstream effective_hash cascades |
+| `provenance` | `telos/provenance.mjs` wrapping `connectors/ai-peer-mcp/lib.mjs` | content-addressed attestation id; missing id → null (fail-closed) |
+| `gate` | `telos/gate.mjs` wrapping `build-gate/gate.mjs` | unanimous council → pass; a reject → blocked |
+| `council` | `telos/council.mjs` wrapping `build-gate/council.mjs` | fan-out produces ordered, signed, verifiable packets |
+| `ledger` | `telos/ledger.mjs` wrapping `merkle-dag/{crypto,merkle,artifact,ledger-gate}.mjs` | settled ledger verifies done(); tampered artifact blocked |
+| `breakout` | `telos/verify.mjs` wrapping `breakout/verifier.mjs` | present evidence → meets; absent evidence → blocked |
+| `design` | `DESIGN.md` (generic design workstream) | design doc verified against plan + ledger + built tree |
+
+## How to reproduce
+
+```bash
+node docs/runs/ai-forge-telos/run.mjs
+# → converged=true merge_status=ready gate_status=pass
+```
+
+No network, no secrets, no timestamps. Keyless and deterministic — the same result
+every run.
+
+## Why this is the self-similar capstone
+
+- ai-forge is itself built on the TELOS trust spine (plan → council gate → build →
+  verify → signed Ed25519 ledger → done()).
+- The TELOS pattern it forges wraps that same spine's real modules — `build-gate/`,
+  `merkle-dag/`, `breakout/`, `connectors/ai-peer-mcp/` — via a ctx-injected
+  `spineRoot`. Each component has a genuine executable selftest that runs the real
+  spine code, not a stub.
+- The forge then puts all 8 workstreams through the full gate pipeline: merkle-dag
+  plan → adversarial breakout-on-facts → market gate. The self-similar loop closes:
+  ai-forge forges a trust system that is structurally identical to the forge that
+  forged it.
+
+## Key properties
+
+- **Fail-closed gates are real:** each selftest has a fail sub-case (tamper / reject /
+  absent evidence) that confirms the gate blocks, not just passes.
+- **Fixture isolation:** the ledger selftest always writes to `os.tmpdir()`, never
+  the forge's in-progress `.telos/` directory, avoiding cross-contamination.
+- **Sanitized evidence:** `run-summary.json` contains no `file://` URLs, no absolute
+  paths (especially not `spineRoot`), no secrets, no timestamps — deterministic and
+  safe to commit.
+- **Zero new dependencies:** pure Node ≥ 18 ESM; all spine modules are already in
+  the repo.
+
+## Run summary
+
+See [`run-summary.json`](run-summary.json) for the committed, sanitized output
+(`converged: true`, `gate_status: "pass"`, 8 workstreams).

--- a/docs/runs/ai-forge-telos/run-summary.json
+++ b/docs/runs/ai-forge-telos/run-summary.json
@@ -1,0 +1,48 @@
+{
+  "converged": true,
+  "merge_status": "ready",
+  "gate_status": "pass",
+  "workstreams": [
+    {
+      "id": "sign",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "plan",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "provenance",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "gate",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "council",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "ledger",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "breakout",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "design",
+      "converged": true,
+      "finalStatus": "meets"
+    }
+  ],
+  "generated_at_note": "deterministic; no timestamps"
+}

--- a/docs/runs/ai-forge-telos/run.mjs
+++ b/docs/runs/ai-forge-telos/run.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// run.mjs — a KEYLESS, reproducible end-to-end evidence run of the ai-forge
+// TELOS pattern: pattern validation -> plan -> generate -> verify ->
+// per-workstream breakout (verdict-on-facts) -> market gate.
+//
+// 7 spine-wrapping components (sign · plan · provenance · gate · council ·
+// ledger · breakout) each with a genuine executable selftest, plus the generic
+// design workstream (8 workstreams total). ai-forge forges a TELOS-like trust
+// system — the self-similar capstone of the catalog.
+//
+// Real gate (validateRecords), real Ed25519 ledger, real merkle-dag.
+// No network, no secrets, no timestamps — deterministic and CI-safe.
+//
+//   node docs/runs/ai-forge-telos/run.mjs
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { forge } from "../../../ai-forge/forge.mjs";
+import { telosPattern, telosContext } from "../../../ai-forge/patterns/telos.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// Throwaway temp workspace: no absolute paths committed.
+const projectRoot = mkdtempSync(path.join(os.tmpdir(), "telos-ai-forge-telos-"));
+mkdirSync(path.join(projectRoot, ".telos"), { recursive: true });
+
+const dossierMeta = {
+  build_id: "ai-forge-telos-evidence",
+  idea_id:  "ai-forge-telos-evidence",
+  use_case: "AI architecture: TELOS pattern evidence run",
+  objective: "Prove the TELOS pattern converges over the real gate + Ed25519 ledger + merkle-dag."
+};
+
+const ctx = telosContext();
+
+const result = await forge({
+  pattern:     telosPattern,
+  ctx,
+  projectRoot,
+  dossierMeta
+});
+
+// Sanitized summary — no absolute paths, no machine-specific data, no timestamps.
+// CRITICAL: strip any field that could carry spineRoot (an absolute file:// URL)
+// or the temp projectRoot. Only scalar convergence data + workstream ids survive.
+const summary = {
+  converged:    result.converged,
+  merge_status: result.converged ? "ready" : "not-ready",
+  gate_status:  result.verdict   ? result.verdict.gate_status : "not-run",
+  workstreams:  (result.records || []).map((r) => ({
+    id:          r.workstream,
+    converged:   r.converged,
+    finalStatus: r.finalStatus
+  })),
+  generated_at_note: "deterministic; no timestamps"
+};
+
+// Verify sanitization: ensure no absolute paths snuck through.
+const raw = JSON.stringify(summary);
+if (raw.includes("file://") || /[A-Za-z]:[\\/]/.test(raw) || raw.includes("/home/") || raw.includes("/Users/")) {
+  throw new Error("SANITIZATION FAILURE: absolute path detected in summary — do not commit.");
+}
+
+writeFileSync(path.join(here, "run-summary.json"), JSON.stringify(summary, null, 2) + "\n");
+console.log(JSON.stringify(summary, null, 2));
+console.log(`\nconverged=${summary.converged} merge_status=${summary.merge_status} gate_status=${summary.gate_status}`);
+process.exit(result.converged ? 0 : 1);


### PR DESCRIPTION
Phase C Task 5 (final build task) — committed run evidence + roadmap/README close-out.

## What
- `docs/runs/ai-forge-telos/{run.mjs,run-summary.json,README.md}` — forges the TELOS pattern into an `os.tmpdir()` root; **sanitized** summary (8 workstreams all `meets`, `merge_status: ready`, gate pass; no `file://`, no absolute path, no timestamps).
- `docs/ROADMAP.md` — Phase C → ✅ done; status row → run link; decisions-log line; "Next action" updated.
- `README.md` — AI Forge section notes the self-similar TELOS pattern.

## Verification
- `node docs/runs/ai-forge-telos/run.mjs` → `converged:true`, 8 workstreams. Sanitization grep: zero `file://`/abs-path matches. `cd ai-forge && npm test` exit 0.
- No spine/saas-forge/RAG/forge edits — docs + evidence only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)