### PR TITLE
fix(merkle-dag,build-gate): run npm-based node tests on Windows

### DIFF
--- a/build-gate/scripts/test-runtime-adaptation.mjs
+++ b/build-gate/scripts/test-runtime-adaptation.mjs
@@ -42,6 +42,13 @@ const node = (id) => ({
 
   const noCmd = await runNodeTest({ id: "n", files: [], test: {} }, baseDir);
   assert.equal(noCmd.ok, false, "no test command => not ok");
+
+  // Cross-platform shim: `npm` is npm.cmd on Windows (cannot be spawned without the
+  // cmd.exe wrapper); runNodeTest must run it and capture exit 0 on Windows and
+  // POSIX alike. `npm --version` needs no project and always exits 0.
+  const npm = await runNodeTest({ id: "npm", files: [], test: { cmd: "npm", args: ["--version"] } }, baseDir);
+  assert.equal(npm.ok, true, `npm-based node test must run cross-platform; got detail=${npm.detail}`);
+  assert.equal(npm.status, 0, "npm --version exits 0");
 }
 
 // --- dispatch inner loop: fail attempt 1, self-correct on attempt 2 using priorFailure ---

--- a/build-gate/test-runner.mjs
+++ b/build-gate/test-runner.mjs
@@ -9,7 +9,7 @@
 // signing), so a team can never self-certify by passing this.
 
 import { spawn } from "node:child_process";
-import { resolveUnder } from "../merkle-dag/vendor.mjs";
+import { resolveUnder, spawnCommand } from "../merkle-dag/vendor.mjs";
 
 const DEFAULT_TIMEOUT_MS = 60000;
 const TAIL = 800; // keep a bounded failure tail so it can flow into a respec/effective_hash
@@ -38,7 +38,8 @@ export function runNodeTest(node, baseDir, { timeoutMs = DEFAULT_TIMEOUT_MS } = 
     let err = "";
     let child;
     try {
-      child = spawn(t.cmd, t.args || [], { cwd });
+      const spec = spawnCommand(t.cmd, t.args || []);
+      child = spawn(spec.command, spec.args, { cwd });
     } catch (e) {
       return resolve({ ok: false, status: null, stdout: "", stderr: "", detail: `${id}: spawn failed: ${e?.message || String(e)}` });
     }

--- a/merkle-dag/ledger-gate.mjs
+++ b/merkle-dag/ledger-gate.mjs
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
 import { recompute, readPlan } from "./merkle.mjs";
 import { computeDiskTreeHash, hasEscape } from "./artifact.mjs";
 import { readLedger, verifyTransaction } from "./crypto.mjs";
-import { resolveUnder } from "./vendor.mjs";
+import { resolveUnder, spawnCommand } from "./vendor.mjs";
 
 export function verify(telosDir, { baseDir } = {}) {
   baseDir = baseDir || path.dirname(path.resolve(telosDir)); // workspace root (parent of .telos)
@@ -55,7 +55,8 @@ export function verify(telosDir, { baseDir } = {}) {
           const cwd = resolveUnder(baseDir, t.cwd || ".") || baseDir;
           if (!t.cmd) { checks.test = "TEST_FAILED"; b.push(`${node.id}: node has no test command`); }
           else {
-            const res = spawnSync(t.cmd, t.args || [], { cwd, encoding: "utf8", timeout: TEST_TIMEOUT_MS, killSignal: "SIGTERM" });
+            const spec = spawnCommand(t.cmd, t.args || []);
+            const res = spawnSync(spec.command, spec.args, { cwd, encoding: "utf8", timeout: TEST_TIMEOUT_MS, killSignal: "SIGTERM" });
             if (res.error || res.status !== 0) { checks.test = "TEST_FAILED"; b.push(`${node.id}: test exit ${res.status}${res.error ? " ("+res.error.message+")" : ""}${res.signal ? " (signal " + res.signal + ")" : ""}`); }
           }
         }

--- a/merkle-dag/orchestrate.mjs
+++ b/merkle-dag/orchestrate.mjs
@@ -7,7 +7,7 @@ import { recompute, readPlan, writePlan, mutateNode, appendPlanHistory } from ".
 import { computeDiskTreeHash } from "./artifact.mjs";
 import { makeRecord, appendLedger, readLedger } from "./crypto.mjs";
 import { verify } from "./ledger-gate.mjs";
-import { resolveUnder, maxConcurrency } from "./vendor.mjs";
+import { resolveUnder, maxConcurrency, spawnCommand } from "./vendor.mjs";
 
 const TEST_TIMEOUT_MS = 60000;
 
@@ -50,7 +50,8 @@ function criticalWeights(planNodes) {
 function runTest(cmd, args, cwd, timeoutMs) {
   return new Promise((resolve) => {
     let done = false;
-    const child = spawn(cmd, args, { cwd });
+    const spec = spawnCommand(cmd, args);
+    const child = spawn(spec.command, spec.args, { cwd });
     const timer = setTimeout(() => {
       if (!done) { done = true; try { child.kill("SIGTERM"); } catch {} resolve({ status: null, timedOut: true }); }
     }, timeoutMs);

--- a/merkle-dag/scripts/test-orchestrate.mjs
+++ b/merkle-dag/scripts/test-orchestrate.mjs
@@ -724,6 +724,18 @@ function makeDispatch(ws) {
 }
 
 // ---------------------------------------------------------------------------
+// Cross-platform: defaultVerifyNode runs a Windows batch shim (npm) via the
+// cmd.exe wrapper and directly on POSIX — a node with no files whose test is
+// `npm --version` verifies ok on both. Regression guard for the shell-less spawn
+// that could never run npm.cmd on Windows.
+// ---------------------------------------------------------------------------
+{
+  const ws = mkdtempSync(path.join(os.tmpdir(), "telos-orch-npm-"));
+  const v = await defaultVerifyNode({ id: "npm", files: [], test: { cmd: "npm", args: ["--version"] } }, ws);
+  assert.equal(v.ok, true, `defaultVerifyNode must run an npm-based node test cross-platform; got ${JSON.stringify(v)}`);
+}
+
+// ---------------------------------------------------------------------------
 // Terminal marker
 // ---------------------------------------------------------------------------
 console.log("test-orchestrate.mjs OK");

--- a/merkle-dag/scripts/test-vendor.mjs
+++ b/merkle-dag/scripts/test-vendor.mjs
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
-import { canonicalize, sha256hex, resolveUnder, maxConcurrency } from "../vendor.mjs";
+import { canonicalize, sha256hex, resolveUnder, maxConcurrency, spawnCommand } from "../vendor.mjs";
 
 // canonicalize: key-order independent, ARRAY ORDER PRESERVED
 assert.equal(canonicalize({ b: 1, a: 2 }), canonicalize({ a: 2, b: 1 }), "keys sorted");
@@ -25,5 +26,25 @@ assert.equal(maxConcurrency(1), 1, "maxConcurrency(1) === 1");
 assert.equal(maxConcurrency(undefined), upper, "maxConcurrency(undefined) === upper bound");
 assert.equal(maxConcurrency(0), upper, "maxConcurrency(0) === upper bound");
 assert.equal(maxConcurrency(10_000), upper, "maxConcurrency(10_000) clamps to upper bound");
+
+// spawnCommand: real executables (node) and all of POSIX pass through unchanged;
+// only win32 batch shims (npm) are routed through cmd.exe.
+assert.deepEqual(spawnCommand("node", ["-e", "0"]), { command: "node", args: ["-e", "0"] }, "node passes through unchanged");
+assert.deepEqual(spawnCommand("no-such-cmd-xyz", ["a"]), { command: "no-such-cmd-xyz", args: ["a"] }, "an unresolved command passes through (fail-closed at spawn)");
+if (process.platform === "win32") {
+  const npm = spawnCommand("npm", ["test"]);
+  assert.match(npm.command.toLowerCase(), /cmd\.exe$/, "win32 npm routes through cmd.exe");
+  assert.deepEqual(npm.args.slice(0, 4), ["/d", "/s", "/c", "npm"], "cmd.exe /c wrapper carries the shim + its args");
+}
+
+// Integration: npm must actually run through spawnCommand on THIS platform (win32
+// .cmd shim via cmd.exe, POSIX shebang script directly). Mirrors how ledger-gate
+// spawns a node's test command with spawnSync.
+{
+  const spec = spawnCommand("npm", ["--version"]);
+  const r = spawnSync(spec.command, spec.args, { encoding: "utf8" });
+  assert.equal(r.status, 0, `npm --version must run via spawnCommand; got status=${r.status} err=${r.error?.code || "-"}`);
+  assert.match((r.stdout || "").trim(), /\d+\.\d+\.\d+/, "npm printed a version");
+}
 
 console.log("test-vendor.mjs OK");

--- a/merkle-dag/vendor.mjs
+++ b/merkle-dag/vendor.mjs
@@ -4,6 +4,7 @@
 //   resolveUnder  <- me/codex/breakout/verifier.mjs (path confinement)
 //   maxConcurrency <- concurrency governance (relocated from council.mjs)
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -49,4 +50,38 @@ export function resolveUnder(baseDir, p) {
   const rel = path.relative(baseDir, resolved);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   return resolved;
+}
+
+// True when `cmd` resolves to a Windows batch shim (.cmd/.bat — npm, npx, yarn).
+// Node cannot spawn a batch file directly since the CVE-2024-27980 hardening, so
+// such commands must go through cmd.exe; a real executable (.exe/.com, e.g. node)
+// must NOT, so its args pass literally rather than being re-parsed by a shell.
+// Always false off win32 (POSIX spawns npm's shebang script directly).
+function isWin32BatchShim(cmd) {
+  if (process.platform !== "win32" || typeof cmd !== "string" || !cmd) return false;
+  const isBatch = (name) => /\.(cmd|bat)$/i.test(name);
+  if (path.extname(cmd)) return isBatch(cmd);            // explicit extension: trust it
+  if (cmd.includes("/") || cmd.includes("\\")) {          // explicit path, no extension
+    return existsSync(cmd + ".cmd") || existsSync(cmd + ".bat");
+  }
+  const exts = (process.env.PATHEXT || ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean);
+  for (const dir of (process.env.PATH || "").split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      if (existsSync(path.join(dir, cmd + ext))) return isBatch(ext); // first PATHEXT match wins
+    }
+  }
+  return false;                                           // not found: spawn directly (ENOENT, fail-closed)
+}
+
+// Normalize a { cmd, args } test command into a spawn-ready { command, args } that
+// works cross-platform WITHOUT `shell: true` (which is deprecated and mangles args
+// like `-e "a; b"`). On win32 a batch shim is routed through `cmd.exe /d /s /c`;
+// everything else — and all of POSIX — is passed through unchanged so args stay
+// literal. Use for both spawn and spawnSync.
+export function spawnCommand(cmd, args = []) {
+  if (isWin32BatchShim(cmd)) {
+    return { command: process.env.ComSpec || "cmd.exe", args: ["/d", "/s", "/c", cmd, ...args] };
+  }
+  return { command: cmd, args };
 }


### PR DESCRIPTION
## Summary

The three sites that spawn a node's **test command** — `test-runner.mjs`, `orchestrate.mjs` `runTest`, and `ledger-gate.mjs` `verify` — spawned it directly with no shell. On Windows `npm` is `npm.cmd`, which Node cannot spawn without a shell (`ENOENT`, or `EINVAL` since the CVE-2024-27980 hardening). `teamPrompts` steers existing-project plans toward `{"cmd":"npm","args":["test"]}`, so **every npm-based autonomous build was permanently verify-failed on the dev platform** while passing on ubuntu CI — and the runtime-adaptation loop burned attempts re-prompting a team over a spawn error it can't fix by editing files.

## Why not `shell: true`

It's the obvious "fix" but it's wrong here. `shell: true` is deprecated (DEP0190) and **mangles arguments**. Probed on Windows:

```
shell=true  node -e "console.log('x'); process.exit(4)"  ->  status 0   (WRONG — ';' hit cmd.exe)
shell=false node -e "console.log('x'); process.exit(4)"  ->  status 4   (correct)
```

The test suites themselves run `node -e "process.exit(N)"`, so `shell: true` would silently corrupt their exit codes.

## Fix

Add `spawnCommand(cmd, args)` to `merkle-dag/vendor.mjs` (the shared, dependency-free helper module all three sites already import). On win32 it routes a resolved `.cmd`/`.bat` shim (npm/npx/yarn) through `cmd.exe /d /s /c` so args are **not** re-parsed by a shell; a real executable (`node.exe`) — and all of POSIX — passes through unchanged so args stay literal. Wired into all three spawn sites (`spawn` and `spawnSync`).

Verified on Windows: `npm --version` runs (status 0) via the wrapper; `node -e "a; b"` keeps its literal args; failures propagate; no DEP0190 warning.

## Tests
- `test-vendor.mjs`: `spawnCommand` unit (node/POSIX pass-through; win32 npm → cmd.exe wrapper) + a real `npm --version` run through the transformed spec.
- `test-runtime-adaptation.mjs`: `runNodeTest` runs an npm-based node test (exit 0).
- `test-orchestrate.mjs`: `defaultVerifyNode` runs an npm-based node test.

These pass on **both** platforms — CI (ubuntu) proves the direct-spawn path, a Windows run proves the `cmd.exe` shim.

## Verification
- `cd merkle-dag && npm test`: pass
- `cd build-gate && npm test` (incl. `breakout`): pass
- `cd saas-forge && npm test` / `cd ai-forge && npm test`: pass (node-based tests unaffected)

No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed. Independent of #64, #65, #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
