### PR TITLE
fix(build-gate): harden signed-mode packet authentication (evidence + provenance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,9 +160,13 @@ and the gate independently re-verifies every team's record on disk.
 - Each required seat's packet is **HMAC-signed** and carries **real provenance**:
   the server-issued response id for remote models (claude/grok/codex/gemini), or a
   content-addressed **local attestation** (`agy-<sha256>`) for the deterministic
-  agy seat. No structured provenance ⇒ `response_id: null` ⇒ the gate blocks. No
-  seat borrows or fabricates another's id. (grok and gemini ride as **advisory** —
-  a missing key for them never blocks the gate.)
+  agy seat. No structured provenance ⇒ `response_id: null` ⇒ the gate blocks, as
+  does a placeholder id or a `response_id` shared across two seats — **no seat
+  borrows another's id**. What the gate cannot do from disk is prove a well-formed,
+  *unique* id is genuine rather than fabricated (it can't re-contact the API); that
+  binding to the real response is made by the council wiring at generation time,
+  with the per-seat HMAC secret as the identity floor. (grok and gemini ride as
+  **advisory** — a missing key for them never blocks the gate.)
 - **Structured output is reliability, not trust.** The schema carries only
   *judgment* (the approval schema omits identity); the gate re-validates packet
   shape, injects identity from the dossier, and binds provenance to the real API

--- a/build-gate/gate.mjs
+++ b/build-gate/gate.mjs
@@ -194,7 +194,7 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
   validateProtectedPaths(dossier, blockers);
   validateLexiGate(dossier, packets, blockers);
   validateGrokResolution(packetsByModel.get("grok"), dossier, blockers, warnings);
-  validateCapabilityPackets(dossier, capabilityPackets, blockers, warnings);
+  validateCapabilityPackets(dossier, capabilityPackets, blockers, warnings, signed);
   validateMarketReadinessPackets(dossier, marketPackets, blockers, warnings, source, signed);
 
   // Visibility: which optional headline gates actually evaluated anything. A
@@ -232,6 +232,33 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
   };
 }
 
