### PR TITLE
feat(forge): signed-mode opt-in for ai-forge and saas-forge

### DIFF
--- a/ai-forge/breakouts.mjs
+++ b/ai-forge/breakouts.mjs
@@ -57,7 +57,7 @@ export async function runPatternBreakouts({ pattern, ctx, baseDir, maxRounds = 3
       fns
     );
     // Attach the deterministic specs so the gate can independently re-verify.
-    records.push({ ...record, checks, lens: ws.lens, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+    records.push({ ...record, checks, lens: ws.lens, signer: ws.signer, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
   }
   return records;
 }

--- a/ai-forge/forge.mjs
+++ b/ai-forge/forge.mjs
@@ -27,6 +27,7 @@ import { generateKeypair } from "../merkle-dag/crypto.mjs";
 import { computePlan, writePlan } from "../merkle-dag/merkle.mjs";
 import { runBuild } from "../merkle-dag/orchestrate.mjs";
 import { validateRecords } from "../build-gate/gate.mjs";
+import { signMarketPacket } from "../build-gate/sign.mjs";
 import { validatePattern, patternTaskDefs, signerForTask } from "./pattern.mjs";
 import { generatorDispatch, makePatternGenerators } from "./generators.mjs";
 import { runPatternBreakouts } from "./breakouts.mjs";
@@ -37,7 +38,7 @@ const TS = "2026-06-29T00:00:00-04:00";
 // record. The breakout's checks point at the workstream's generated artifacts, so
 // the gate re-verifies on disk the very files the build produced.
 // Mirrors saas-forge/forge.mjs's marketPacketFromRecord.
-function marketPacketFromRecord(record, dossierMeta) {
+function marketPacketFromRecord(record, dossierMeta, { signed = false } = {}) {
   const packet = {
     build_id: dossierMeta.build_id,
     idea_id: dossierMeta.idea_id,
@@ -70,7 +71,7 @@ function marketPacketFromRecord(record, dossierMeta) {
     timestamp: TS
   };
   packet[record.findingsKey] = [record.finding];
-  return packet;
+  return signed ? signMarketPacket(packet, record, record.signer) : packet;
 }
 
 // Synthetic council approvals for the keyless/offline path. Marked honestly:
@@ -116,6 +117,7 @@ export async function forge({
   makeGenerators = makePatternGenerators,
   makeBreakoutFns,
   makeApprovals = syntheticApprovals,
+  signed = false,
   maxCycles = 3
 }) {
   // Step 1: validate the pattern; throw immediately on schema errors.
@@ -176,6 +178,7 @@ export async function forge({
         idea_id: dossierMeta.idea_id,
         use_case: dossierMeta.use_case,
         objective: dossierMeta.objective,
+        trust_mode: signed ? "signed" : undefined,
         required_docs: [],
         write_targets: [],
         protected_paths: [],
@@ -185,7 +188,7 @@ export async function forge({
         lexi_required: false,
         required_market_workstreams: pattern.workstreams.map((w) => w.id)
       };
-      const marketPackets = records.map((r) => marketPacketFromRecord(r, dossierMeta));
+      const marketPackets = records.map((r) => marketPacketFromRecord(r, dossierMeta, { signed }));
       verdict = validateRecords(dossier, approvals, { dossierDir: projectRoot }, [], marketPackets);
     } else {
       verdict = null;

--- a/ai-forge/forge.mjs
+++ b/ai-forge/forge.mjs
@@ -105,6 +105,7 @@ export function syntheticApprovals(dossierMeta) {
  *   makeGenerators  (pattern, ctx) -> generateFiles adapter  [default: makePatternGenerators]
  *   makeBreakoutFns optional breakout factory; default = factBreakout (keyless, verdict on disk)
  *   makeApprovals   (dossierMeta) -> packet[]  [default: syntheticApprovals]
+ *   signed          default false; when true, gate runs under trust_mode: "signed"
  *   maxCycles       plan->build->breakout->gate iterations before giving up  [default: 3]
  *
  * Returns { converged, cycles[], records[], verdict }.

--- a/ai-forge/live.mjs
+++ b/ai-forge/live.mjs
@@ -204,6 +204,7 @@ export function liveBoundaries({ embed, vectorStore, callTool }) {
  *   ctx          override the default ragContext
  *   serverPath   path to ai-peer-mcp server.mjs     (live spawn only)
  *   maxCycles    default 3
+ *   signed       default false; when true, gate runs under trust_mode: "signed"
  */
 export async function runForgeLive({
   projectRoot, telos, dossierMeta,

--- a/ai-forge/live.mjs
+++ b/ai-forge/live.mjs
@@ -209,7 +209,7 @@ export async function runForgeLive({
   projectRoot, telos, dossierMeta,
   embed, vectorStore, callTool,
   pattern, ctx,
-  serverPath, maxCycles = 3
+  serverPath, maxCycles = 3, signed = false
 }) {
   const resolvedPattern = pattern || ragPattern;
   const resolvedCtx = ctx || ragContext({ telos });
@@ -255,7 +255,8 @@ export async function runForgeLive({
       makeGenerators,
       makeBreakoutFns,
       makeApprovals,
-      maxCycles
+      maxCycles,
+      signed
     });
   } finally {
     close();

--- a/ai-forge/scripts/test-live.mjs
+++ b/ai-forge/scripts/test-live.mjs
@@ -145,6 +145,46 @@ for (const model of ["claude", "agy", "codex"]) {
     `${model} approval must carry real council provenance, not the synthetic fallback; got ${JSON.stringify(pv)}`);
 }
 
+// --- signed mode: converge THROUGH the hardened signature+provenance gate ---
+// All four model signers used in the RAG pattern need secrets in signed mode:
+// the three required approval seats (claude/agy/codex) AND grok (guardrails
+// workstream signer), because the gate calls enforceSignedPacketAuth on every
+// market packet — not just the required approval trio.
+process.env.TELOS_SECRET_CLAUDE = "test-claude";
+process.env.TELOS_SECRET_AGY = "test-agy";
+process.env.TELOS_SECRET_CODEX = "test-codex";
+process.env.TELOS_SECRET_GROK = "test-grok";
+{
+  const signedRoot = mkdtempSync(path.join(os.tmpdir(), "ai-forge-signed-"));
+  const signedResult = await runForgeLive({
+    projectRoot: signedRoot, telos: ctx.telos, dossierMeta,
+    embed: stubEmbed, vectorStore: stubVectorStore, callTool, signed: true
+  });
+  assert.equal(signedResult.converged, true,
+    `signed-mode live run must converge through the hardened gate; cycles=${JSON.stringify(signedResult.cycles)}`);
+  assert.equal(signedResult.verdict.gate_status, "pass", "signed-mode gate passes");
+  assert.equal(signedResult.verdict.headline_checks.signing_enforced, true, "signing enforced in the verdict");
+  assert.equal(signedResult.verdict.headline_checks.provenance_enforced, true, "provenance enforced in the verdict");
+}
+// negative: a missing required secret must fail closed in signed mode.
+{
+  delete process.env.TELOS_SECRET_CODEX;
+  const failRoot = mkdtempSync(path.join(os.tmpdir(), "ai-forge-signed-fail-"));
+  const failResult = await runForgeLive({
+    projectRoot: failRoot, telos: ctx.telos, dossierMeta,
+    embed: stubEmbed, vectorStore: stubVectorStore, callTool, signed: true
+  });
+  assert.equal(failResult.converged, false, "signed mode without a required secret must not converge");
+  const blockers = (failResult.verdict && failResult.verdict.blockers) || [];
+  assert.ok(blockers.some((b) => /no secret to verify codex|signature invalid/i.test(b)),
+    `expected a fail-closed signature blocker; got ${JSON.stringify(blockers)}`);
+  process.env.TELOS_SECRET_CODEX = "test-codex";
+}
+delete process.env.TELOS_SECRET_CLAUDE;
+delete process.env.TELOS_SECRET_AGY;
+delete process.env.TELOS_SECRET_CODEX;
+delete process.env.TELOS_SECRET_GROK;
+
 console.log(
   `test-live.mjs OK: live path executed — ` +
   `cycles=${result.cycles.length}, converged=${result.converged}, ` +

--- a/build-gate/scripts/test-sign.mjs
+++ b/build-gate/scripts/test-sign.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
-import { canonicalize, signPacket, verifyPacket, secretFor } from "../sign.mjs";
+import { canonicalize, signPacket, verifyPacket, secretFor, signMarketPacket } from "../sign.mjs";
 
 const base = { model: "claude", decision: "approve", build_id: "b1", nested: { b: 2, a: 1 } };
 
@@ -33,5 +33,28 @@ process.env.TELOS_SECRET_CLAUDE = "abc";
 assert.equal(secretFor("claude"), "abc");
 delete process.env.TELOS_SECRET_CLAUDE;
 assert.equal(secretFor("claude"), null);
+
+// signMarketPacket: content-addressed attestation + re-attribution to the signer +
+// HMAC signature under the signer's secret; lens preserved; unsigned without a secret.
+process.env.TELOS_SECRET_CODEX = "cx";
+{
+  const packet = { model: "grok", build_id: "b1", workstreams_reviewed: ["security-trust"] };
+  const record = { workstream: "security-trust", converged: true, checks: [{ type: "file_exists", path: "x" }] };
+  const out = signMarketPacket(packet, record, "codex");
+  assert.equal(out.model, "codex", "market packet re-attributed to the signer");
+  assert.equal(out.reviewed_by_lens, "grok", "the reviewing lens is preserved");
+  assert.equal(out.provenance.model, "codex", "provenance attributed to the signer");
+  assert.match(out.provenance.response_id, /^market-[0-9a-f]{64}$/, "content-addressed market attestation");
+  assert.equal(verifyPacket(out, "cx").ok, true, "signed under the signer's secret");
+  // deterministic: same record -> same attestation id
+  assert.equal(signMarketPacket(packet, record, "codex").provenance.response_id, out.provenance.response_id, "attestation is content-addressed (stable)");
+}
+{
+  const out = signMarketPacket({ model: "grok" }, { workstream: "x" }, "model-without-secret");
+  assert.equal(out.signature, undefined, "no secret => unsigned packet (fail-closed at the gate)");
+  assert.equal(out.model, "model-without-secret", "still re-attributed");
+  assert.match(out.provenance.response_id, /^market-[0-9a-f]{64}$/, "still attested");
+}
+delete process.env.TELOS_SECRET_CODEX;
 
 console.log("test-sign.mjs OK");

--- a/build-gate/sign.mjs
+++ b/build-gate/sign.mjs
@@ -5,7 +5,7 @@
 // rubber-stamping, not a malicious owner — the chosen (honest-but-careless)
 // threat model. Identity here is integrity + binding, not non-repudiation.
 
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { createHmac, timingSafeEqual, createHash } from "node:crypto";
 
 function stripSignature(obj) {
   if (!obj || typeof obj !== "object" || Array.isArray(obj)) return obj;
@@ -46,4 +46,22 @@ export function verifyPacket(packet, secret) {
 export function secretFor(model) {
   if (typeof model !== "string" || !model) return null;
   return process.env["TELOS_SECRET_" + model.toUpperCase()] || null;
+}
+
+// A market-readiness packet is authored by the trusted harness from an on-disk-
+// verified breakout record, so it has no live server response id. In signed mode it
+// is re-attributed to the workstream's SIGNER (a required seat with a secret — never
+// an advisory lens), carries a reproducible content-addressed attestation over the
+// record, and is HMAC-signed. The reviewing `lens` is preserved as `reviewed_by_lens`.
+// Without a secret the packet is returned attested-but-unsigned so the gate blocks it.
+export function signMarketPacket(packet, record, signer) {
+  const digest = createHash("sha256").update(canonicalize(record ?? null)).digest("hex");
+  const stamped = {
+    ...packet,
+    model: signer,
+    reviewed_by_lens: packet.model,
+    provenance: { model: signer, source: "forge/market-attestation", response_id: `market-${digest}` }
+  };
+  const secret = secretFor(signer);
+  return secret ? signPacket(stamped, secret) : stamped;
 }

--- a/build-gate/sign.mjs
+++ b/build-gate/sign.mjs
@@ -50,10 +50,10 @@ export function secretFor(model) {
 
 // A market-readiness packet is authored by the trusted harness from an on-disk-
 // verified breakout record, so it has no live server response id. In signed mode it
-// is re-attributed to the workstream's SIGNER (a required seat with a secret — never
-// an advisory lens), carries a reproducible content-addressed attestation over the
-// record, and is HMAC-signed. The reviewing `lens` is preserved as `reviewed_by_lens`.
-// Without a secret the packet is returned attested-but-unsigned so the gate blocks it.
+// is re-attributed to the workstream's SIGNER (which must have a TELOS_SECRET_*),
+// carries a reproducible content-addressed attestation over the record, and is
+// HMAC-signed. The reviewing `lens` is preserved as `reviewed_by_lens`. Without a
+// secret the packet is returned attested-but-unsigned so the gate blocks it.
 export function signMarketPacket(packet, record, signer) {
   const digest = createHash("sha256").update(canonicalize(record ?? null)).digest("hex");
   const stamped = {

--- a/docs/superpowers/plans/2026-07-02-signed-mode-forge-opt-in.md
+++ b/docs/superpowers/plans/2026-07-02-signed-mode-forge-opt-in.md
@@ -129,6 +129,8 @@ git commit -m "feat(sign): add signMarketPacket (attest + HMAC-sign a market pac
 - Consumes: `signMarketPacket(packet, record, signer)` from Task 1.
 - Produces: `forge({ ..., signed })` and `runForgeLive({ ..., signed })` — when `signed: true`, the gate dossier carries `trust_mode: "signed"` and every market packet is signed via `signMarketPacket(packet, record, record.signer)`.
 
+> **Correction (decided during implementation):** several ai-forge patterns sign guardrail/adversary workstreams with `grok`, so a grok-signed market packet needs `TELOS_SECRET_GROK` in signed mode. The signed-mode test in Step 1 therefore also sets `process.env.TELOS_SECRET_GROK` (and cleans it up). This does not apply to saas-forge (Task 3), whose signers are all `claude`/`codex`.
+
 - [ ] **Step 1: Write the failing test**
 
 Append to `ai-forge/scripts/test-live.mjs` immediately before its final `console.log(...)` call. (`runForgeLive`, `mkdtempSync`, `os`, `path`, `stubEmbed`, `stubVectorStore`, `callTool`, `dossierMeta`, `ctx` are already in scope in that file.)

--- a/docs/superpowers/plans/2026-07-02-signed-mode-forge-opt-in.md
+++ b/docs/superpowers/plans/2026-07-02-signed-mode-forge-opt-in.md
@@ -1,0 +1,483 @@
+# Signed-mode Forge Opt-in Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `ai-forge` and `saas-forge` run their gate under `trust_mode: "signed"` so a live run converges *through* the hardened HMAC-signature + provenance enforcement (PR #66), not around it.
+
+**Architecture:** A new opt-in `signed` flag threads `runForgeLive → forge → the gate dossier` (`trust_mode: "signed"`). Approval packets are already HMAC-signed + provenance-stamped by the live council (`council.runSeat` + `liveSeatCaller`). The only new authored evidence is the market packet: a shared `signMarketPacket` helper re-attributes it to the workstream's *signer* (claude/codex), attaches a content-addressed `market-<sha256(record)>` provenance attestation, and HMAC-signs it. Unsigned/keyless behavior is unchanged.
+
+**Tech Stack:** Node ≥ 18, ESM `.mjs`, `node:crypto` (`createHash`, `createHmac`), existing `build-gate/sign.mjs` (`signPacket`, `verifyPacket`, `secretFor`, `canonicalize`). No test framework — tests are plain `node:assert/strict` scripts run via `npm test`.
+
+## Global Constraints
+
+- Zero runtime dependencies; standard library only, `node:` prefix on stdlib imports. No new npm packages, no lockfile.
+- ESM only (`.mjs`, `"type":"module"`). Match surrounding style: double-quoted strings, semicolons, 2-space indent, small pure functions.
+- Never commit secrets or runtime `.telos/` artifacts. Test HMAC secrets are local `process.env.TELOS_SECRET_*` values set and deleted within the test.
+- Do NOT weaken the gate or the unsigned path. Unsigned/keyless runs and their existing tests must stay byte-for-byte equivalent in behavior.
+- Run the affected package's `npm test` before each commit and report the result.
+
+---
+
+### Task 1: Shared `signMarketPacket` helper
+
+**Files:**
+- Modify: `build-gate/sign.mjs` (add `createHash` to the `node:crypto` import; add exported `signMarketPacket`)
+- Test: `build-gate/scripts/test-sign.mjs` (add a block before the final `console.log`)
+
+**Interfaces:**
+- Consumes: `canonicalize`, `signPacket`, `secretFor` (already in `sign.mjs`).
+- Produces: `signMarketPacket(packet, record, signer) -> packet'` — returns a new packet with `model` set to `signer`, `reviewed_by_lens` set to the original `packet.model`, `provenance = { model: signer, source: "forge/market-attestation", response_id: "market-" + sha256hex(canonicalize(record)) }`, and (when `secretFor(signer)` is truthy) a `signature` field from `signPacket`. When the signer has no secret, the packet is returned attested but **unsigned** (the gate blocks it in signed mode — fail-closed).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `build-gate/scripts/test-sign.mjs` immediately before `console.log("test-sign.mjs OK");`, and add `signMarketPacket` to the import on line 3 (`import { canonicalize, signPacket, verifyPacket, secretFor, signMarketPacket } from "../sign.mjs";`):
+
+```javascript
+// signMarketPacket: content-addressed attestation + re-attribution to the signer +
+// HMAC signature under the signer's secret; lens preserved; unsigned without a secret.
+process.env.TELOS_SECRET_CODEX = "cx";
+{
+  const packet = { model: "grok", build_id: "b1", workstreams_reviewed: ["security-trust"] };
+  const record = { workstream: "security-trust", converged: true, checks: [{ type: "file_exists", path: "x" }] };
+  const out = signMarketPacket(packet, record, "codex");
+  assert.equal(out.model, "codex", "market packet re-attributed to the signer");
+  assert.equal(out.reviewed_by_lens, "grok", "the reviewing lens is preserved");
+  assert.equal(out.provenance.model, "codex", "provenance attributed to the signer");
+  assert.match(out.provenance.response_id, /^market-[0-9a-f]{64}$/, "content-addressed market attestation");
+  assert.equal(verifyPacket(out, "cx").ok, true, "signed under the signer's secret");
+  // deterministic: same record -> same attestation id
+  assert.equal(signMarketPacket(packet, record, "codex").provenance.response_id, out.provenance.response_id, "attestation is content-addressed (stable)");
+}
+{
+  const out = signMarketPacket({ model: "grok" }, { workstream: "x" }, "model-without-secret");
+  assert.equal(out.signature, undefined, "no secret => unsigned packet (fail-closed at the gate)");
+  assert.equal(out.model, "model-without-secret", "still re-attributed");
+  assert.match(out.provenance.response_id, /^market-[0-9a-f]{64}$/, "still attested");
+}
+delete process.env.TELOS_SECRET_CODEX;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd build-gate && node scripts/test-sign.mjs`
+Expected: FAIL — `SyntaxError` / `signMarketPacket is not a function` (not yet exported).
+
+- [ ] **Step 3: Implement `signMarketPacket`**
+
+In `build-gate/sign.mjs`, change the crypto import (line 8) from:
+
+```javascript
+import { createHmac, timingSafeEqual } from "node:crypto";
+```
+
+to:
+
+```javascript
+import { createHmac, timingSafeEqual, createHash } from "node:crypto";
+```
+
+Then append at the end of the file:
+
+```javascript
+// A market-readiness packet is authored by the trusted harness from an on-disk-
+// verified breakout record, so it has no live server response id. In signed mode it
+// is re-attributed to the workstream's SIGNER (a required seat with a secret — never
+// an advisory lens), carries a reproducible content-addressed attestation over the
+// record, and is HMAC-signed. The reviewing `lens` is preserved as `reviewed_by_lens`.
+// Without a secret the packet is returned attested-but-unsigned so the gate blocks it.
+export function signMarketPacket(packet, record, signer) {
+  const digest = createHash("sha256").update(canonicalize(record ?? null)).digest("hex");
+  const stamped = {
+    ...packet,
+    model: signer,
+    reviewed_by_lens: packet.model,
+    provenance: { model: signer, source: "forge/market-attestation", response_id: `market-${digest}` }
+  };
+  const secret = secretFor(signer);
+  return secret ? signPacket(stamped, secret) : stamped;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd build-gate && node scripts/test-sign.mjs`
+Expected: `test-sign.mjs OK`
+
+- [ ] **Step 5: Run the full package suite**
+
+Run: `cd build-gate && npm test`
+Expected: all suites pass (ends with `test-...` OK lines; exit 0).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add build-gate/sign.mjs build-gate/scripts/test-sign.mjs
+git commit -m "feat(sign): add signMarketPacket (attest + HMAC-sign a market packet)"
+```
+
+---
+
+### Task 2: ai-forge signed-mode opt-in
+
+**Files:**
+- Modify: `ai-forge/breakouts.mjs:60` (carry `signer` on records)
+- Modify: `ai-forge/forge.mjs` (import `signMarketPacket`; `signed` param on `forge`; `marketPacketFromRecord` signed branch; dossier `trust_mode`; market map)
+- Modify: `ai-forge/live.mjs` (thread `signed` through `runForgeLive`)
+- Test: `ai-forge/scripts/test-live.mjs` (append a signed positive + negative block)
+
+**Interfaces:**
+- Consumes: `signMarketPacket(packet, record, signer)` from Task 1.
+- Produces: `forge({ ..., signed })` and `runForgeLive({ ..., signed })` — when `signed: true`, the gate dossier carries `trust_mode: "signed"` and every market packet is signed via `signMarketPacket(packet, record, record.signer)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `ai-forge/scripts/test-live.mjs` immediately before its final `console.log(...)` call. (`runForgeLive`, `mkdtempSync`, `os`, `path`, `stubEmbed`, `stubVectorStore`, `callTool`, `dossierMeta`, `ctx` are already in scope in that file.)
+
+```javascript
+// --- signed mode: converge THROUGH the hardened signature+provenance gate ---
+process.env.TELOS_SECRET_CLAUDE = "test-claude";
+process.env.TELOS_SECRET_AGY = "test-agy";
+process.env.TELOS_SECRET_CODEX = "test-codex";
+{
+  const signedRoot = mkdtempSync(path.join(os.tmpdir(), "ai-forge-signed-"));
+  const signedResult = await runForgeLive({
+    projectRoot: signedRoot, telos: ctx.telos, dossierMeta,
+    embed: stubEmbed, vectorStore: stubVectorStore, callTool, signed: true
+  });
+  assert.equal(signedResult.converged, true,
+    `signed-mode live run must converge through the hardened gate; cycles=${JSON.stringify(signedResult.cycles)}`);
+  assert.equal(signedResult.verdict.gate_status, "pass", "signed-mode gate passes");
+  assert.equal(signedResult.verdict.headline_checks.signing_enforced, true, "signing enforced in the verdict");
+  assert.equal(signedResult.verdict.headline_checks.provenance_enforced, true, "provenance enforced in the verdict");
+}
+// negative: a missing required secret must fail closed in signed mode.
+{
+  delete process.env.TELOS_SECRET_CODEX;
+  const failRoot = mkdtempSync(path.join(os.tmpdir(), "ai-forge-signed-fail-"));
+  const failResult = await runForgeLive({
+    projectRoot: failRoot, telos: ctx.telos, dossierMeta,
+    embed: stubEmbed, vectorStore: stubVectorStore, callTool, signed: true
+  });
+  assert.equal(failResult.converged, false, "signed mode without a required secret must not converge");
+  const blockers = (failResult.verdict && failResult.verdict.blockers) || [];
+  assert.ok(blockers.some((b) => /no secret to verify codex|signature invalid/i.test(b)),
+    `expected a fail-closed signature blocker; got ${JSON.stringify(blockers)}`);
+  process.env.TELOS_SECRET_CODEX = "test-codex";
+}
+delete process.env.TELOS_SECRET_CLAUDE;
+delete process.env.TELOS_SECRET_AGY;
+delete process.env.TELOS_SECRET_CODEX;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd ai-forge && node scripts/test-live.mjs`
+Expected: FAIL — the signed run does not converge yet (`gate_status` blocked or `signing_enforced` false), because `forge`/`runForgeLive` do not yet accept or thread `signed`.
+
+- [ ] **Step 3: Carry `signer` on breakout records**
+
+In `ai-forge/breakouts.mjs` line 60, change:
+
+```javascript
+    records.push({ ...record, checks, lens: ws.lens, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+```
+
+to:
+
+```javascript
+    records.push({ ...record, checks, lens: ws.lens, signer: ws.signer, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+```
+
+- [ ] **Step 4: Thread `signed` through `ai-forge/forge.mjs`**
+
+(a) Add the import after the existing `validateRecords` import (near line 29):
+
+```javascript
+import { signMarketPacket } from "../build-gate/sign.mjs";
+```
+
+(b) Change `marketPacketFromRecord`'s signature and its `return` (the function that starts `function marketPacketFromRecord(record, dossierMeta) {`):
+
+```javascript
+function marketPacketFromRecord(record, dossierMeta, { signed = false } = {}) {
+```
+
+and change the final two lines of that function from:
+
+```javascript
+  packet[record.findingsKey] = [record.finding];
+  return packet;
+}
+```
+
+to:
+
+```javascript
+  packet[record.findingsKey] = [record.finding];
+  return signed ? signMarketPacket(packet, record, record.signer) : packet;
+}
+```
+
+(c) Add `signed = false,` to the `forge({ ... })` destructured parameters (after `makeApprovals = syntheticApprovals,`):
+
+```javascript
+  makeApprovals = syntheticApprovals,
+  signed = false,
+  maxCycles = 3
+```
+
+(d) In the `if (allConverged) {` block, add `trust_mode` to the dossier literal (immediately after `objective: dossierMeta.objective,`):
+
+```javascript
+        objective: dossierMeta.objective,
+        trust_mode: signed ? "signed" : undefined,
+```
+
+(e) In the same block, change the market map from:
+
+```javascript
+      const marketPackets = records.map((r) => marketPacketFromRecord(r, dossierMeta));
+```
+
+to:
+
+```javascript
+      const marketPackets = records.map((r) => marketPacketFromRecord(r, dossierMeta, { signed }));
+```
+
+- [ ] **Step 5: Thread `signed` through `ai-forge/live.mjs` `runForgeLive`**
+
+Add `signed = false` to the `runForgeLive({ ... })` destructured parameters (alongside `serverPath, maxCycles = 3`):
+
+```javascript
+  serverPath, maxCycles = 3, signed = false
+```
+
+and add `signed` to the `forge({ ... })` call inside `runForgeLive`:
+
+```javascript
+      makeApprovals,
+      maxCycles,
+      signed
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd ai-forge && node scripts/test-live.mjs`
+Expected: prints the existing `test-live.mjs OK` line with no assertion failures.
+
+If it FAILS on a blocker containing `"existence-only"`: a RAG-pattern workstream's `checks()` is existence-only, which the signed-mode sufficiency floor rejects. Fix by adding one `file_contains` check with a real needle to that workstream's `checks()` in `ai-forge/patterns/rag.mjs` — e.g. `{ type: "file_contains", path: "<that workstream's file>", needle: "<a stable literal already written into that file>" }` — then re-run. (This does not affect unsigned runs.)
+
+- [ ] **Step 7: Run the full package suite**
+
+Run: `cd ai-forge && npm test`
+Expected: all suites pass, exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ai-forge/breakouts.mjs ai-forge/forge.mjs ai-forge/live.mjs ai-forge/scripts/test-live.mjs
+git commit -m "feat(ai-forge): signed-mode gate opt-in (signed flag + signed market packets)"
+```
+
+---
+
+### Task 3: saas-forge signed-mode opt-in
+
+**Files:**
+- Modify: `saas-forge/breakouts.mjs:52` (carry `signer` on records)
+- Modify: `saas-forge/forge.mjs` (import `signMarketPacket`; `signed` param on `forge` and `runMarketGate`; `marketPacketFromRecord` signed branch; dossier `trust_mode`)
+- Modify: `saas-forge/live.mjs` (thread `signed` through `runForgeLive`)
+- Test: `saas-forge/scripts/test-live.mjs` (append a signed positive + negative block)
+
+**Interfaces:**
+- Consumes: `signMarketPacket(packet, record, signer)` from Task 1.
+- Produces: `forge({ ..., signed })` and `runForgeLive({ ..., signed })` with the same semantics as Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `saas-forge/scripts/test-live.mjs` immediately before its final `console.log(...)`. (`forge`, `liveGenerators`, `makeCouncilFactFns`, `councilApprovals`, `mkdtempSync`, `os`, `path`, `dossierMeta`, `telos`, `callTool` are already in scope.)
+
+```javascript
+// --- signed mode: converge THROUGH the hardened signature+provenance gate ---
+process.env.TELOS_SECRET_CLAUDE = "test-claude";
+process.env.TELOS_SECRET_AGY = "test-agy";
+process.env.TELOS_SECRET_CODEX = "test-codex";
+{
+  const signedRoot = mkdtempSync(path.join(os.tmpdir(), "saas-forge-signed-"));
+  const signedResult = await forge({
+    projectRoot: signedRoot, telos, dossierMeta,
+    makeGenerators: liveGenerators({ callTool }),
+    makeBreakoutFns: makeCouncilFactFns({ callTool }),
+    makeApprovals: councilApprovals({ callTool }),
+    signed: true
+  });
+  assert.equal(signedResult.converged, true,
+    `signed-mode forge must converge through the hardened gate; cycles=${JSON.stringify(signedResult.cycles)}`);
+  assert.equal(signedResult.verdict.gate_status, "pass", "signed-mode gate passes");
+  assert.equal(signedResult.verdict.headline_checks.signing_enforced, true, "signing enforced in the verdict");
+  assert.equal(signedResult.verdict.headline_checks.provenance_enforced, true, "provenance enforced in the verdict");
+}
+// negative: a missing required secret must fail closed in signed mode.
+{
+  delete process.env.TELOS_SECRET_CODEX;
+  const failRoot = mkdtempSync(path.join(os.tmpdir(), "saas-forge-signed-fail-"));
+  const failResult = await forge({
+    projectRoot: failRoot, telos, dossierMeta,
+    makeGenerators: liveGenerators({ callTool }),
+    makeBreakoutFns: makeCouncilFactFns({ callTool }),
+    makeApprovals: councilApprovals({ callTool }),
+    signed: true
+  });
+  assert.equal(failResult.converged, false, "signed mode without a required secret must not converge");
+  const blockers = (failResult.verdict && failResult.verdict.blockers) || [];
+  assert.ok(blockers.some((b) => /no secret to verify codex|signature invalid/i.test(b)),
+    `expected a fail-closed signature blocker; got ${JSON.stringify(blockers)}`);
+  process.env.TELOS_SECRET_CODEX = "test-codex";
+}
+delete process.env.TELOS_SECRET_CLAUDE;
+delete process.env.TELOS_SECRET_AGY;
+delete process.env.TELOS_SECRET_CODEX;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd saas-forge && node scripts/test-live.mjs`
+Expected: FAIL — the signed run does not converge yet (`forge`/`runMarketGate` ignore `signed`).
+
+- [ ] **Step 3: Carry `signer` on breakout records**
+
+In `saas-forge/breakouts.mjs` line 52, change:
+
+```javascript
+    records.push({ ...record, checks, lens: ws.lens, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+```
+
+to:
+
+```javascript
+    records.push({ ...record, checks, lens: ws.lens, signer: ws.signer, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+```
+
+- [ ] **Step 4: Thread `signed` through `saas-forge/forge.mjs`**
+
+(a) Add the import after the existing `validateRecords` import (near line 17):
+
+```javascript
+import { signMarketPacket } from "../build-gate/sign.mjs";
+```
+
+(b) Change `marketPacketFromRecord`'s signature (from `function marketPacketFromRecord(record, dossierMeta) {`):
+
+```javascript
+function marketPacketFromRecord(record, dossierMeta, { signed = false } = {}) {
+```
+
+and change its final two lines from:
+
+```javascript
+  packet[record.findingsKey] = [record.finding];
+  return packet;
+}
+```
+
+to:
+
+```javascript
+  packet[record.findingsKey] = [record.finding];
+  return signed ? signMarketPacket(packet, record, record.signer) : packet;
+}
+```
+
+(c) Change `runMarketGate` to accept and use `signed`. Change its signature from `function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals }) {` to:
+
+```javascript
+function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals, signed = false }) {
+```
+
+Add `trust_mode` to its dossier literal (immediately after `objective: dossierMeta.objective,`):
+
+```javascript
+    objective: dossierMeta.objective,
+    trust_mode: signed ? "signed" : undefined,
+```
+
+and change its market map from:
+
+```javascript
+  const marketPackets = teamRecords.map((r) => marketPacketFromRecord(r, dossierMeta));
+```
+
+to:
+
+```javascript
+  const marketPackets = teamRecords.map((r) => marketPacketFromRecord(r, dossierMeta, { signed }));
+```
+
+(d) Add `signed = false,` to the `forge({ ... })` destructured parameters (after `makeApprovals = async ({ dossierMeta: dm }) => syntheticApprovals(dm),`):
+
+```javascript
+  makeApprovals = async ({ dossierMeta: dm }) => syntheticApprovals(dm),
+  signed = false,
+  maxCycles = 3
+```
+
+(e) Pass `signed` into the `runMarketGate` call. Change line 161 from:
+
+```javascript
+    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams, approvals }) : null;
+```
+
+to:
+
+```javascript
+    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams, approvals, signed }) : null;
+```
+
+- [ ] **Step 5: Thread `signed` through `saas-forge/live.mjs` `runForgeLive`**
+
+Add `signed = false` to the `runForgeLive({ ... })` destructured parameters (alongside `team, reviewer, maxCycles = 3`):
+
+```javascript
+  team, reviewer, maxCycles = 3, signed = false
+```
+
+and add `signed` to the `forge({ ... })` call inside `runForgeLive`:
+
+```javascript
+      makeApprovals: councilApprovals({ callTool }),
+      maxCycles,
+      signed
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `cd saas-forge && node scripts/test-live.mjs`
+Expected: prints the existing `test-live OK: ...` line with no assertion failures. (All saas-forge workstream `checks()` already include a `file_contains`, so the signed-mode sufficiency floor is satisfied. If a future workstream is existence-only and blocks on `"existence-only"`, add a `file_contains` check to its `checks()` in `saas-forge/workstreams.mjs`.)
+
+- [ ] **Step 7: Run the full package suite**
+
+Run: `cd saas-forge && npm test`
+Expected: all suites pass, exit 0.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add saas-forge/breakouts.mjs saas-forge/forge.mjs saas-forge/live.mjs saas-forge/scripts/test-live.mjs
+git commit -m "feat(saas-forge): signed-mode gate opt-in (signed flag + signed market packets)"
+```
+
+---
+
+## Cross-package verification (after all tasks)
+
+- [ ] Run every affected package suite once more: `cd build-gate && npm test`, `cd ai-forge && npm test`, `cd saas-forge && npm test`. All exit 0.
+- [ ] Confirm no `.telos/` artifacts or secrets were staged: `git status --short` shows only the intended source/test files.
+
+## Self-Review (completed while writing this plan)
+
+**Spec coverage:** toggle (explicit `signed` flag) → Tasks 2/3 Steps 4–5; approval packets already signed → no code (verified: `council.runSeat` signs with `secretFor` + `liveSeatCaller` provenance); market packets signed + attested → Task 1 + Tasks 2/3 Step 4b; `signer` on records → Tasks 2/3 Step 3; `reviewed_by_lens` preserved → Task 1; unsigned unchanged → signed branch is gated on `signed`, default `false`; tests incl. negative fail-closed → Tasks 2/3 Step 1; content-addressed `market-<sha256(record)>` → Task 1. All covered.
+
+**Placeholder scan:** none — every step shows the exact edit. The one conditional ("if it blocks on existence-only") is a concrete, code-showing contingency, not a TODO.
+
+**Type/name consistency:** `signMarketPacket(packet, record, signer)` is defined in Task 1 and consumed with that exact signature in Tasks 2/3. `record.signer` is produced in Step 3 of Tasks 2/3 and read in `marketPacketFromRecord`. `signed` flag name is consistent across `forge`, `runForgeLive`, `runMarketGate`, and `marketPacketFromRecord`. Verdict fields (`headline_checks.signing_enforced`, `.provenance_enforced`, `.gate_status`, `.blockers`) match `build-gate/gate.mjs`.

--- a/docs/superpowers/specs/2026-07-01-signed-mode-forge-opt-in-design.md
+++ b/docs/superpowers/specs/2026-07-01-signed-mode-forge-opt-in-design.md
@@ -1,0 +1,137 @@
+# Signed-mode forge opt-in — design
+
+**Date:** 2026-07-01
+**Status:** approved (brainstorm), pending implementation plan
+**Depends on:** PR #66 (signed-mode packet authentication), merged to `main` as `7814378`
+
+## Motivation
+
+`ai-forge` and `saas-forge` drive a project to a gate-certified state, but they build the
+gate dossier with **no `trust_mode`**, so the gate runs unsigned: HMAC signatures and
+provenance are never enforced on any packet the forge produces. PR #66 hardened signed
+mode so it now enforces signature + provenance on **all** evidence packets (approval,
+market, capability) and blocks cross-seat id reuse. This opt-in lets the forges run their
+gate under `trust_mode: "signed"` so their live runs actually exercise that hardened
+enforcement — closing the gap where a "live" forge pass never proved anything was signed.
+
+## Goals
+
+- A caller can run either forge in signed mode and have it converge **through** the real
+  signature + provenance gate (not around it).
+- Fail-closed: if signed mode is requested but the required secrets or real council packets
+  are absent, the gate blocks — a demo can never be mistaken for a signed pass.
+- Zero behavior change for existing unsigned runs (keyless demos, current tests).
+
+## Non-goals
+
+- No change to the merkle-dag Ed25519 ledger/build signing (separate mechanism, already
+  always signed).
+- No capability packets — the forges don't produce them, so signed-mode capability
+  enforcement is out of scope here.
+- No new API calls per workstream (market provenance is content-addressed, not live).
+
+## Design
+
+### 1. Toggle — explicit `signed` flag
+
+A new `signed: boolean` option (default `false`) threads:
+
+```
+runForgeLive({ ..., signed })  ->  forge({ ..., signed })  ->  dossier.trust_mode = signed ? "signed" : undefined
+```
+
+Signed mode is a **live-only** path. The keyless `syntheticApprovals` fallback carries no
+signature or provenance, so it cannot satisfy signed mode; that is intentional and
+fail-closed. If `signed: true` but a required `TELOS_SECRET_*` is unset, `council.runSeat`
+emits an unsigned packet and the gate blocks with `"... signature invalid in signed mode"`
+— the failure is a gate blocker, surfaced in the forge result, not a silent downgrade.
+
+### 2. Approval packets — no new code
+
+`council.runSeat` already HMAC-signs each seat's packet with `secretFor(model)` when the
+secret is present, and `liveSeatCaller` already stamps real provenance (the server-issued
+`response_id`, or agy's `agy-<sha256>` content attestation). So in the live path with
+secrets set, the claude/agy/codex approval trio is already signed + provenance-bound. The
+only requirement signed mode adds is that the run go through the **live council** (not the
+synthetic fallback) with secrets present.
+
+### 3. Market packets — sign + content-addressed attestation
+
+`marketPacketFromRecord(record, dossierMeta, { signed })` gains signed-mode behavior:
+
+- **Provenance:** attach `provenance: { model: <signer>, source: "forge/market-attestation",
+  response_id: "market-<sha256(canonical breakout record)>" }`. The breakout record was
+  already re-verified on disk by the gate, so a content hash over it is a reproducible,
+  non-fabricated binding — mirroring the agy local attestation. Each workstream's record is
+  distinct, so the ids are unique.
+- **Signature:** `signPacket(packet, secretFor(signer))`.
+- **Signing identity — `signer`, not `lens`:** the packet's `model` is set to the
+  workstream's `signer` (always `claude`/`codex`, which must have secrets in signed mode
+  anyway), not its `lens` (which includes advisory `grok`/`agy`). A market packet is
+  harness-derived from a disk-verified record, so the honest cryptographic identity is the
+  trusted controller signing with a required-seat secret — *who signs* is not *who
+  reviewed*. The reviewing `lens` is preserved as a descriptive `reviewed_by_lens` field on
+  the packet (non-load-bearing; the gate keys coverage off `workstreams_reviewed`, not
+  `model`). This avoids forcing operators to provision `TELOS_SECRET_GROK`.
+
+In **unsigned mode nothing changes**: `packet.model = lens`, no provenance, no signature.
+
+The workstream config must expose `signer` to the market-packet builder. In `saas-forge`
+`workstreams.mjs` each entry already has `signer`; in `ai-forge` the pattern workstreams
+have `signer`. The breakout record carries `lens` today; it must also carry `signer` (add
+it alongside `lens` where records are assembled in `breakouts.mjs`).
+
+### 4. Data flow (signed live run)
+
+```
+runForgeLive({ signed: true, callTool })
+  -> councilApprovals (live): claude/agy/codex packets, HMAC-signed by runSeat + real provenance
+  -> forge({ signed: true }): build -> per-workstream breakout (verdict on disk)
+  -> marketPacketFromRecord(record, meta, { signed: true }):
+       model = record.signer; provenance = market-<sha256(record)>; signPacket(_, secretFor(signer))
+  -> dossier.trust_mode = "signed"
+  -> validateRecords(dossier, approvals, source, [], marketPackets)
+       -> #66 enforces: approval trio signed+provenance; every market packet signed+provenance
+  -> gate_status "pass" only if every packet authenticates AND breakout re-verify passes
+```
+
+## Error handling / fail-closed
+
+- Missing `TELOS_SECRET_<signer>` in signed mode → market packet unsigned → gate blocker
+  `"Market readiness packet for <signer> signature invalid in signed mode"`.
+- Missing approval-seat secret → approval packet unsigned → gate blocker.
+- Synthetic fallback used in signed mode (e.g. live council threw) → unsigned/no-provenance
+  → gate blocks. Signed mode never converges on synthetic approvals.
+- All blockers surface in `forge()`'s returned `verdict.blockers` and `converged: false`.
+
+## Testing
+
+Existing unsigned keyless tests are untouched and must stay green.
+
+New per-forge signed-mode integration test (keyless HMAC secrets, stub transport):
+
+1. Set `process.env.TELOS_SECRET_CLAUDE/AGY/CODEX` to test values (as `test-trust.mjs` does).
+2. Stub `callTool` returns, for chat seats, a `{text, provenance:{response_id}}` envelope so
+   `liveSeatCaller` binds real-ish provenance; for `agy_checkpoint`, an advancing checkpoint.
+3. `const r = await runForgeLive({ ..., signed: true, callTool })`.
+4. Assert `r.converged === true`, `r.verdict.gate_status === "pass"`,
+   `r.verdict.headline_checks.signing_enforced === true` and `provenance_enforced === true`.
+5. Negative: with one required secret unset, assert `r.converged === false` and a blocker
+   mentioning `"signature invalid in signed mode"` — proving fail-closed.
+
+Unit test for the market-packet builder: in signed mode it produces a packet whose
+`signature` verifies under `secretFor(signer)` and whose `provenance.response_id` matches
+`/^market-[0-9a-f]+$/`; in unsigned mode it produces neither.
+
+## Files touched (anticipated)
+
+- `ai-forge/forge.mjs` — `signed` option; `marketPacketFromRecord` signed branch; dossier
+  `trust_mode`.
+- `ai-forge/live.mjs` — thread `signed` through `runForgeLive`.
+- `ai-forge/breakouts.mjs` — carry `signer` on records.
+- `saas-forge/forge.mjs`, `saas-forge/live.mjs`, `saas-forge/breakouts.mjs` — same.
+- Tests: `ai-forge/scripts/test-forge.mjs` (or `test-live.mjs`), `saas-forge` equivalents.
+
+Constraints (CLAUDE.md): zero runtime deps, ESM `.mjs`, `node:` imports; reuse
+`signPacket`/`secretFor` from `build-gate/sign.mjs` and the existing canonicalization; no
+committed secrets or `.telos/` artifacts.

--- a/docs/superpowers/specs/2026-07-01-signed-mode-forge-opt-in-design.md
+++ b/docs/superpowers/specs/2026-07-01-signed-mode-forge-opt-in-design.md
@@ -66,13 +66,20 @@ synthetic fallback) with secrets present.
   distinct, so the ids are unique.
 - **Signature:** `signPacket(packet, secretFor(signer))`.
 - **Signing identity — `signer`, not `lens`:** the packet's `model` is set to the
-  workstream's `signer` (always `claude`/`codex`, which must have secrets in signed mode
-  anyway), not its `lens` (which includes advisory `grok`/`agy`). A market packet is
-  harness-derived from a disk-verified record, so the honest cryptographic identity is the
-  trusted controller signing with a required-seat secret — *who signs* is not *who
-  reviewed*. The reviewing `lens` is preserved as a descriptive `reviewed_by_lens` field on
-  the packet (non-load-bearing; the gate keys coverage off `workstreams_reviewed`, not
-  `model`). This avoids forcing operators to provision `TELOS_SECRET_GROK`.
+  workstream's `signer`, not its `lens`. A market packet is harness-derived from a
+  disk-verified record, so the honest cryptographic identity is the trusted controller
+  signing with the workstream's signer secret — *who signs* is not *who reviewed*. The
+  reviewing `lens` is preserved as a descriptive `reviewed_by_lens` field on the packet
+  (non-load-bearing; the gate keys coverage off `workstreams_reviewed`, not `model`).
+- **Secret requirement (decided during implementation):** signed mode requires a
+  `TELOS_SECRET_<SIGNER>` for **every** workstream signer, because the gate authenticates
+  each market packet by `secretFor(packet.model)`. In `saas-forge` all signers are
+  `claude`/`codex`, so the approval-trio secrets suffice. In `ai-forge`, several patterns
+  sign guardrail/adversary workstreams with `grok`, so **`ai-forge` signed mode also
+  requires `TELOS_SECRET_GROK`**. A missing signer secret leaves that market packet
+  unsigned and the gate blocks it (fail-closed). (An earlier "sign by signer avoids
+  advisory secrets" rationale was based on a saas-forge-only survey and does not hold for
+  ai-forge; requiring the grok secret was the chosen resolution.)
 
 In **unsigned mode nothing changes**: `packet.model = lens`, no provenance, no signature.
 

--- a/saas-forge/breakouts.mjs
+++ b/saas-forge/breakouts.mjs
@@ -49,7 +49,7 @@ export async function runTeamBreakouts({ baseDir, architecture, maxRounds = 3, m
       fns
     );
     // Attach the deterministic specs so the gate can independently re-verify.
-    records.push({ ...record, checks, lens: ws.lens, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
+    records.push({ ...record, checks, lens: ws.lens, signer: ws.signer, isUi: !!ws.isUi, finding: ws.finding, findingsKey: ws.findingsKey });
   }
   return records;
 }

--- a/saas-forge/forge.mjs
+++ b/saas-forge/forge.mjs
@@ -15,6 +15,7 @@ import { generateKeypair } from "../merkle-dag/crypto.mjs";
 import { writePlan } from "../merkle-dag/merkle.mjs";
 import { runBuild } from "../merkle-dag/orchestrate.mjs";
 import { validateRecords } from "../build-gate/gate.mjs";
+import { signMarketPacket } from "../build-gate/sign.mjs";
 import { researchArchitecture, offlineDocsFor } from "./research.mjs";
 import { compileConvergencePlan, signerForTask } from "./plan.mjs";
 import { generatorDispatch, makeDemoGenerators } from "./generator.mjs";
@@ -25,7 +26,7 @@ const TS = "2026-06-28T00:00:00-04:00";
 // One market-readiness packet per team, generated FROM its breakout record. The
 // breakout's checks point at the team's generated artifacts, so the gate
 // re-verifies on disk the very files the build produced.
-function marketPacketFromRecord(record, dossierMeta) {
+function marketPacketFromRecord(record, dossierMeta, { signed = false } = {}) {
   const packet = {
     build_id: dossierMeta.build_id,
     idea_id: dossierMeta.idea_id,
@@ -58,7 +59,7 @@ function marketPacketFromRecord(record, dossierMeta) {
     timestamp: TS
   };
   packet[record.findingsKey] = [record.finding];
-  return packet;
+  return signed ? signMarketPacket(packet, record, record.signer) : packet;
 }
 
 // Synthetic council approvals for the keyless/offline path. Marked honestly:
@@ -84,12 +85,13 @@ export function syntheticApprovals(dossierMeta) {
 // The REQUIRED-seat approval packets are produced by the seats (or the synthetic
 // fallback) — NEVER fabricated inside the gate call. A dissenting seat
 // (decision != approve) or absent provenance fails the gate closed.
-function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals }) {
+function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals, signed = false }) {
   const dossier = {
     build_id: dossierMeta.build_id,
     idea_id: dossierMeta.idea_id,
     use_case: dossierMeta.use_case,
     objective: dossierMeta.objective,
+    trust_mode: signed ? "signed" : undefined,
     required_docs: [],
     write_targets: [],
     protected_paths: [],
@@ -100,7 +102,7 @@ function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals }) {
     required_market_workstreams: dossierMeta.required_market_workstreams
   };
 
-  const marketPackets = teamRecords.map((r) => marketPacketFromRecord(r, dossierMeta));
+  const marketPackets = teamRecords.map((r) => marketPacketFromRecord(r, dossierMeta, { signed }));
   return validateRecords(dossier, approvals, { dossierDir: projectRoot }, [], marketPackets);
 }
 
@@ -122,6 +124,7 @@ export async function forge({
   makeGenerators = makeDemoGenerators,
   makeBreakoutFns,
   makeApprovals = async ({ dossierMeta: dm }) => syntheticApprovals(dm),
+  signed = false,
   maxCycles = 3
 }) {
   const telosDir = path.join(projectRoot, ".telos");
@@ -158,7 +161,7 @@ export async function forge({
     // Required-seat approvals come from the seats (live) or the synthetic
     // fallback (offline) — produced here, then handed to the gate.
     const approvals = teamsConverged ? await makeApprovals({ dossierMeta, architecture }) : [];
-    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams, approvals }) : null;
+    verdict = teamsConverged ? runMarketGate({ projectRoot, dossierMeta, teamRecords: teams, approvals, signed }) : null;
 
     cycles.push({
       cycle,

--- a/saas-forge/forge.mjs
+++ b/saas-forge/forge.mjs
@@ -114,6 +114,7 @@ function runMarketGate({ projectRoot, dossierMeta, teamRecords, approvals, signe
  *   docsFor       research adapter (default offline; live = Context7)
  *   makeGenerators(arch) -> generateFiles (default keyless demo team renderers)
  *   maxCycles     research->build->breakout->gate iterations before giving up
+ *   signed        default false; when true, gate runs under trust_mode: "signed"
  * Returns { converged, cycles[], teams[], architecture, verdict }.
  */
 export async function forge({

--- a/saas-forge/live.mjs
+++ b/saas-forge/live.mjs
@@ -162,7 +162,7 @@ export function makeCouncilFactFns({ callTool, team, reviewer, challengerTool, c
  */
 export async function runForgeLive({
   projectRoot, telos, dossierMeta, serverPath, docsFor,
-  team, reviewer, maxCycles = 3
+  team, reviewer, maxCycles = 3, signed = false
 }) {
   const { client, close } = spawnMcpClient({ serverPath });
   const callTool = (name, args) => client.callTool(name, args);
@@ -172,7 +172,8 @@ export async function runForgeLive({
       makeGenerators: liveGenerators({ callTool }),
       makeBreakoutFns: makeCouncilFactFns({ callTool, team, reviewer }),
       makeApprovals: councilApprovals({ callTool }),
-      maxCycles
+      maxCycles,
+      signed
     });
   } finally {
     close();

--- a/saas-forge/live.mjs
+++ b/saas-forge/live.mjs
@@ -159,6 +159,9 @@ export function makeCouncilFactFns({ callTool, team, reviewer, challengerTool, c
  * Run the forge against live model seats. Spawns the ai-peer-mcp server, wires
  * `callTool`, and runs the same forge loop with live generation + council+fact
  * breakouts. Requires API keys in the server's environment (claude/codex/grok).
+ *
+ * @param {object} opts
+ *   signed default false; when true, gate runs under trust_mode: "signed"
  */
 export async function runForgeLive({
   projectRoot, telos, dossierMeta, serverPath, docsFor,

--- a/saas-forge/scripts/test-live.mjs
+++ b/saas-forge/scripts/test-live.mjs
@@ -96,4 +96,44 @@ for (const [rel, needle] of [["db/schema.sql", "create policy"], ["web/DESIGN.md
 const png = path.join(root, "docs/verification/s03-dynamics-discriminator.png");
 assert.ok(existsSync(png) && statSync(png).size > 0, "live: binary screenshot placeholder filled by harness");
 
+// --- signed mode: converge THROUGH the hardened signature+provenance gate ---
+process.env.TELOS_SECRET_CLAUDE = "test-claude";
+process.env.TELOS_SECRET_AGY = "test-agy";
+process.env.TELOS_SECRET_CODEX = "test-codex";
+{
+  const signedRoot = mkdtempSync(path.join(os.tmpdir(), "saas-forge-signed-"));
+  const signedResult = await forge({
+    projectRoot: signedRoot, telos, dossierMeta,
+    makeGenerators: liveGenerators({ callTool }),
+    makeBreakoutFns: makeCouncilFactFns({ callTool }),
+    makeApprovals: councilApprovals({ callTool }),
+    signed: true
+  });
+  assert.equal(signedResult.converged, true,
+    `signed-mode forge must converge through the hardened gate; cycles=${JSON.stringify(signedResult.cycles)}`);
+  assert.equal(signedResult.verdict.gate_status, "pass", "signed-mode gate passes");
+  assert.equal(signedResult.verdict.headline_checks.signing_enforced, true, "signing enforced in the verdict");
+  assert.equal(signedResult.verdict.headline_checks.provenance_enforced, true, "provenance enforced in the verdict");
+}
+// negative: a missing required secret must fail closed in signed mode.
+{
+  delete process.env.TELOS_SECRET_CODEX;
+  const failRoot = mkdtempSync(path.join(os.tmpdir(), "saas-forge-signed-fail-"));
+  const failResult = await forge({
+    projectRoot: failRoot, telos, dossierMeta,
+    makeGenerators: liveGenerators({ callTool }),
+    makeBreakoutFns: makeCouncilFactFns({ callTool }),
+    makeApprovals: councilApprovals({ callTool }),
+    signed: true
+  });
+  assert.equal(failResult.converged, false, "signed mode without a required secret must not converge");
+  const blockers = (failResult.verdict && failResult.verdict.blockers) || [];
+  assert.ok(blockers.some((b) => /no secret to verify codex|signature invalid/i.test(b)),
+    `expected a fail-closed signature blocker; got ${JSON.stringify(blockers)}`);
+  process.env.TELOS_SECRET_CODEX = "test-codex";
+}
+delete process.env.TELOS_SECRET_CLAUDE;
+delete process.env.TELOS_SECRET_AGY;
+delete process.env.TELOS_SECRET_CODEX;
+
 console.log("test-live OK: seat-backed generation + council+fact breakout converged through the live path (stubbed transport)");


### PR DESCRIPTION
## Summary

Lets `ai-forge` and `saas-forge` run their gate under `trust_mode: "signed"` so a live run converges **through** the hardened HMAC-signature + provenance enforcement (from #66), not around it. Previously the forges built their gate dossier with no `trust_mode`, so a "live" forge pass never proved anything was signed.

Opt-in via an explicit `signed: true` flag on `runForgeLive`/`forge`. Default (unsigned/keyless) behavior is **unchanged**.

## How it works

- **Toggle:** `signed` threads `runForgeLive → forge → gate dossier` (`trust_mode: "signed"`). Fail-closed: if a required `TELOS_SECRET_*` is missing, packets are unsigned and the gate blocks — a demo can't be mistaken for a signed pass.
- **Approval packets:** no new code — the live council (`council.runSeat` + `liveSeatCaller`) already HMAC-signs the claude/agy/codex trio and stamps real provenance when secrets are set.
- **Market packets:** new shared helper `signMarketPacket(packet, record, signer)` in `build-gate/sign.mjs` re-attributes each harness-generated market packet to the workstream's signer, attaches a content-addressed `provenance.response_id = "market-<sha256(record)>"` attestation, and HMAC-signs it. The reviewing `lens` is preserved as `reviewed_by_lens`. Signing happens *before* the HMAC, so the signature covers the provenance and the embedded breakout record.

## Design note (decided during implementation)

Signed mode requires a `TELOS_SECRET_<SIGNER>` for **every** workstream signer. `saas-forge` signers are all `claude`/`codex`, so its approval-trio secrets suffice. `ai-forge` signs guardrail/adversary workstreams with `grok`, so **`ai-forge` signed mode also requires `TELOS_SECRET_GROK`**. (An earlier "sign by signer avoids advisory secrets" rationale was based on a saas-forge-only survey; requiring the signer's secret, fail-closed, was the chosen resolution.)

## Tests

Per forge, a signed-mode integration test (test HMAC secrets + provenance-returning stub):
- **Positive:** the run converges with `verdict.gate_status === "pass"` and `headline_checks.signing_enforced`/`provenance_enforced === true` — proving it passed *through* the hardened gate.
- **Negative:** with one required secret removed, `converged === false` and a signature blocker is present — proving fail-closed.
- Plus a `signMarketPacket` unit test (attestation shape, signature round-trip, unsigned-without-secret).

## Verification

- `cd build-gate && npm test` (incl. `breakout`): pass
- `cd ai-forge && npm test`: pass
- `cd saas-forge && npm test`: pass

The gate itself (`build-gate/gate.mjs`) is unchanged — this branch only *feeds* the already-hardened path. A whole-branch review confirmed the signed path is fail-closed by construction and the unsigned path is untouched.

## Process

Brainstormed → spec → plan → subagent-driven TDD (one implementer + task-review per task) → whole-branch review. Design spec and implementation plan are included under `docs/superpowers/`.

**Depends on #66** (signed-mode packet authentication), already merged to `main`. No new dependencies, ESM-only `.mjs`, no runtime/secret artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
