### PR TITLE
fix(council): derive agy checkpoint inputs from the dossier (stop the rubber stamp)

### DIFF
--- a/ai-forge/live.mjs
+++ b/ai-forge/live.mjs
@@ -19,7 +19,7 @@
 
 import { spawnMcpClient } from "../breakout/mcp_client.mjs";
 import { makeCouncilBreakout } from "../breakout/breakout.mjs";
-import { runCouncil, liveSeatCaller, agyApprovalPacket } from "../build-gate/council.mjs";
+import { runCouncil, liveSeatCaller, agyApprovalPacket, agyCheckpointArgs } from "../build-gate/council.mjs";
 import { forge, syntheticApprovals } from "./forge.mjs";
 import { factBreakout } from "./breakouts.mjs";
 import { ragPattern, ragContext } from "./patterns/rag.mjs";
@@ -67,11 +67,11 @@ export function councilApprovals({ callTool, models = {} }) {
 
     function promptFor(model) {
       if (model === "agy") {
-        return { tool: "agy_checkpoint", args: {
-          phase: "merge-gate", scope: "ai-forge",
-          required_packets: ["claude", "codex"], present_packets: ["claude", "codex"],
-          protected_path_check: "pass"
-        } };
+        // Governance inputs derived from the dossier, not asserted (see
+        // council.agyCheckpointArgs). ai-forge declares no protected/LEXI
+        // constraints, so this honestly resolves to advance rather than a
+        // hardcoded present==required rubber stamp.
+        return { tool: "agy_checkpoint", args: agyCheckpointArgs(dossierMeta, "ai-forge") };
       }
       return {
         tool: `${model}_ask`, model: models[model],

--- a/build-gate/council.mjs
+++ b/build-gate/council.mjs
@@ -151,6 +151,45 @@ function tryParseJson(text) {
  * the council fills these from the dossier; provenance is stamped separately by
  * runSeat from the checkpoint's attestation.
  */
+// Protected-path prefixes the gate treats as off-limits (mirror of gate.mjs's
+// DEFAULT_PROTECTED_PATHS), kept here so the council can DERIVE agy's checkpoint
+// inputs from the dossier instead of asserting them.
+const DEFAULT_PROTECTED_PATHS = ["CHATGPT/", "me/claude-code/", "me/claude-desktop/", "me/gemini/"];
+
+function normalizeGovPath(p) {
+  return String(p).replace(/\\/g, "/").replace(/^\.\//, "").replace(/^\/+/, "").replace(/\/+$/, "").toLowerCase();
+}
+
+/**
+ * Build the agy_checkpoint inputs for a merge-gate governance check FROM the
+ * dossier rather than asserting them. The prior wiring hardcoded
+ * `present_packets == required_packets` and `protected_path_check: "pass"`, so
+ * agyCheckpoint could only ever return "advance" — a REQUIRED governance seat
+ * reduced to a constant approve, with its documented blocking path dead. Here:
+ *   - protected_path_check is DERIVED: "pass" only when no declared write target
+ *     falls under a protected prefix; otherwise a fail reason (agy dissents).
+ *   - lexi_required / lexi_reference_read pass through so agy blocks an unmet LEXI.
+ *   - packet PRESENCE is NOT asserted — the concurrent council can't know it at
+ *     agy's call time, and the gate independently requires every seat's packet.
+ */
+export function agyCheckpointArgs(dossier, scope) {
+  const protectedPaths = [...DEFAULT_PROTECTED_PATHS, ...(Array.isArray(dossier?.protected_paths) ? dossier.protected_paths : [])]
+    .map(normalizeGovPath)
+    .filter(Boolean);
+  let violation = null;
+  for (const target of Array.isArray(dossier?.write_targets) ? dossier.write_targets : []) {
+    const t = normalizeGovPath(target);
+    if (protectedPaths.some((p) => t === p || t.startsWith(p + "/"))) { violation = target; break; }
+  }
+  return {
+    phase: "merge-gate",
+    scope: scope ?? dossier?.use_case ?? "",
+    protected_path_check: violation ? `not-pass: write target '${violation}' is under a protected path` : "pass",
+    lexi_required: dossier?.lexi_required === true,
+    lexi_reference_read: dossier?.lexi_reference_read === true
+  };
+}
+
 export function agyApprovalPacket(checkpoint, meta = {}) {
   const advance = !!checkpoint && checkpoint.phase_gate_status === "advance";
   const blocked = Array.isArray(checkpoint?.blocked_reasons) ? checkpoint.blocked_reasons : [];

--- a/build-gate/scripts/test-council-orchestrator.mjs
+++ b/build-gate/scripts/test-council-orchestrator.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import os from "node:os";
-import { runCouncil, planSeats, maxConcurrency, liveSeatCaller, agyApprovalPacket } from "../council.mjs";
+import { runCouncil, planSeats, maxConcurrency, liveSeatCaller, agyApprovalPacket, agyCheckpointArgs } from "../council.mjs";
 import { verifyPacket } from "../sign.mjs";
 import { validateRecords } from "../gate.mjs";
 // Cross-package (integration): the agy seat consumes the REAL agy_checkpoint
@@ -232,6 +232,28 @@ const okSeatCaller = async ({ model }) => ({
   assert.ok(blockedPkt.hard_stops.length > 0, "blocked checkpoint carries hard_stops");
   const blockedReport = validateRecords(dossier, [blockedPkt, mkApprover("claude"), mkApprover("codex")]);
   assert.ok(blockedReport.blockers.some((b) => /agy/i.test(b)), "a blocked agy checkpoint must block the gate");
+}
+
+// --- agyCheckpointArgs: the required agy seat DERIVES its checkpoint inputs from
+// the dossier so it can actually dissent (no hardcoded present==required stamp) ---
+{
+  // Clean dossier -> pass -> advance -> agy approves.
+  const clean = agyCheckpointArgs({ use_case: "u", write_targets: ["src/app.mjs"] }, "s");
+  assert.equal(clean.protected_path_check, "pass", "no protected write target => pass");
+  assert.equal(clean.present_packets, undefined, "packet presence is not asserted (the gate enforces it)");
+  assert.equal(agyCheckpoint(clean).phase_gate_status, "advance", "clean dossier => agy advances");
+  assert.equal(agyApprovalPacket(agyCheckpoint(clean)).decision, "approve", "advance => approve");
+
+  // A write target under a protected prefix -> not pass -> blocked -> agy revises.
+  const guarded = agyCheckpointArgs({ write_targets: ["me/gemini/scratch.md"] }, "s");
+  assert.notEqual(guarded.protected_path_check, "pass", "protected write target => not pass");
+  assert.equal(agyCheckpoint(guarded).phase_gate_status, "blocked", "protected write => agy blocks");
+  assert.equal(agyApprovalPacket(agyCheckpoint(guarded)).decision, "revise", "blocked => revise (agy dissents)");
+
+  // LEXI required but not read -> blocked.
+  const lexi = agyCheckpointArgs({ lexi_required: true, lexi_reference_read: false }, "s");
+  assert.equal(agyCheckpoint(lexi).phase_gate_status, "blocked", "LEXI required but unread => agy blocks");
+  console.log("agyCheckpointArgs derivation OK");
 }
 
 console.log("test-council-orchestrator.mjs OK");

--- a/build-gate/scripts/test-team-prompts.mjs
+++ b/build-gate/scripts/test-team-prompts.mjs
@@ -73,7 +73,11 @@ import { buildableSeat, promptForTeam, nodeBuildPrompt, parseTeamFiles, makeLive
   const promptFor = approvalPromptFor({ build_id: "b", use_case: "u", objective: "ship it" }, { models: { claude: "claude-sonnet-4-6" } });
   const agy = promptFor("agy", "approver");
   assert.equal(agy.tool, "agy_checkpoint", "agy uses the structured checkpoint tool");
-  assert.equal(agy.args.protected_path_check, "pass", "agy checkpoint carries governance args");
+  assert.equal(agy.args.protected_path_check, "pass", "a dossier with no protected writes derives protected_path_check:'pass'");
+  assert.equal(agy.args.present_packets, undefined, "packet presence is no longer asserted (the gate enforces it)");
+  // Derived, not asserted: a dossier writing under a protected path makes agy dissent.
+  const guardedAgy = approvalPromptFor({ build_id: "b", use_case: "u", objective: "x", write_targets: ["me/claude-code/notes.md"] })("agy", "approver");
+  assert.notEqual(guardedAgy.args.protected_path_check, "pass", "a protected write target must not derive protected_path_check:'pass'");
   const claude = promptFor("claude", "approver");
   assert.equal(claude.tool, "claude_ask", "chat seats use their ask tool");
   assert.equal(claude.model, "claude-sonnet-4-6", "per-seat model id is threaded through");

--- a/build-gate/teamPrompts.mjs
+++ b/build-gate/teamPrompts.mjs
@@ -8,7 +8,7 @@
 // the gate honest-blocks), mirroring the existing `smoke` scripts. The pure
 // prompt/parse helpers are unit-tested without a network.
 
-import { agyApprovalPacket } from "./council.mjs";
+import { agyApprovalPacket, agyCheckpointArgs } from "./council.mjs";
 import { SCHEMAS } from "./schemas.mjs";
 
 // Chat seats expose an `<model>_ask` tool; agy is structured (no code generation).
@@ -141,8 +141,9 @@ const PACKET_INSTRUCTION =
 export function approvalPromptFor(dossier, { models = {} } = {}) {
   return (model, role, _dossier, workstream) => {
     if (model === "agy") {
-      // A real governance checkpoint: required packets present, paths clean.
-      return { tool: "agy_checkpoint", args: { phase: "merge-gate", scope: dossier?.use_case ?? "", required_packets: ["claude", "codex"], present_packets: ["claude", "codex"], protected_path_check: "pass" } };
+      // Governance checkpoint DERIVED from the dossier (protected paths + LEXI),
+      // not asserted — so agy can actually dissent (see council.agyCheckpointArgs).
+      return { tool: "agy_checkpoint", args: agyCheckpointArgs(dossier, dossier?.use_case) };
     }
     const lens = workstream ? `, workstream lens: ${workstream}` : "";
     return {

--- a/saas-forge/live.mjs
+++ b/saas-forge/live.mjs
@@ -12,7 +12,7 @@
 
 import { spawnMcpClient } from "../breakout/mcp_client.mjs";
 import { makeCouncilBreakout } from "../breakout/breakout.mjs";
-import { runCouncil, liveSeatCaller, agyApprovalPacket } from "../build-gate/council.mjs";
+import { runCouncil, liveSeatCaller, agyApprovalPacket, agyCheckpointArgs } from "../build-gate/council.mjs";
 import { forge } from "./forge.mjs";
 import { factBreakout } from "./breakouts.mjs";
 import { workstreamById } from "./workstreams.mjs";
@@ -51,11 +51,9 @@ export function councilApprovals({ callTool, models = {} }) {
 
     function promptFor(model) {
       if (model === "agy") {
-        return { tool: "agy_checkpoint", args: {
-          phase: "merge-gate", scope: "saas-forge",
-          required_packets: ["claude", "codex"], present_packets: ["claude", "codex"],
-          protected_path_check: "pass"
-        } };
+        // Governance inputs derived from the dossier, not asserted (see
+        // council.agyCheckpointArgs) — no hardcoded present==required rubber stamp.
+        return { tool: "agy_checkpoint", args: agyCheckpointArgs(dossierMeta, "saas-forge") };
       }
       return {
         tool: `${model}_ask`, model: models[model],


### PR DESCRIPTION
## Summary

The three live wirings that feed the **required** `agy` governance seat hardcoded its `agy_checkpoint` inputs:

```js
{ required_packets: ["claude","codex"], present_packets: ["claude","codex"], protected_path_check: "pass" }
```

Since `agyCheckpoint` is pure over its args, `present_packets == required_packets` + `protected_path_check: "pass"` means it can **only** ever return `phase_gate_status: "advance"` → `agyApprovalPacket` → decision `"approve"`. So agy always approved — one of the gate's three required seats reduced to a compile-time constant, with its documented `revise`/`hard_stops` path dead code. (The controller is trusted, so this was never a forgery hole — but a required governance check that can never dissent adds no verification.)

Worse, `present_packets: ["claude","codex"]` is asserted while those seats are *still running* in the concurrent `runCouncil` fan-out — a self-report of state that hasn't been established.

## Fix

Add `council.agyCheckpointArgs(dossier, scope)` and use it at all three sites (`teamPrompts.approvalPromptFor`, `ai-forge/live`, `saas-forge/live`). It **derives** the two signals agy can legitimately evaluate at its call time from the trusted dossier:

- `protected_path_check`: `"pass"` only when no declared write target falls under a protected prefix (`CHATGPT/`, `me/claude-code/`, … + `dossier.protected_paths`); otherwise a fail reason → agy blocks → decision `"revise"`.
- `lexi_required` / `lexi_reference_read` pass through → agy blocks an unmet LEXI requirement.

Packet **presence is no longer asserted** — the concurrent council can't know it at agy's call time, and the gate independently requires every seat's packet (`REQUIRED_MODELS`). agy's approval is now a real function of the build request instead of a constant.

The forge dossiers declare no protected-path or LEXI constraints, so they honestly resolve to `advance` (nothing to gate) rather than via a hardcoded stamp — same outcome, honest mechanism, and it *would* block if a constraint appeared.

## Tests
- `test-council-orchestrator.mjs`: `agyCheckpointArgs` derivation end-to-end — clean dossier → `advance` → `approve`; a write target under a protected prefix → `blocked` → `revise` (agy dissents); unmet LEXI → `blocked`.
- `test-team-prompts.mjs`: `approvalPromptFor` derives `protected_path_check` (a protected write target no longer yields `"pass"`) and drops the asserted `present_packets`.

## Verification
- `cd build-gate && npm test` (incl. `breakout`): pass
- `cd saas-forge && npm test` / `cd ai-forge && npm test`: pass

No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed. Independent of #64/#65/#66/#67 (only `ai-forge/live.mjs` also appears in #64, in a far-apart function — clean auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