+// In trust_mode "signed", evidence packets that decide gate outcomes (market
+// readiness, capability acquisition) must be authenticated exactly like the
+// required approval packets: HMAC-verified with the model's secret AND bound to
+// real (non-placeholder) provenance. Unverifiable evidence blocks — a
+// self-asserted market/capability packet must never satisfy the gate under
+// signed mode. Mirrors the required-approval checks in validateRecords.
+function enforceSignedPacketAuth(packet, label, blockers) {
+  const model = typeof packet?.model === "string" ? packet.model : "unknown";
+  const secret = secretFor(model);
+  if (!secret) {
+    blockers.push(`trust_mode 'signed' but no secret to verify ${label} for '${model}' (set TELOS_SECRET_${model.toUpperCase()}).`);
+  } else {
+    const result = verifyPacket(packet, secret);
+    if (!result.ok) {
+      blockers.push(`${label} for ${model} signature invalid in signed mode: ${result.reason}.`);
+    }
+  }
+  const prov = packet && packet.provenance && typeof packet.provenance === "object" ? packet.provenance : null;
+  const responseId = prov && typeof prov.response_id === "string" ? prov.response_id : null;
+  const placeholder = !responseId || /^$|_self$|^self$|placeholder/i.test(responseId);
+  if (!prov) {
+    blockers.push(`${label} for ${model} carries no provenance; model identity is self-declared, not authenticated.`);
+  } else if (placeholder) {
+    blockers.push(`${label} for ${model} has placeholder provenance.response_id '${responseId}'; not bound to a real model response.`);
+  }
+}
+
 function validateMarketReadinessPackets(dossier, marketPackets, blockers, warnings, source = {}, signed = false) {
   const requiredWorkstreams = requiredMarketWorkstreams(dossier, marketPackets);
   if (requiredWorkstreams.length === 0) return;
@@ -254,6 +281,7 @@ function validateMarketReadinessPackets(dossier, marketPackets, blockers, warnin
 
   for (const packet of marketPackets) {
     validateMarketReadinessPacketShape(packet, blockers);
+    if (signed) enforceSignedPacketAuth(packet, "Market readiness packet", blockers);
     if (packet?.build_id !== dossier.build_id) {
       blockers.push(`Market readiness packet for ${packet?.model ?? "unknown"} has build_id '${packet?.build_id}' but dossier requires '${dossier.build_id}'.`);
     }
@@ -449,7 +477,7 @@ function validateDossierShape(dossier, blockers) {
   requireArrayField(dossier, "write_targets", "Dossier", blockers);
 }
 
-function validateCapabilityPackets(dossier, capabilityPackets, blockers, warnings) {
+function validateCapabilityPackets(dossier, capabilityPackets, blockers, warnings, signed = false) {
   const requiredModels = requiredCapabilityModels(dossier, capabilityPackets);
   if (requiredModels.length === 0) return;
 
@@ -463,6 +491,7 @@ function validateCapabilityPackets(dossier, capabilityPackets, blockers, warning
   const packetsByModel = new Map();
   for (const packet of capabilityPackets) {
     validateCapabilityPacketShape(packet, blockers);
+    if (signed) enforceSignedPacketAuth(packet, "Capability packet", blockers);
     if (packet?.build_id !== dossier.build_id) {
       blockers.push(`Capability packet for ${packet?.model ?? "unknown"} has build_id '${packet?.build_id}' but dossier requires '${dossier.build_id}'.`);
     }

--- a/build-gate/gate.mjs
+++ b/build-gate/gate.mjs
@@ -164,11 +164,16 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
   }
   const evidencePackets = signed ? trustedPackets : packets;
 
-  // Provenance is advisory: the gate CANNOT cryptographically authenticate which
-  // model authored a packet. It surfaces whether each required approval carries a
-  // `provenance` block (ideally captured from the real model response — see
-  // ai-peer-mcp council_review) and warns when identity is merely self-declared.
+  // Provenance binding. Under signed mode the gate BLOCKS a required approval that
+  // carries no provenance, a placeholder response_id, or a response_id shared with
+  // another seat (no seat borrows another's id — a real server-issued id or agy
+  // attestation is unique to its producer). What it cannot do from disk is prove a
+  // well-formed, UNIQUE id is genuine rather than fabricated — it can't re-contact
+  // the API; that binding to the real response is made by the live council wiring
+  // (ai-peer-mcp) at generation time, with the per-seat HMAC secret as the identity
+  // floor. In unsigned/legacy mode these are advisory (a missing block warns).
   const provenance = [];
+  const seenResponseIds = new Map(); // lowercased response_id -> first seat that carried it
   for (const model of REQUIRED_MODELS) {
     const packet = packetsByModel.get(model);
     const prov = packet && packet.provenance && typeof packet.provenance === "object" ? packet.provenance : null;
@@ -186,6 +191,14 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
         ? `Approval packet for ${model} carries no provenance; model identity is self-declared, not authenticated.`
         : `Approval packet for ${model} has placeholder provenance.response_id '${responseId}'; not bound to a real model response.`;
       if (signed) blockers.push(msg); else if (!prov) warnings.push(msg);
+    } else if (packet && responseId) {
+      const key = responseId.toLowerCase();
+      if (seenResponseIds.has(key)) {
+        const msg = `Approval packets for ${seenResponseIds.get(key)} and ${model} share provenance.response_id '${responseId}'; a seat may not borrow another's id.`;
+        if (signed) blockers.push(msg); else warnings.push(msg);
+      } else {
+        seenResponseIds.set(key, model);
+      }
     }
   }
 

--- a/build-gate/gate.mjs
+++ b/build-gate/gate.mjs
@@ -139,6 +139,12 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
     }
   }
 
+  // In signed mode, only signature-verified required packets are trusted as
+  // evidence for docs_reviewed / LEXI review below. A duplicate packet (only the
+  // first per model reaches packetsByModel and is verified) or a non-required-model
+  // packet is never signature-checked, so it must not clear a required-doc or LEXI
+  // blocker. Legacy/unsigned mode authenticates nothing, so every packet counts.
+  const trustedPackets = [];
   if (signed) {
     for (const model of REQUIRED_MODELS) {
       const packet = packetsByModel.get(model);
@@ -151,9 +157,12 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
       const result = verifyPacket(packet, secret);
       if (!result.ok) {
         blockers.push(`${model} packet signature invalid in signed mode: ${result.reason}.`);
+      } else {
+        trustedPackets.push(packet);
       }
     }
   }
+  const evidencePackets = signed ? trustedPackets : packets;
 
   // Provenance is advisory: the gate CANNOT cryptographically authenticate which
   // model authored a packet. It surfaces whether each required approval carries a
@@ -181,7 +190,7 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
   }
 
   const requiredDocs = asArray(dossier.required_docs);
-  const docsReviewed = unique(packets.flatMap((packet) => asArray(packet.docs_reviewed)));
+  const docsReviewed = unique(evidencePackets.flatMap((packet) => asArray(packet.docs_reviewed)));
   // Membership is path-normalized: separators (\ vs /) and case do not change
   // whether a required doc counts as reviewed.
   const reviewedNormalized = new Set(docsReviewed.map(normalizeDocPath));
@@ -192,7 +201,7 @@ export function validateRecords(dossier, packets, source = {}, capabilityPackets
   }
 
   validateProtectedPaths(dossier, blockers);
-  validateLexiGate(dossier, packets, blockers);
+  validateLexiGate(dossier, evidencePackets, blockers);
   validateGrokResolution(packetsByModel.get("grok"), dossier, blockers, warnings);
   validateCapabilityPackets(dossier, capabilityPackets, blockers, warnings, signed);
   validateMarketReadinessPackets(dossier, marketPackets, blockers, warnings, source, signed);

--- a/build-gate/scripts/test-trust.mjs
+++ b/build-gate/scripts/test-trust.mjs
@@ -96,6 +96,7 @@ assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass", "valid 
       architecture_findings: [], backend_schema_findings: [], security_findings: [], accuracy_eval_findings: [],
       scalability_findings: [], frontend_design_findings: [], lexi_class_ui_status: "meets",
       go_to_market_blockers: [], recommendation_to_claude: "ship", timestamp: "2026-06-27T00:00:00Z",
+      provenance: { model: "real-claude", source: "ai-peer-mcp", response_id: "resp_market_claude_1" },
       breakout: {
         workstream: "frontend-brand-experience", converged: true, finalStatus: "meets",
         surviving_blockers: [], rounds: [{ round: 1 }], checks
@@ -133,6 +134,7 @@ assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass", "valid 
       architecture_findings: [], backend_schema_findings: [], security_findings: [], accuracy_eval_findings: [],
       scalability_findings: [], frontend_design_findings: [], lexi_class_ui_status: "meets",
       go_to_market_blockers: [], recommendation_to_claude: "ship", timestamp: "2026-06-27T00:00:00Z",
+      provenance: { model: "real-claude", source: "ai-peer-mcp", response_id: "resp_market_claude_1" },
       breakout: {
         workstream: "frontend-brand-experience", converged: true, finalStatus: "meets",
         surviving_blockers: [], rounds: [{ round: 1 }], checks
@@ -150,6 +152,73 @@ assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass", "valid 
     emptyNeedleBypass.blockers.some((b) => b.includes("existence-only") || b.includes("zero-byte")),
     "blocker must mention existence-only or zero-byte; got: " + JSON.stringify(emptyNeedleBypass.blockers)
   );
+}
+
+// 9. Market packets are authenticated in signed mode: unsigned or no-provenance
+//    market evidence must block even when its on-disk checks would pass.
+{
+  const dir = mkdtempSync(path.join(os.tmpdir(), "telos-market-auth-"));
+  writeFileSync(path.join(dir, "art.txt"), "marker-TELOS-OK");
+  const marketDossier = {
+    ...dossier, idea_id: "telos-upgrade", market_bound: true, user_facing_frontend: false,
+    affected_directories: [dir], required_market_workstreams: ["frontend-brand-experience"]
+  };
+  const mkPacket = () => ({
+    build_id: "trust-demo", idea_id: "telos-upgrade", model: "claude", project_state: "prototype",
+    workstreams_reviewed: ["frontend-brand-experience"], business_thesis: "t", target_users: ["u"],
+    architecture_findings: [], backend_schema_findings: [], security_findings: [], accuracy_eval_findings: [],
+    scalability_findings: [], frontend_design_findings: [], lexi_class_ui_status: "meets",
+    go_to_market_blockers: [], recommendation_to_claude: "ship", timestamp: "2026-06-27T00:00:00Z",
+    provenance: { model: "real-claude", source: "ai-peer-mcp", response_id: "resp_market_claude_1" },
+    breakout: {
+      workstream: "frontend-brand-experience", converged: true, finalStatus: "meets",
+      surviving_blockers: [], rounds: [{ round: 1 }],
+      checks: [{ type: "file_contains", path: "art.txt", needle: "marker-TELOS-OK" }]
+    }
+  });
+
+  const good = validateRecords(marketDossier, signedTrio(), { dossierDir: dir }, [], [signPacket(mkPacket(), SECRET.claude)]);
+  assert.equal(good.gate_status, "pass", "signed market packet with provenance should pass; got: " + JSON.stringify(good.blockers));
+
+  const unsigned = validateRecords(marketDossier, signedTrio(), { dossierDir: dir }, [], [mkPacket()]);
+  assert.equal(unsigned.gate_status, "blocked");
+  assert.ok(unsigned.blockers.some((b) => b.includes("Market readiness packet for claude signature invalid")),
+    "unsigned market packet must block in signed mode; got: " + JSON.stringify(unsigned.blockers));
+
+  const noProv = mkPacket(); delete noProv.provenance;
+  const noProvSigned = validateRecords(marketDossier, signedTrio(), { dossierDir: dir }, [], [signPacket(noProv, SECRET.claude)]);
+  assert.equal(noProvSigned.gate_status, "blocked");
+  assert.ok(noProvSigned.blockers.some((b) => b.includes("Market readiness packet for claude carries no provenance")),
+    "market packet without provenance must block in signed mode; got: " + JSON.stringify(noProvSigned.blockers));
+}
+
+// 10. Capability packets are authenticated in signed mode the same way.
+{
+  const capDossier = {
+    ...dossier, idea_id: "cap-idea", telos: "prove capability signing", required_capability_models: ["claude"]
+  };
+  const capPacket = () => ({
+    build_id: "trust-demo", idea_id: "cap-idea", model: "claude", telos: "prove capability signing",
+    docs_needed: [], skills_needed: [], connectors_needed: [], available_now: [],
+    missing_capabilities: [], can_build_during_planning: [], built_during_planning: [],
+    must_request_user_or_install: [], presented_to_claude: true,
+    recommendation_to_claude: "ready", timestamp: "2026-06-27T00:00:00Z",
+    provenance: { model: "real-claude", source: "ai-peer-mcp", response_id: "resp_cap_claude_1" }
+  });
+
+  const good = validateRecords(capDossier, signedTrio(), {}, [signPacket(capPacket(), SECRET.claude)]);
+  assert.equal(good.gate_status, "pass", "signed capability packet with provenance should pass; got: " + JSON.stringify(good.blockers));
+
+  const unsigned = validateRecords(capDossier, signedTrio(), {}, [capPacket()]);
+  assert.ok(unsigned.blockers.some((b) => b.includes("Capability packet for claude signature invalid")),
+    "unsigned capability packet must block in signed mode; got: " + JSON.stringify(unsigned.blockers));
+
+  const noProv = capPacket(); delete noProv.provenance;
+  const noProvSigned = validateRecords(capDossier, signedTrio(), {}, [signPacket(noProv, SECRET.claude)]);
+  assert.ok(noProvSigned.blockers.some((b) => b.includes("Capability packet for claude carries no provenance")),
+    "capability packet without provenance must block in signed mode; got: " + JSON.stringify(noProvSigned.blockers));
+
+  console.log("test-trust.mjs signed-mode market/capability auth OK");
 }
 
 console.log("test-trust.mjs OK");

--- a/build-gate/scripts/test-trust.mjs
+++ b/build-gate/scripts/test-trust.mjs
@@ -221,4 +221,41 @@ assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass", "valid 
   console.log("test-trust.mjs signed-mode market/capability auth OK");
 }
 
+// 11. required_docs evidence must come from a signature-verified packet in signed
+//     mode: an unsigned extra / non-required-model packet cannot clear a doc blocker.
+{
+  const docDossier = { ...dossier, required_docs: ["doc-a", "secret-doc"] };
+  // The signed trio reviewed only doc-a. An UNSIGNED gemini packet claims secret-doc;
+  // it is never signature-checked, so it must not satisfy the required doc.
+  const geminiClaim = approval("gemini", ["doc-a", "secret-doc"]);
+  const r = validateRecords(docDossier, [...signedTrio(), geminiClaim]);
+  assert.equal(r.gate_status, "blocked");
+  assert.ok(r.blockers.some((b) => b.includes("Required doc was not reviewed by any packet: secret-doc")),
+    "an unsigned extra packet must not satisfy a required doc in signed mode; got: " + JSON.stringify(r.blockers));
+
+  // Sanity: when the signed required packets review the doc, it is satisfied.
+  const withDoc = ["claude", "agy", "codex"].map((m) => signPacket(approval(m, ["doc-a", "secret-doc"]), SECRET[m]));
+  assert.equal(validateRecords(docDossier, withDoc).gate_status, "pass",
+    "signed packets that reviewed the doc should satisfy it");
+}
+
+// 12. LEXI review must likewise come from a signature-verified packet in signed mode.
+{
+  const lexiRef = "shared/Filing_Package_July_2026/LEXI_DB_REFERENCE.md";
+  const lexiDossier = { ...dossier, lexi_required: true, lexi_reference_read: true };
+  // Signed trio did NOT review the LEXI ref; an unsigned gemini packet claims it.
+  const geminiClaim = approval("gemini", ["doc-a", lexiRef]);
+  const r = validateRecords(lexiDossier, [...signedTrio(), geminiClaim]);
+  assert.equal(r.gate_status, "blocked");
+  assert.ok(r.blockers.some((b) => b.includes("LEXI reference document")),
+    "an unsigned packet must not satisfy the LEXI review in signed mode; got: " + JSON.stringify(r.blockers));
+
+  // A signed required packet that reviewed the LEXI ref satisfies it.
+  const withLexi = ["claude", "agy", "codex"].map((m) => signPacket(approval(m, ["doc-a", lexiRef]), SECRET[m]));
+  assert.equal(validateRecords(lexiDossier, withLexi).gate_status, "pass",
+    "signed packets that reviewed the LEXI ref should satisfy it");
+
+  console.log("test-trust.mjs signed-mode docs/LEXI evidence auth OK");
+}
+
 console.log("test-trust.mjs OK");

--- a/build-gate/scripts/test-trust.mjs
+++ b/build-gate/scripts/test-trust.mjs
@@ -258,4 +258,23 @@ assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass", "valid 
   console.log("test-trust.mjs signed-mode docs/LEXI evidence auth OK");
 }
 
