### PR TITLE
chore(ai-forge): Phase C.2 cosmetic cleanup (stale header counts, dead imports)

### DIFF
--- a/ai-forge/patterns/eval.mjs
+++ b/ai-forge/patterns/eval.mjs
@@ -1,6 +1,7 @@
 // patterns/eval.mjs — an eval-harness pattern as DATA.
-// 4 build workstreams (dataset / target / runner / metrics), each a self-contained
-// ESM module with an inline --selftest run as its nodeTest. Keyless, deterministic.
+// 7 build workstreams (dataset / target / runner / metrics / scorecard / threshold /
+// regression), each a self-contained ESM module with an inline --selftest run as its
+// nodeTest. Keyless, deterministic.
 import { makeDesignWorkstream } from "../workstreams/design.mjs";
 
 function mod({ id, signer, dependencies, file, source, finding, needle }) {

--- a/ai-forge/patterns/serving.mjs
+++ b/ai-forge/patterns/serving.mjs
@@ -1,6 +1,7 @@
 // patterns/serving.mjs — a serving+guardrails pattern as DATA.
-// 4 build workstreams (schema / handler / input-guardrail / output-guardrail), each a
-// self-contained ESM module with an inline --selftest run as its nodeTest. Keyless, deterministic.
+// 7 build workstreams (schema / handler / input-guardrail / output-guardrail / ratelimit /
+// authz / audit), each a self-contained ESM module with an inline --selftest run as its
+// nodeTest. Keyless, deterministic.
 import { makeDesignWorkstream } from "../workstreams/design.mjs";
 
 function mod({ id, signer, dependencies, file, source, finding, needle }) {

--- a/ai-forge/scripts/test-eval.mjs
+++ b/ai-forge/scripts/test-eval.mjs
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/ai-forge/scripts/test-multiagent.mjs
+++ b/ai-forge/scripts/test-multiagent.mjs
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";

--- a/ai-forge/scripts/test-serving.mjs
+++ b/ai-forge/scripts/test-serving.mjs
@@ -1,4 +1,3 @@
-import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";


### PR DESCRIPTION
Final whole-branch review minors (READY-TO-MERGE verdict; no Critical/Important).

- `patterns/eval.mjs` / `patterns/serving.mjs`: header comments said "4 build workstreams" (scaffold-phase count); both ship 7 — corrected to list all seven.
- `scripts/test-{multiagent,eval,serving}.mjs`: removed the unused `import assert` (the harnesses signal failure via `process.exit(1)`, not `assert.fail`).

No behavior change; all three harnesses + full `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)