### PR TITLE
fix(ai-forge): breakout selftest wraps reverifyRecord (spec fidelity)

### DIFF
--- a/ai-forge/patterns/telos.mjs
+++ b/ai-forge/patterns/telos.mjs
@@ -163,13 +163,16 @@ function breakoutSelftest(spineRoot) {
 import { mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { buildCheck } from "${spineRoot}breakout/verifier.mjs";
+import { reverifyRecord } from "${spineRoot}breakout/verifier.mjs";
 const dir = mkdtempSync(path.join(os.tmpdir(), "telos-verify-"));
 writeFileSync(path.join(dir, "evidence.txt"), "proof");
-const present = await buildCheck({ type: "file_exists", path: "evidence.txt" }, dir).run();
-assert.equal(present.ok, true, "present evidence -> meets");
-const absent = await buildCheck({ type: "file_exists", path: "NOPE.txt" }, dir).run();
-assert.equal(absent.ok, false, "absent evidence -> blocked");
+// Verdict-on-facts: rebuild a record's declarative checks against disk, confined to dir.
+const present = reverifyRecord({ checks: [{ type: "file_exists", path: "evidence.txt" }] }, dir);
+assert.equal(present.reverifiable, 1, "present evidence -> re-verifiable");
+assert.equal(present.allPass, true, "present evidence -> meets");
+const absent = reverifyRecord({ checks: [{ type: "file_exists", path: "NOPE.txt" }] }, dir);
+assert.equal(absent.allPass, false, "absent evidence -> blocked");
+assert.equal(absent.failing.length, 1, "absent evidence -> one failing fact");
 console.log("telos/verify selftest OK");
 `;
 }


### PR DESCRIPTION
Phase C final-review follow-up. The approved spec names `reverifyRecord` as the export the TELOS `breakout` component wraps; the merged implementation wrapped `buildCheck`. Per the user's call (exact spec fidelity), the selftest now wraps `reverifyRecord`.

## What
- `patterns/telos.mjs` breakout selftest: build a record's declarative `checks` and `reverifyRecord(record, dir)` against disk confined to a tmpdir — present evidence → `allPass:true`/`reverifiable:1`; absent → `allPass:false` with one failing fact. Verdict-on-facts, genuinely executable.

## Verification
- `node ai-forge/scripts/test-telos.mjs` → OK; `node ai-forge/scripts/test-telos-forge.mjs` → OK (e2e still converges, gate re-runs the breakout node test); full `npm test` exit 0.
- Single-file change; fixture isolation (os.tmpdir) preserved; no spine/forge/RAG edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)