### PR TITLE
fix(breakout): fail closed on empty/invalid file_contains needle

### DIFF
--- a/breakout/scripts/test-verifier.mjs
+++ b/breakout/scripts/test-verifier.mjs
@@ -170,9 +170,10 @@ const selfName = thisFile.split(/[\\/]/).pop();
   console.log("test-verifier sufficiency OK");
 }
 
-// 11. Empty-needle bypass is closed: a file_contains spec with needle:"" on a
-//     zero-byte file must NOT satisfy hasFileContains, and the file MUST be
-//     flagged in emptyEvidenceFiles.
+// 11. Empty-needle bypass is fully closed (all modes): a file_contains spec whose
+//     needle is empty / whitespace / missing is not evidence, so the check must
+//     FAIL re-verification (not merely be excluded from the signed-mode floor).
+//     This closes the unsigned-mode vacuous pass where allPass stayed true.
 {
   const { mkdtempSync, writeFileSync } = await import("node:fs");
   const os = await import("node:os");
@@ -183,28 +184,37 @@ const selfName = thisFile.split(/[\\/]/).pop();
   writeFileSync(path.join(dir, "empty.txt"), "");
   writeFileSync(path.join(dir, "real.txt"), "actual-content-marker");
 
-  // Empty needle on zero-byte file: must NOT count as hasFileContains, must flag emptyEvidenceFiles.
-  const emptyNeedle = reverifyRecord(
-    { checks: [{ type: "file_contains", path: "empty.txt", needle: "" }] },
-    dir
-  );
+  // Empty needle: the check FAILS (closes the unsigned vacuous pass), still counts
+  // as reverifiable, and never satisfies hasFileContains (signed-mode floor).
+  const emptyNeedle = reverifyRecord({ checks: [{ type: "file_contains", path: "empty.txt", needle: "" }] }, dir);
+  assert.equal(emptyNeedle.allPass, false, "empty needle must fail re-verification, not pass vacuously");
+  assert.equal(emptyNeedle.reverifiable, 1, "the empty-needle check still ran (counts as reverifiable)");
   assert.equal(emptyNeedle.hasFileContains, false, "empty needle must not satisfy hasFileContains");
-  assert.ok(emptyNeedle.emptyEvidenceFiles.includes("empty.txt"), "zero-byte file_contains target must appear in emptyEvidenceFiles");
 
-  // Whitespace-only needle should also not satisfy hasFileContains.
-  const wsNeedle = reverifyRecord(
-    { checks: [{ type: "file_contains", path: "empty.txt", needle: "   " }] },
-    dir
-  );
+  // The bug was String.includes(""): an empty needle on a NON-empty file must fail too.
+  const emptyOnReal = reverifyRecord({ checks: [{ type: "file_contains", path: "real.txt", needle: "" }] }, dir);
+  assert.equal(emptyOnReal.allPass, false, "empty needle on a non-empty file must also fail");
+
+  // Whitespace-only and missing needle must also fail (match the realNeedle predicate).
+  const wsNeedle = reverifyRecord({ checks: [{ type: "file_contains", path: "real.txt", needle: "   " }] }, dir);
+  assert.equal(wsNeedle.allPass, false, "whitespace-only needle must fail");
   assert.equal(wsNeedle.hasFileContains, false, "whitespace-only needle must not satisfy hasFileContains");
+  const missingNeedle = reverifyRecord({ checks: [{ type: "file_contains", path: "real.txt" }] }, dir);
+  assert.equal(missingNeedle.allPass, false, "missing needle must fail (no includes('undefined') match)");
 
-  // Non-empty needle on non-empty file: must set hasFileContains=true and must NOT flag as empty.
-  const realContains = reverifyRecord(
-    { checks: [{ type: "file_contains", path: "real.txt", needle: "actual-content-marker" }] },
-    dir
-  );
+  // Non-empty needle on non-empty file still passes and sets hasFileContains.
+  const realContains = reverifyRecord({ checks: [{ type: "file_contains", path: "real.txt", needle: "actual-content-marker" }] }, dir);
+  assert.equal(realContains.allPass, true, "real needle on real file passes");
   assert.equal(realContains.hasFileContains, true, "real needle on real file must set hasFileContains=true");
   assert.ok(!realContains.emptyEvidenceFiles.includes("real.txt"), "non-empty file must not appear in emptyEvidenceFiles");
+
+  // The live path (buildCheck -> runVerifiedBreakout) must also fail closed.
+  const liveEmpty = await runVerifiedBreakout(
+    { workstream: "x", claimedStatus: "meets" },
+    [buildCheck({ type: "file_contains", path: "real.txt", needle: "" }, dir)]
+  );
+  assert.equal(liveEmpty.converged, false, "live breakout must not converge on an empty-needle check");
+  assert.equal(liveEmpty.finalStatus, "needs-work");
 
   console.log("test-verifier empty-needle bypass OK");
 }

