### PR TITLE
docs(ai-forge): eval-harness pattern run evidence (sanitized)

### DIFF
--- a/docs/runs/ai-forge-eval/README.md
+++ b/docs/runs/ai-forge-eval/README.md
@@ -1,0 +1,43 @@
+# ai-forge eval-harness pattern — run evidence
+
+## What this run proves
+
+`run.mjs` exercises the `evalPattern` from `ai-forge/patterns/eval.mjs` through the forge gate.
+It demonstrates that ai-forge can forge a complete, self-testing eval harness in a single converged run.
+
+## What the eval harness contains
+
+The pattern produces seven interdependent build workstreams plus a design workstream (8 total):
+
+| Workstream | What it contributes |
+|---|---|
+| **dataset** | A fixed, labelled eval set (binary sentiment, ≥4 unique cases). |
+| **target** | A deterministic keyword classifier; total over the dataset inputs. |
+| **runner** | Runs the target over the dataset; produces one id-aligned prediction per case. |
+| **metrics** | Computes accuracy, precision, and recall; proven against a hand-computed fixture. |
+| **scorecard** | Writes `scorecard.json`; asserts stored metrics ≈ recomputed on read-back (fail-closed). |
+| **threshold** | Gates metrics against minimum thresholds; passes above bounds, blocks below. |
+| **regression** | Flags metrics that drop below a stored baseline beyond tolerance. |
+| **design** | Verified architectural design synthesised from all seven build findings. |
+
+## The scorecard cross-check and issue #30 item 2
+
+The `scorecard` workstream's `verifyScorecard` function is the first-class form of the deferred
+issue #30 item-2 cross-check: it recomputes all metrics from the runner and asserts that the stored
+values differ by at most ε (1 × 10⁻⁹). Tampered values are rejected. This is structural verification,
+not a post-hoc audit step.
+
+## Run result
+
+All 8 workstreams converge (`finalStatus: meets`). Gate status: `pass`.
+
+```
+eval run: converged=true gate_status=pass workstreams=8
+```
+
+## Properties
+
+- **Keyless**: no API keys, no network calls, no secrets.
+- **Deterministic**: the classifier is a fixed keyword lookup; metrics are exact fractions of 4 cases.
+- **Sanitized**: `run-summary.json` contains no absolute paths, no `file://` URIs, no timestamps.
+- **Node ≥ 18, ESM**: pure ES modules throughout.

--- a/docs/runs/ai-forge-eval/run-summary.json
+++ b/docs/runs/ai-forge-eval/run-summary.json
@@ -1,0 +1,48 @@
+{
+  "converged": true,
+  "merge_status": "ready",
+  "gate_status": "pass",
+  "workstreams": [
+    {
+      "id": "dataset",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "target",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "runner",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "metrics",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "scorecard",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "threshold",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "regression",
+      "converged": true,
+      "finalStatus": "meets"
+    },
+    {
+      "id": "design",
+      "converged": true,
+      "finalStatus": "meets"
+    }
+  ],
+  "generated_at_note": "deterministic; no timestamps"
+}

--- a/docs/runs/ai-forge-eval/run.mjs
+++ b/docs/runs/ai-forge-eval/run.mjs
@@ -1,0 +1,35 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { forge } from "../../../ai-forge/forge.mjs";
+import { evalPattern, evalContext } from "../../../ai-forge/patterns/eval.mjs";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const projectRoot = mkdtempSync(path.join(os.tmpdir(), "aiforge-eval-run-"));
+mkdirSync(path.join(projectRoot, ".telos"), { recursive: true });
+
+const dossierMeta = {
+  build_id: "ai-forge-eval-evidence",
+  idea_id: "ai-forge-eval-evidence",
+  use_case: "AI architecture: eval-harness pattern evidence run",
+  objective: "Prove the eval-harness pattern converges over the forge gate."
+};
+
+const result = await forge({ pattern: evalPattern, ctx: evalContext(), projectRoot, dossierMeta });
+
+// Sanitized summary — mirrors docs/runs/ai-forge-telos/run.mjs exactly.
+const summary = {
+  converged: result.converged,
+  merge_status: result.converged ? "ready" : "not-ready",
+  gate_status: result.verdict ? result.verdict.gate_status : "not-run",
+  workstreams: (result.records || []).map((r) => ({ id: r.workstream, converged: r.converged, finalStatus: r.finalStatus })),
+  generated_at_note: "deterministic; no timestamps"
+};
+const raw = JSON.stringify(summary);
+if (raw.includes("file://") || /[A-Za-z]:[\\/]/.test(raw) || raw.includes("/home/") || raw.includes("/Users/")) {
+  throw new Error("SANITIZATION FAILURE: absolute path detected in summary — do not commit.");
+}
+writeFileSync(path.join(here, "run-summary.json"), JSON.stringify(summary, null, 2) + "\n");
+console.log(`eval run: converged=${summary.converged} gate_status=${summary.gate_status} workstreams=${summary.workstreams.length}`);
+process.exit(result.converged ? 0 : 1);


### PR DESCRIPTION
Phase C.2 Task 8 — sanitized run evidence for the eval-harness pattern (completes pattern 2 of 3).

- `docs/runs/ai-forge-eval/{run.mjs,run-summary.json,README.md}` — forges into an `os.tmpdir()` root; all 8 workstreams `meets`, `merge_status: ready`, gate pass; no `file://`/absolute path/secret/timestamp (verified clean).
- The scorecard's stored≈recomputed assertion (first-class #30-item-2 cross-check) is exercised in the run.
- Docs/evidence only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)