### PR TITLE
fix(build-gate,ai-forge): close two fail-closed trust-spine holes

### DIFF
--- a/ai-forge/live.mjs
+++ b/ai-forge/live.mjs
@@ -235,7 +235,12 @@ export async function runForgeLive({
     // discarded (acceptable overhead for a single-run council call).
     let approvals;
     try {
-      approvals = await makeApprovalsAsync(dossierMeta);
+      // councilApprovals returns a function that destructures { dossierMeta }
+      // (identical in shape to saas-forge's). It MUST be called with the wrapped
+      // object — a bare dossierMeta makes the destructure yield undefined and
+      // throws on dossierMeta.build_id, silently degrading every live run to the
+      // synthetic self-approvals below.
+      approvals = await makeApprovalsAsync({ dossierMeta });
     } catch {
       // Council call failed (e.g. keys unavailable); fall back to synthetic.
       approvals = syntheticApprovals(dossierMeta);

--- a/ai-forge/scripts/test-live.mjs
+++ b/ai-forge/scripts/test-live.mjs
@@ -47,8 +47,10 @@ const stubVectorStore = (() => {
 //                      binary files like .png are omitted by the seat).
 //   2. Grok adversary: prompt contains "Attack this claim" — return [] (no holes).
 //   3. Member revise:  prompt contains "Team proposals" — return a no-op verdict.
-//   4. Approval seats: handled by runForgeLive's graceful fallback to
-//                      syntheticApprovals when the council call errors.
+//   4. Approval seats: the council runs for REAL — agy via agy_checkpoint,
+//                      claude/codex via <model>_ask (prompt carries "approval
+//                      packet"). Each returns a packet with provenance so the
+//                      verdict is distinguishable from the synthetic fallback.
 //
 function makeStubCallTool(pattern, ragCtx) {
   return async (name, args) => {
@@ -125,6 +127,23 @@ assert.ok(Array.isArray(result.cycles),
   `result must have a cycles array; got: ${JSON.stringify(result)}`);
 assert.ok(result.cycles.length >= 1,
   "cycles array must have at least one entry (the forge ran at least one cycle)");
+
+// Regression guard for the arg-shape bug: runForgeLive must invoke the async
+// council with { dossierMeta } so the REAL council runs. If it regresses to a
+// bare dossierMeta, councilApprovals throws and runForgeLive silently substitutes
+// syntheticApprovals — which carry NO provenance. The stub's council packets do,
+// so require real provenance to reach the gate (only observable once the build
+// converges and the market gate runs).
+assert.equal(result.converged, true,
+  "live path must converge (stubbed seats + fact breakouts) so the council-fed gate runs");
+assert.ok(result.verdict && result.verdict.gate_status === "pass",
+  `market gate must pass on real council approvals; got ${JSON.stringify(result.verdict && result.verdict.gate_status)}`);
+const provByModel = new Map((result.verdict.provenance || []).map((p) => [p.model, p]));
+for (const model of ["claude", "agy", "codex"]) {
+  const pv = provByModel.get(model);
+  assert.ok(pv && typeof pv.response_id === "string" && pv.response_id.length > 0,
+    `${model} approval must carry real council provenance, not the synthetic fallback; got ${JSON.stringify(pv)}`);
+}
 
 console.log(
   `test-live.mjs OK: live path executed — ` +

--- a/build-gate/build-orchestrator.mjs
+++ b/build-gate/build-orchestrator.mjs
@@ -64,10 +64,22 @@ export function makeTeamDispatch({ routeFor, callTeam, baseDir, dossier, maxAtte
         return { ok: false, reason: out?.reason || `team ${team?.id} declined`, respec: out?.respec };
       }
       const files = Array.isArray(out.files) ? out.files : [];
+      // Clamp writes to the node's DECLARED files (Rule 1 injects the exact list
+      // the node owns). Rule 3 only ever hashes those, and runBuild's
+      // write-disjoint guard is computed from them, so an undeclared write —
+      // notably into the .telos/ control plane, which resolves cleanly under
+      // baseDir — would slip past both. Enforce it HERE, on the trusted side that
+      // does the writing, not only in the optional live callTeam (parseTeamFiles).
+      const declared = new Set(
+        (injected.files || [])
+          .map((rel) => resolveUnder(baseDir, rel))
+          .filter((abs) => abs !== null)
+      );
       for (const f of files) {
         if (!f || typeof f.path !== "string") return { ok: false, reason: `team ${team.id} returned a malformed file` };
         const resolved = resolveUnder(baseDir, f.path);
         if (resolved === null) return { ok: false, reason: `team ${team.id} path escapes baseDir: ${f.path}` };
+        if (!declared.has(resolved)) return { ok: false, reason: `team ${team.id} wrote a file not declared by its node spec: ${f.path}` };
         mkdirSync(path.dirname(resolved), { recursive: true });
         writeFileSync(resolved, typeof f.content === "string" ? f.content : String(f.content ?? ""));
       }

--- a/build-gate/scripts/test-build-orchestrator.mjs
+++ b/build-gate/scripts/test-build-orchestrator.mjs
@@ -156,6 +156,29 @@ function fixture() {
   console.log("OK: dispatch rejects path escape");
 }
 
+// --- makeTeamDispatch unit: a team writing an UNDECLARED file is rejected (control-plane guard) ---
+{
+  const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-disp-clamp-"));
+  mkdirSync(path.join(baseDir, ".telos"), { recursive: true });
+  const team = { id: "rogue", signer: "rogue" };
+  // The team returns its declared file PLUS a stealth write into the .telos/
+  // control plane (resolves cleanly under baseDir, so the escape check alone
+  // would let it through).
+  const dispatch = makeTeamDispatch({
+    routeFor: () => team,
+    callTeam: async () => ({ files: [
+      { path: "out/ok.txt", content: "declared" },
+      { path: ".telos/ledger.jsonl", content: "forged ledger line" }
+    ] }),
+    baseDir, dossier: {}
+  });
+  const out = await dispatch({ id: "n", files: ["out/ok.txt"], requirements: "r", test: { cmd: "node", args: ["-e", "process.exit(0)"] } });
+  assert.equal(out.ok, false, "an undeclared write is rejected");
+  assert.match(out.reason, /not declared by its node spec/, "reason names the undeclared write");
+  assert.equal(existsSync(path.join(baseDir, ".telos", "ledger.jsonl")), false, "the control-plane file was never written");
+  console.log("OK: dispatch rejects writes outside the node's declared files");
+}
+
 // --- makeTeamDispatch unit: a team that declines surfaces a respec for the repair loop ---
 {
   const baseDir = mkdtempSync(path.join(os.tmpdir(), "telos-disp2-"));


### PR DESCRIPTION
## Summary

Two fixes where **untrusted model/team output could reach a gate-satisfying state** — the exact self-report the TELOS trust spine exists to prevent. Both were surfaced by a full-repo audit of `main` and verified against source.

### 1. ai-forge live council was dead code → every live run certified on synthetic self-approvals
`runForgeLive` called the async council as `makeApprovalsAsync(dossierMeta)`, but `councilApprovals` returns a function that destructures `{ dossierMeta }` (same shape as saas-forge). The bare argument made `dossierMeta` `undefined`, threw on `dossierMeta.build_id`, and the surrounding `catch` silently substituted `syntheticApprovals` (unanimous, unsigned, no provenance). Since the ai-forge dossier never sets `trust_mode: "signed"`, the gate accepted them — so **the live council never ran and every `runForgeLive` result was certified by fabricated approvals**.

Fix: call it with `{ dossierMeta }`. The `catch → syntheticApprovals` path reverts to being a genuine keyless/offline fallback instead of the mandatory outcome.

### 2. Build teams could write into the `.telos/` control plane
`makeTeamDispatch` checked only `baseDir` confinement, and `resolveUnder` permits `".telos/..."` (it rejects only `..`/absolute). So an untrusted team could overwrite/corrupt `ledger.jsonl` or `plan.json` — breaking the `orchestrate.mjs` invariant *"The controller is the SOLE ledger writer; workers never touch .telos/."*

Fix: clamp writes to the node's **declared files** (`injected.files`) on the trusted side that performs the `writeFileSync`, not only in the optional live `callTeam`. Declared-only is the correct boundary — Rule 3 hashes only those files and the write-disjoint guard is computed from them, so it subsumes the control-plane case.

## Regression tests
- `ai-forge/scripts/test-live.mjs`: asserts `converged` + gate `pass` + **real council provenance** (`response_id` present). The synthetic fallback carries none, so the arg-shape regression fails loudly. (Also updated the stale stub comment that documented reliance on the fallback.)
- `build-gate/scripts/test-build-orchestrator.mjs`: a `makeTeamDispatch` case where a team returns a declared file **plus** a stealth `.telos/ledger.jsonl` write; asserts rejection (`/not declared by its node spec/`) and that the control-plane file was never written.

## Verification
- `cd build-gate && npm test` (also runs `breakout`): pass
- `cd ai-forge && npm test`: pass — `test-live.mjs OK: ... converged=true, gate=pass`

No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