--- a/breakout/verifier.mjs
+++ b/breakout/verifier.mjs
@@ -179,11 +179,18 @@ export function fileExistsCheck(id, path) {
 }
 
 export function fileContainsCheck(id, path, needle) {
+  // A missing / empty / whitespace-only needle is not evidence: includes("") is
+  // always true and includes(undefined) matches the literal "undefined". Such a
+  // check must FAIL so a vacuous file_contains can never satisfy re-verification
+  // in any mode. Same predicate as reverifyRecord's realNeedle / the signed-mode
+  // sufficiency floor, so "a real needle" has one definition.
+  const validNeedle = typeof needle === "string" && needle.trim().length > 0;
   return {
     id,
     description: `${path} contains "${needle}"`,
     spec: { type: "file_contains", path, needle, id },
     run: () => {
+      if (!validNeedle) return { ok: false, detail: `file_contains needs a non-empty needle (got ${JSON.stringify(needle)})` };
       if (!existsSync(path)) return { ok: false, detail: `missing ${path}` };
       const ok = readFileSync(path, "utf8").includes(needle);
       return { ok, detail: ok ? `found "${needle}"` : `"${needle}" not in ${path}` };


### PR DESCRIPTION
## Summary

`fileContainsCheck` ran `readFileSync(path).includes(needle)` with no validation of `needle`. Since `String.includes("")` is always `true` and `includes(undefined)` matches the literal `"undefined"`, a spec like `{ type: "file_contains", needle: "" }` was **a check that could never fail**.

In `reverifyRecord`, the `realNeedle` guard only excluded such a needle from `hasFileContains` (the *signed-mode* sufficiency floor) — it still counted toward `reverifiable` and `allPass`. So in **unsigned mode (every forge layer)**, a breakout record whose only evidence was a vacuous `file_contains` passed the gate's re-verification: an unfalsifiable check satisfying the "truth test" that the deterministic grounding layer exists to prevent.

## Fix

Fail closed at the single builder both paths funnel through — `safeCheckFromSpec` (gate re-verification) and `buildCheck` (live breakout):

```js
const validNeedle = typeof needle === "string" && needle.trim().length > 0;
...
if (!validNeedle) return { ok: false, detail: `file_contains needs a non-empty needle (got ${JSON.stringify(needle)})` };
```

An empty / whitespace-only / missing needle now makes the check **fail**, so `allPass` goes false and the record is blocked in **both** signed and unsigned mode. Reuses the same `realNeedle` predicate so "a real needle" has one definition across the builder and the sufficiency floor.

## Tests

`breakout/scripts/test-verifier.mjs` #11 now asserts the check **fails** (`allPass === false`, still `reverifiable === 1`) for empty, empty-on-a-non-empty-file, whitespace, and missing needles; that real needles still pass and set `hasFileContains`; and that the live path (`runVerifiedBreakout` via `buildCheck`) fails closed too.

Signed-mode trust tests are unaffected — they still emit the `existence-only` / `zero-byte` blockers, now alongside a `FAILED re-verification` one.

## Verification
- `cd build-gate && npm test` (incl. `test-trust` + `breakout`): pass
- `cd saas-forge && npm test`: pass (converges on real needles; fail-closed case still blocks)
- `cd ai-forge && npm test`: pass

No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed. Independent of #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