+// 13. No seat borrows another's id: two required packets sharing a response_id
+//     block in signed mode (each real id is unique to its producer).
+{
+  const claude = signPacket(approval("claude", ["doc-a"]), SECRET.claude);
+  const agy = signPacket(approval("agy", ["doc-a"]), SECRET.agy);
+  const codexPkt = approval("codex", ["doc-a"]);
+  codexPkt.provenance.response_id = "resp_claude_123"; // borrow claude's real id, then re-sign
+  const codex = signPacket(codexPkt, SECRET.codex);
+  const r = validateRecords(dossier, [claude, agy, codex]);
+  assert.equal(r.gate_status, "blocked");
+  assert.ok(r.blockers.some((b) => b.includes("may not borrow another's id")),
+    "a response_id shared across seats must block in signed mode; got: " + JSON.stringify(r.blockers));
+
+  // Distinct ids (the signed trio) do not trip the uniqueness check.
+  assert.equal(validateRecords(dossier, signedTrio()).gate_status, "pass",
+    "distinct per-seat response_ids must still pass");
+  console.log("test-trust.mjs signed-mode provenance id-uniqueness OK");
+}
+
 console.log("test-trust.mjs OK");


### PR DESCRIPTION
## Summary

Closes several signed-mode holes where **unauthenticated or unbound packet content decided gate outcomes**, plus the drift between the README trust model and what the gate actually enforced. Unifying principle: in `trust_mode: "signed"`, only *authenticated, uniquely-bound* packets count.

### 1. Market-readiness & capability packets skipped signature + provenance

The gate verified HMAC + provenance only on the three required *approval* packets. `validateMarketReadinessPackets` / `validateCapabilityPackets` ran no such check, yet their self-asserted fields decide outcomes (workstream coverage, `lexi_class_ui_status: "meets"`, absent blockers). A hand-authored, unsigned, provenance-free market/capability packet was accepted in signed mode.

**Fix:** `enforceSignedPacketAuth` — HMAC (`secretFor`/`verifyPacket`) + non-placeholder provenance — applied in signed mode to every market and capability packet.

### 2. required_docs / LEXI evidence unioned across *all* packets

`docsReviewed` and `validateLexiGate` scanned every packet, but only the first packet per required model is signature-verified. A duplicate, or a non-required-model packet (grok/gemini) never signature-checked, could inject `docs_reviewed` clearing the required-doc and LEXI blockers unauthenticated.

**Fix:** collect signature-verified required packets into `trustedPackets`; in signed mode compute `docsReviewed` and run `validateLexiGate` over that set (`evidencePackets`).

### 3. Provenance "no seat borrows another's id" was claimed but not enforced

The gate's provenance check only required a non-placeholder `response_id`; nothing stopped one seat's real server-issued id from being copied into another seat's packet. The README claimed *"no seat borrows or fabricates another's id"* — drift.

**Fix:** a real (non-placeholder) `response_id` must be **unique across seats**; a shared id blocks in signed mode. The gate comment and README now state precisely what is enforced (absent / placeholder / shared id all block) and the honest residual the gate cannot close from disk — it can't re-contact the API to prove a well-formed, unique id is genuine rather than fabricated; that binding is made by the live council wiring at generation time, with the per-seat HMAC secret as the identity floor.

## Not changed

Legacy/unsigned dossiers behave exactly as before (`evidencePackets` = every packet; market/capability auth gated on `signed`; provenance uniqueness only warns). The forge layers and `build-orchestrator` run unsigned, so they're unaffected.

## Tests (`build-gate/scripts/test-trust.mjs`)
- Market & capability: signed+provenance passes; unsigned blocks on `signature invalid`; signed-without-provenance blocks on `carries no provenance`.
- Docs & LEXI: an unsigned extra / non-required-model packet cannot clear a required-doc or LEXI blocker; a signed required packet that reviewed it satisfies it.
- Provenance: a packet borrowing another seat's `response_id` blocks in signed mode; the distinct-id signed trio still passes.

## Verification
- `cd build-gate && npm test` (incl. `test-trust` + `breakout`): pass
- `cd saas-forge && npm test` / `cd ai-forge && npm test`: pass

No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed. Independent of #64, #65, #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
