### PR TITLE
feat(forge): workstream manifests as data

### DIFF
--- a/docs/runs/crossroad-threads/manifest.json
+++ b/docs/runs/crossroad-threads/manifest.json
@@ -1,0 +1,362 @@
+{
+  "build_id": "crossroad-threads-launch-audit",
+  "idea_id": "crossroad-threads",
+  "use_case": "launch-audit",
+  "telos": "Launch Crossroad Threads on its own domain.",
+  "objective": "Certify the launch audit of Crossroad Threads for its own domain. PRODUCT & SURFACE: Crossroad Threads (github.com/dsmcewan/CrossroadThreads) — a live Next.js static-export apparel storefront styled as a museum (103 exhibits, five wings, narrated audio tour), today on GitHub Pages, auditing its launch as a standalone storefront on its OWN DOMAIN with the operator-pinned stack: AWS hosting, Docker-containerized services, and order/transaction/print-on-demand pipelines. TARGET USERS: collectors of narrative apparel, Southern Gothic / mythology enthusiasts, story-rich gift buyers. SOURCE MATERIALS: the full repository clone at workdir/source (README, next.config.ts, deploy workflow, content/designs.json, package.json) plus a pinned deterministic repo brief — every technical claim cites these. THE SEVEN AUDIT ARTIFACTS (each with contract-required sections and deterministic content checks, re-verified from disk): audit/COMMERCE-GAP.md (purchase path + order/transaction/POD pipeline specs), audit/POSITIONING.md (hypothesis-framed ICP/pricing/differentiation), audit/LAUNCH-ARCHITECTURE.md (AWS topology, Docker, DNS/CDN, migration), audit/SECURITY.md (CSP/TLS, PCI boundary, pipeline security, IAM), audit/OPERATIONS.md (CI, Docker build, content workflow, asset budget, runbooks), audit/BRAND-EXPERIENCE.md (conceit-vs-commerce collisions, accessibility), audit/ADVERTISING.md (hypothesis demographics, channel plan, creative system, measurement, budget gates). ADVERSARIAL GROUNDING STANDARD: every artifact survived a dual-adversary breakout (grok + agy) reading the complete artifact text and source anchors under a contract-bounded scope, with a gemini referee ending unproductive loops and a durable defeat memory; market claims are admissible only as labeled hypotheses with assumptions and validation plans; technical claims only with repository citations. GATE THRESHOLDS: acceptable Phase-2 gaps are enumerated, buildable work items inside each artifact's 'Phase 2 Work Items' section (missing commerce/infra the audit exists to specify); HARD STOPS are unresolved adversary blockers, any artifact failing its deterministic checks on disk, or any approval packet lacking real per-seat provenance — each blocks certification. This audit certifies the GAP MAP is complete and grounded, not that the launch is done.",
+  "business_thesis": "The museum conceit is the moat: an e-commerce site disguised as a gallery of applied mythology converts narrative depth into premium apparel sales.",
+  "target_users": [
+    "collectors of narrative apparel",
+    "Southern Gothic / mythology enthusiasts",
+    "gift buyers seeking story-rich objects"
+  ],
+  "workstreams": [
+    {
+      "id": "commerce-gap",
+      "signer": "codex",
+      "lens": "codex",
+      "dependencies": [],
+      "files": [
+        "audit/COMMERCE-GAP.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAudit the COMMERCE GAP: the site presents itself as a store, so determine from the repo what purchase path exists today (cite files) and specify every capability an own-domain storefront needs that is absent. OPERATOR-PINNED LAUNCH STACK: the launch requires (a) an ORDER PIPELINE — order lifecycle from cart through payment capture to fulfillment handoff and customer notification, with explicit states and failure handling; (b) a TRANSACTION PIPELINE — payment provider integration, webhook verification, idempotency, refunds/disputes; (c) a POD PIPELINE — print-on-demand integration (product/variant sync to the POD catalog, order submission, shipment tracking webhooks back to the customer). Spec each pipeline's stages, the AWS services or containers they run on, and the events between them. Sections required: Current Purchase Path, Gap Analysis, Checkout, Payment, Order Pipeline, Transaction Pipeline, POD Pipeline, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/COMMERCE-GAP.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/COMMERCE-GAP.md",
+          "needle": "Checkout"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/COMMERCE-GAP.md",
+          "needle": "Payment"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/COMMERCE-GAP.md",
+          "needle": "Order Pipeline"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/COMMERCE-GAP.md",
+          "needle": "Transaction Pipeline"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/COMMERCE-GAP.md",
+          "needle": "POD"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/package.json"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/README.md"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "architecture_findings",
+      "finding": "Commerce gap audit: what selling on its own domain actually requires."
+    },
+    {
+      "id": "positioning-launch",
+      "signer": "claude",
+      "lens": "claude",
+      "dependencies": [],
+      "files": [
+        "audit/POSITIONING.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAudit LAUNCH POSITIONING for the real brand ('a publishing house that prints on cotton' — Southern Gothic Americana x mythology, museum conceit with 103 exhibits and an audio tour). As LABELED HYPOTHESES with assumptions and validation plans: ICP segments, price architecture for premium graphic tees, differentiation (the museum experience IS the moat — argue it), channel strategy for an own-domain launch, and the riskiest assumption to test first. Ground every claim in what the repo/product actually contains. Sections required: ICP, Pricing, Differentiation, Riskiest Hypothesis, Validation Plan.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/POSITIONING.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/POSITIONING.md",
+          "needle": "Hypothesis"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/POSITIONING.md",
+          "needle": "ICP"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/POSITIONING.md",
+          "needle": "Pricing"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/POSITIONING.md",
+          "needle": "Validation"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/README.md"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "accuracy_eval_findings",
+      "finding": "Launch positioning: hypothesis-framed ICP, pricing, and differentiation for a real, shipped brand."
+    },
+    {
+      "id": "launch-architecture",
+      "signer": "codex",
+      "lens": "gemini",
+      "dependencies": [],
+      "files": [
+        "audit/LAUNCH-ARCHITECTURE.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nNEXT.CONFIG.TS:\nimport type { NextConfig } from \"next\";\r\n\r\n// Project site on GitHub Pages → served under /<repo>. Local dev serves at /.\r\nconst repo = \"CrossroadThreads\";\r\nconst isPages = process.env.GITHUB_ACTIONS === \"true\";\r\nconst basePath = isPages ? `/${repo}` : \"\";\r\n\r\nconst nextConfig: NextConfig = {\r\n  output: \"export\",\r\n  trailingSlash: true,\r\n  basePath,\r\n  assetPrefix: basePath,\r\n  images: { unoptimized: true },\r\n  env: {\r\n    NEXT_PUBLIC_BASE_PATH: basePath,\r\n  },\r\n};\r\n\r\nexport default nextConfig;\r\n\nDEPLOY WORKFLOW:\nname: Deploy to GitHub Pages\r\n\r\non:\r\n  push:\r\n    branches: [main]\r\n  workflow_dispatch:\r\n\r\npermissions:\r\n  contents: read\r\n  pages: write\r\n  id-token: write\r\n\r\nconcurrency:\r\n  group: pages\r\n  cancel-in-progress: true\r\n\r\njobs:\r\n  build:\r\n    runs-on: ubuntu-latest\r\n    steps:\r\n      - uses: actions/checkout@v4\r\n\r\n      - uses: actions/setup-node@v4\r\n        with:\r\n          node-version: 22\r\n          cache: npm\r\n\r\n      # Image derivatives are content-addressed; only re-encode sources that changed\r\n      - name: Cache processed images\r\n        uses: actions/cache@v4\r\n        with:\r\n          path: |\r\n            public/images/designs\r\n            .image-cache.json\r\n          key: images-${{ hashFiles('crossroad_imgs/**', 'scripts/image-pipeline.ts') }}\r\n          restore-keys: images-\r\n\r\n      - run: npm ci\r\n\r\n      - run: npm test\r\n\r\n      # GITHUB_ACTIONS=true is set by the runner, which bakes in the /CrossroadThreads basePath\r\n      - run: npm run build\r\n\r\n      - uses: actions/upload-pages-artifact@v3\r\n        with:\r\n          path: out\r\n\r\n  deploy:\r\n    needs: build\r\n    runs-on: ubuntu-latest\r\n    environment:\r\n      name: github-pages\r\n      url: ${{ steps.deployment.outputs.page_url }}\r\n    steps:\r\n      - id: deployment\r\n        uses: actions/deploy-pages@v4\r\n\nAudit LAUNCH ARCHITECTURE for moving from GitHub Pages to an own domain. OPERATOR-PINNED TARGET: AWS. Specify the AWS topology: static export on S3 + CloudFront (TLS via ACM, Route 53 DNS), and the commerce services (order/transaction/POD pipelines from the commerce audit) as DOCKER CONTAINERS — state where they run (ECS Fargate vs Lambda-container trade-off, with a recommendation), how images are built and stored (ECR), and how the static site talks to them (API Gateway/ALB). Also: what in the current config binds the site to the Pages basePath (cite lines), redirect strategy from the Pages URL, and how CI deploy changes for AWS. Sections required: Current Coupling, AWS Topology, Docker, DNS, CDN, Migration Steps, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/LAUNCH-ARCHITECTURE.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/LAUNCH-ARCHITECTURE.md",
+          "needle": "AWS"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/LAUNCH-ARCHITECTURE.md",
+          "needle": "Docker"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/LAUNCH-ARCHITECTURE.md",
+          "needle": "DNS"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/LAUNCH-ARCHITECTURE.md",
+          "needle": "CDN"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/LAUNCH-ARCHITECTURE.md",
+          "needle": "basePath"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/next.config.ts"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/.github/workflows/deploy.yml"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "scalability_findings",
+      "finding": "Own-domain launch architecture: hosting, DNS, CDN, basePath migration, asset strategy."
+    },
+    {
+      "id": "security-trust",
+      "signer": "codex",
+      "lens": "grok",
+      "dependencies": [],
+      "files": [
+        "audit/SECURITY.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAudit SECURITY AND TRUST for an own-domain storefront on the OPERATOR-PINNED AWS/Docker stack: current static-site posture (headers, CSP, TLS), what changes the moment payments exist (PCI scope boundaries under hosted-checkout vs self-hosted), securing the order/transaction/POD pipelines (webhook signature verification, idempotency keys, secrets in AWS Secrets Manager, least-privilege IAM for the containers, ECR image scanning), privacy posture, and a threat sketch for a small commerce site. Sections required: Current Posture, CSP, Payment Security Boundary, Pipeline Security, IAM, Privacy, Threats, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/SECURITY.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/SECURITY.md",
+          "needle": "CSP"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/SECURITY.md",
+          "needle": "TLS"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/SECURITY.md",
+          "needle": "payment"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/SECURITY.md",
+          "needle": "IAM"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/SECURITY.md",
+          "needle": "webhook"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/next.config.ts"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "security_findings",
+      "finding": "Security and trust posture for a commerce-bearing own-domain launch."
+    },
+    {
+      "id": "ops-content",
+      "signer": "claude",
+      "lens": "agy",
+      "dependencies": [],
+      "files": [
+        "audit/OPERATIONS.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAudit OPERATIONS AND CONTENT for an own-domain launch on the OPERATOR-PINNED AWS/Docker stack: the CI build (image pipeline with content-addressed caching, TTS generation) retargeted to AWS (build Docker images -> ECR -> deploy; static export -> S3/CloudFront invalidation), the accessioning flow (drop a PNG -> it appears -> POD variant sync), the 344MB-source/89MB-derivative asset budget and its S3/CloudFront cost meaning, operational runbooks for the order/ transaction/POD pipelines (monitoring, alerts, dead-letter handling), and the single-editor content workflow's launch risks. Sections required: CI Pipeline, Docker Build, Content Workflow, Asset Budget, Pipeline Operations, Launch Risks, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/OPERATIONS.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/OPERATIONS.md",
+          "needle": "CI"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/OPERATIONS.md",
+          "needle": "Docker"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/OPERATIONS.md",
+          "needle": "pipeline"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/OPERATIONS.md",
+          "needle": "budget"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/OPERATIONS.md",
+          "needle": "runbook"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/.github/workflows/deploy.yml"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/package.json"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "backend_schema_findings",
+      "finding": "Operations audit: CI, image/audio pipelines, content accessioning, asset budget."
+    },
+    {
+      "id": "brand-experience",
+      "signer": "claude",
+      "lens": "gemini",
+      "dependencies": [],
+      "files": [
+        "audit/BRAND-EXPERIENCE.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAudit the BRAND EXPERIENCE for the own-domain launch: how the museum conceit (wings, placards, provenance, conservation status, audio-guide stops) currently carries the storefront, where the conceit will COLLIDE with commerce mechanics (cart, prices, checkout language — 'gift shop' framing as the resolution?), what an own domain changes about first-visit comprehension, and accessibility considerations for the audio tour. Sections required: Conceit Inventory, Commerce Collisions, First Visit, Accessibility, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/BRAND-EXPERIENCE.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/BRAND-EXPERIENCE.md",
+          "needle": "wing"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/BRAND-EXPERIENCE.md",
+          "needle": "placard"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/BRAND-EXPERIENCE.md",
+          "needle": "audio"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/BRAND-EXPERIENCE.md",
+          "needle": "conceit"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/README.md"
+        }
+      ],
+      "isUi": true,
+      "findingsKey": "frontend_design_findings",
+      "finding": "Brand experience audit: does the museum conceit survive contact with commerce?"
+    },
+    {
+      "id": "advertising-launch",
+      "signer": "claude",
+      "lens": "grok",
+      "dependencies": [],
+      "files": [
+        "audit/ADVERTISING.md"
+      ],
+      "requirements": "POSTURE: Crossroad Threads is launching on ITS OWN DOMAIN as a real storefront (today it is a static Next.js export on GitHub Pages under a basePath). Audit the PRODUCT AS IT EXISTS in the repository excerpts below and in the bout evidence (workdir/source). Every market claim must be an explicitly-labeled HYPOTHESIS with assumptions and a validation plan; every technical claim must cite the repository. Findings end in a numbered GAP LIST: concrete, buildable items for Phase 2.\n\nREPO FACTS (deterministic): assets crossroad_imgs=344MB, public=18MB; commerce keyword hits: {\"checkout\":[\".github/workflows/deploy.yml\",\"content/designs.json\"],\"cart\":[\"content/designs.json\",\"README.md\",\"src/lib/commerce.ts\",\"src/lib/types.ts\"],\"price\":[\"content/designs.json\",\"src/components/exhibit/GiftShopPanel.module.css\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/types.ts\"],\"shop\":[\"content/designs.json\",\"docs/BRAND.md\",\"README.md\",\"src/app/exhibit/[slug]/page.tsx\",\"src/app/layout.tsx\",\"src/components/exhibit/GiftShopPanel.tsx\",\"src/lib/commerce.ts\",\"src/lib/copy.ts\"]}\nPACKAGE.JSON:\n{\r\n  \"name\": \"crossroad-collection\",\r\n  \"version\": \"0.1.0\",\r\n  \"private\": true,\r\n  \"scripts\": {\r\n    \"predev\": \"tsx scripts/build-catalog.ts\",\r\n    \"dev\": \"next dev\",\r\n    \"prebuild\": \"tsx scripts/build-catalog.ts\",\r\n    \"build\": \"next build\",\r\n    \"postbuild\": \"node scripts/verify-export.mjs\",\r\n    \"catalog\": \"tsx scripts/build-catalog.ts\",\r\n    \"preview:pages\": \"node scripts/preview-pages.mjs\",\r\n    \"audio\": \"tts/.venv/Scripts/python tts/generate_audio.py\",\r\n    \"test\": \"vitest run\",\r\n    \"lint\": \"next lint\"\r\n  },\r\n  \"dependencies\": {\r\n    \"next\": \"^15.3.0\",\r\n    \"react\": \"^19.0.0\",\r\n    \"react-dom\": \"^19.0.0\"\r\n  },\r\n  \"devDependencies\": {\r\n    \"@types/node\": \"^22\",\r\n    \"@types/react\": \"^19\",\r\n    \"@types/react-dom\": \"^19\",\r\n    \"playwright\": \"^1.61.1\",\r\n    \"sharp\": \"^0.34.0\",\r\n    \"tsx\": \"^4.19.0\",\r\n    \"typescript\": \"^5\",\r\n    \"vitest\": \"^3.1.0\"\r\n  }\r\n}\r\n\nAuthor the DIGITAL ADVERTISING LAUNCH PLAN for the own-domain launch. All audience and performance claims are LABELED HYPOTHESES (pre-launch: no campaign data exists) with assumptions and a validation plan. Required content: (1) TARGET DEMOGRAPHICS — hypothesis segments for premium narrative graphic tees (Southern Gothic Americana x mythology, museum conceit): age bands, interests/affinities, purchase occasions (self-expression vs gifting), with the reasoning grounded in what the product actually is; (2) CHANNEL PLAN across the current paid-social landscape — Meta (Facebook + Instagram, Advantage+ catalog-style prospecting), TikTok (the audio-tour and exhibit lore are native short-video material — say how), Pinterest (visual discovery for apparel/gifting), X/Twitter (niche lore/mythology communities, modest role), and YouTube Shorts — for each: role in the funnel, hypothesis audience, creative format, and a starting budget SHARE (percentages of a total, not invented dollar results); (3) CREATIVE SYSTEM — how the museum conceit converts to ad creative (exhibit placards as carousel cards, audio-guide clips as voiceover video, 'Recent Acquisitions' as drop announcements); (4) MEASUREMENT — pixels/Conversion APIs per platform, UTM discipline, the KPI ladder (CTR -> CVR -> AOV -> ROAS) with target hypotheses and the kill/scale rules; (5) BUDGET STRUCTURE — phased test->prove->scale plan in budget shares and decision gates; (6) Phase 2 Work Items (pixel/CAPI install, catalog feed, creative asset pipeline from existing exhibit imagery). Sections required: Target Demographics, Channel Plan, Creative System, Measurement, Budget Structure, Phase 2 Work Items.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "audit/ADVERTISING.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "Hypothesis"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "Meta"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "TikTok"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "Pinterest"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "Measurement"
+        },
+        {
+          "type": "file_contains",
+          "path": "audit/ADVERTISING.md",
+          "needle": "Budget"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/README.md"
+        },
+        {
+          "type": "file_exists",
+          "path": "source/content/designs.json"
+        }
+      ],
+      "isUi": false,
+      "findingsKey": "accuracy_eval_findings",
+      "finding": "Digital advertising launch plan: hypothesis-framed demographics, channel strategy, creative system, measurement."
+    }
+  ]
+}

--- a/docs/runs/crossroad-threads/run-audit.mjs
+++ b/docs/runs/crossroad-threads/run-audit.mjs
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import { computePlan, writePlan } from "../../../merkle-dag/merkle.mjs";
 import { runBuild } from "../../../merkle-dag/orchestrate.mjs";
 import { openState, foldDefs, styxGenerateFiles, bankVerifyFailures, runBouts, approvalEvidenceDigest, loadKeys } from "../../../forge/ratchet.mjs";
+import { validateManifest, workstreamsFromManifest, defsFromManifest } from "../../../forge/manifest.mjs";
 import { createSeatRouter } from "../../../breakout/seat_router.mjs";
 import { defaultSeatRegistry } from "../../../build-gate/seat-registry.mjs";
 import { generatorDispatch } from "../../../saas-forge/generator.mjs";
@@ -260,6 +261,38 @@ const dossierMeta = {
 };
 const telos = "Launch Crossroad Threads on its own domain.";
 
+// Checks derived from each workstream's declaration: manifest files exist,
+// needles anchor the contract, source anchors pull the real repository into
+// the bout evidence (and trivially hold on disk).
+const checksFor = (ws) => [
+  ...ws.files.map((p) => ({ type: "file_exists", path: p })),
+  ...ws.needles.map((needle) => ({ type: "file_contains", path: ws.files[0], needle })),
+  ...ws.anchors.map((p) => ({ type: "file_exists", path: p }))
+];
+
+// One-time manifest emission (Batch 2 migration): materialize the current spec
+// as data, hash-stable by construction. `TELOS_EMIT_MANIFEST=1 node run-audit.mjs`
+if (process.env.TELOS_EMIT_MANIFEST === "1") {
+  const manifest = {
+    build_id: dossierMeta.build_id,
+    idea_id: dossierMeta.idea_id,
+    use_case: dossierMeta.use_case,
+    telos,
+    objective: dossierMeta.objective,
+    business_thesis: dossierMeta.business_thesis,
+    target_users: dossierMeta.target_users,
+    workstreams: AUDIT_WORKSTREAMS.map((ws) => ({
+      id: ws.id, signer: ws.signer, lens: ws.lens, dependencies: ws.dependencies,
+      files: ws.files, requirements: ws.requirements, checks: checksFor(ws),
+      isUi: !!ws.isUi, findingsKey: ws.findingsKey, finding: ws.finding
+    }))
+  };
+  validateManifest(manifest);
+  saveJson(path.join(here, "manifest.json"), manifest);
+  console.log(`manifest emitted: ${path.join(here, "manifest.json")}`);
+  process.exit(0);
+}
+
 const keys = loadKeys(workdir, ["claude", "codex"], log);
 
 const router = createSeatRouter(defaultSeatRegistry());
@@ -272,22 +305,28 @@ let summary = { generated_for: dossierMeta.build_id, live: true, phase: "audit",
 try {
   const state = openState(workdir);
 
-  const checksFor = (ws) => [
-    ...ws.files.map((p) => ({ type: "file_exists", path: p })),
-    ...ws.needles.map((needle) => ({ type: "file_contains", path: ws.files[0], needle })),
-    // Anchors pull the real repository into the bout evidence (and trivially
-    // hold on disk): adversaries attack the audit AGAINST the source.
-    ...ws.anchors.map((p) => ({ type: "file_exists", path: p }))
-  ];
-  const wsWithChecks = AUDIT_WORKSTREAMS.map((ws) => ({ ...ws, checks: checksFor(ws) }));
-
-  const rawDefs = wsWithChecks.map((ws) => ({
-    id: ws.id,
-    files: ws.files,
-    requirements: ws.requirements,
-    test: { cmd: "node", args: [CHECK_NODE, JSON.stringify(ws.checks)] },
-    dependencies: ws.dependencies
-  }));
+  // The spec comes from manifest.json when present (the declarative path);
+  // the in-file AUDIT_WORKSTREAMS remain the authoring source it was emitted
+  // from. defsFromManifest is hash-stable with the previous inline derivation.
+  const manifestPath = path.join(here, "manifest.json");
+  const manifest = loadJson(manifestPath, null);
+  let wsWithChecks, rawDefs;
+  if (manifest) {
+    validateManifest(manifest);
+    wsWithChecks = workstreamsFromManifest(manifest);
+    rawDefs = defsFromManifest(manifest, { checkNodePath: CHECK_NODE });
+    log(`spec: loaded from manifest.json (${wsWithChecks.length} workstreams)`);
+  } else {
+    wsWithChecks = AUDIT_WORKSTREAMS.map((ws) => ({ ...ws, checks: checksFor(ws) }));
+    rawDefs = wsWithChecks.map((ws) => ({
+      id: ws.id,
+      files: ws.files,
+      requirements: ws.requirements,
+      test: { cmd: "node", args: [CHECK_NODE, JSON.stringify(ws.checks)] },
+      dependencies: ws.dependencies
+    }));
+    log("spec: manifest.json absent — using in-file workstreams");
+  }
   const defs = foldDefs(rawDefs, state, log);
   const defById = new Map(defs.map((d) => [d.id, d]));
   const { plan, errors } = computePlan(defs, {

--- a/docs/runs/saas-forge-plugin-seats/manifest.json
+++ b/docs/runs/saas-forge-plugin-seats/manifest.json
@@ -1,0 +1,319 @@
+{
+  "build_id": "saas-forge-plugin-seats",
+  "idea_id": "idea-convergence",
+  "use_case": "forge-live-plugin-seats",
+  "telos": "Make the convergence demo market-ready.",
+  "objective": "Forge the convergence demo live through the seat-router plugin backends. SCOPE: the seven fixture workstreams (product-architecture, business-positioning, backend-schema, security-trust, accuracy-evals, scale-operations, frontend-brand-experience), each authoring its declared files in the run workdir. 'Live' means REAL provider API calls with per-seat response-id provenance — nothing fabricated. SEAT ENUMERATION (all traversal via breakout/seat_router.mjs over build-gate/seat-registry.mjs; routing is fail-closed — an unrouted tool throws, so NO seat can bypass the router): claude -> ai-peer-mcp (Anthropic API); codex -> codex-api plugin server (OpenAI gpt-5.5, xhigh); grok -> grok plugin server (xAI grok-4.3, adversary); gemini -> gemini plugin server (Google gemini-3.1-pro-preview, bout referee); agy -> Antigravity CLI plugin server (co-adversary, content-addressed provenance) plus the agy_checkpoint LOCAL governance approver on ai-peer-mcp. Each backend is authorized via its operator-held API key or signed-in CLI session. SUCCESS CRITERIA (verified, not asserted): every workstream's deterministic checks re-verified from disk by the gate; every artifact survived a dual-adversary breakout (grok + agy) with the gemini referee; every approval packet carries real provenance (a missing/duplicate response_id blocks); all nodes settled on the append-only Ed25519 ledger. SAFEGUARDS: observability via persisted fight logs (.telos/fights), the signed ledger, and run summaries; rollback/fallback via forward-invalidation (a changed spec re-hashes, stale ledger lines fall invalid, the ratchet workdir preserves every prior state); the gate fails closed on any missing evidence.",
+  "workstreams": [
+    {
+      "id": "product-architecture",
+      "signer": "codex",
+      "lens": "codex",
+      "dependencies": [],
+      "files": [
+        "docs/ARCHITECTURE.md"
+      ],
+      "requirements": "Document the researched capability stack (UI/DB/infra) as a coherent SaaS architecture.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "docs/ARCHITECTURE.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "Vite"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "Tailwind CSS"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "Supabase"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "AWS CDK"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "Supabase Auth"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/ARCHITECTURE.md",
+          "needle": "Vitest"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"docs/ARCHITECTURE.md\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"Vite\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"Tailwind CSS\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"Supabase\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"AWS CDK\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"Supabase Auth\"},{\"type\":\"file_contains\",\"path\":\"docs/ARCHITECTURE.md\",\"needle\":\"Vitest\"}]"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "architecture_findings",
+      "finding": "Coherent multi-tier architecture grounded in the researched stack."
+    },
+    {
+      "id": "business-positioning",
+      "signer": "claude",
+      "lens": "claude",
+      "dependencies": [
+        "product-architecture"
+      ],
+      "files": [
+        "docs/POSITIONING.md"
+      ],
+      "requirements": "State the ICP, value proposition, differentiation, and pricing posture — as EXPLICITLY-LABELED HYPOTHESES, not market facts. This product is pre-market: no real pricing, adoption, or competitive data exists yet, and the document must not pretend otherwise. For every positioning claim: (1) label it a hypothesis, (2) state the assumptions it rests on, (3) state how it would be validated or falsified (the validation plan IS the methodology). Reviewers judge internal coherence, honest labeling, and testability — demands for real market evidence are out of scope until the validation plan has been executed.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "docs/POSITIONING.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/POSITIONING.md",
+          "needle": "Target users"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/POSITIONING.md",
+          "needle": "Differentiation"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"docs/POSITIONING.md\"},{\"type\":\"file_contains\",\"path\":\"docs/POSITIONING.md\",\"needle\":\"Target users\"},{\"type\":\"file_contains\",\"path\":\"docs/POSITIONING.md\",\"needle\":\"Differentiation\"}]"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "architecture_findings",
+      "finding": "Positioning ties technical credibility to a defensible market thesis."
+    },
+    {
+      "id": "backend-schema",
+      "signer": "codex",
+      "lens": "agy",
+      "dependencies": [
+        "product-architecture"
+      ],
+      "files": [
+        "db/schema.sql"
+      ],
+      "requirements": "Relational schema with tenant isolation enforced by row-level security.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "db/schema.sql"
+        },
+        {
+          "type": "file_contains",
+          "path": "db/schema.sql",
+          "needle": "create table"
+        },
+        {
+          "type": "file_contains",
+          "path": "db/schema.sql",
+          "needle": "create policy"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"db/schema.sql\"},{\"type\":\"file_contains\",\"path\":\"db/schema.sql\",\"needle\":\"create table\"},{\"type\":\"file_contains\",\"path\":\"db/schema.sql\",\"needle\":\"create policy\"}]"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "backend_schema_findings",
+      "finding": "Schema enforces tenant isolation via row-level security policies."
+    },
+    {
+      "id": "security-trust",
+      "signer": "codex",
+      "lens": "grok",
+      "dependencies": [
+        "product-architecture"
+      ],
+      "files": [
+        "web/SECURITY.md",
+        "web/site/csp.txt"
+      ],
+      "requirements": "No client-side secrets; strict CSP; read-only findings. CSP SEMANTICS ARE SPEC-BOUND (W3C): require-trusted-types-for accepts ONLY the 'script' sink group — demands to add other tokens to that directive are invalid and are not blockers.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "web/site/csp.txt"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/site/csp.txt",
+          "needle": "Content-Security-Policy"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/site/csp.txt",
+          "needle": "default-src"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"web/site/csp.txt\"},{\"type\":\"file_contains\",\"path\":\"web/site/csp.txt\",\"needle\":\"Content-Security-Policy\"},{\"type\":\"file_contains\",\"path\":\"web/site/csp.txt\",\"needle\":\"default-src\"}]"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "security_findings",
+      "finding": "Strict CSP and RLS-guarded anon key; no secrets in the client bundle."
+    },
+    {
+      "id": "accuracy-evals",
+      "signer": "claude",
+      "lens": "claude",
+      "dependencies": [
+        "product-architecture"
+      ],
+      "files": [
+        "evals/scorecard.json",
+        "evals/run.mjs"
+      ],
+      "requirements": "Measure the discriminator against a fixed labeled set; clear the precision threshold. The eval runner is READ-ONLY: it must not create or modify any file (the scorecard is static data it validates against) — print results to stdout and exit 0 on pass, 1 on miss. HARD CONSTRAINT: no self-referential cryptographic checks — do NOT embed precomputed hashes (sha256 etc.) of the artifact's own content for the runner to recompute; an authored hash cannot be correct and artifact integrity is already enforced by the pipeline's signed ledger tree-hash. Self-consistency checks must be ARITHMETIC (e.g. the confusion-matrix counts re-derived from the embedded labeled set must equal the stored metrics).",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "evals/scorecard.json"
+        },
+        {
+          "type": "file_contains",
+          "path": "evals/scorecard.json",
+          "needle": "precision"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "evals/run.mjs"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "accuracy_eval_findings",
+      "finding": "Precision 0.94 clears the 0.90 threshold on the labeled set."
+    },
+    {
+      "id": "scale-operations",
+      "signer": "codex",
+      "lens": "codex",
+      "dependencies": [
+        "product-architecture"
+      ],
+      "files": [
+        "docs/OPERATIONS.md"
+      ],
+      "requirements": "Document hosting (S3 + CloudFront), scale path, and monitoring/SLOs.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "docs/OPERATIONS.md"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/OPERATIONS.md",
+          "needle": "CloudFront"
+        },
+        {
+          "type": "file_contains",
+          "path": "docs/OPERATIONS.md",
+          "needle": "S3"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"docs/OPERATIONS.md\"},{\"type\":\"file_contains\",\"path\":\"docs/OPERATIONS.md\",\"needle\":\"CloudFront\"},{\"type\":\"file_contains\",\"path\":\"docs/OPERATIONS.md\",\"needle\":\"S3\"}]"
+        ]
+      },
+      "isUi": false,
+      "findingsKey": "scalability_findings",
+      "finding": "Edge-scaled static delivery with CloudFront/CloudWatch SLOs."
+    },
+    {
+      "id": "frontend-brand-experience",
+      "signer": "claude",
+      "lens": "claude",
+      "dependencies": [
+        "product-architecture",
+        "security-trust",
+        "accuracy-evals"
+      ],
+      "files": [
+        "web/index.html",
+        "web/site/style.css",
+        "web/site/tokens.css",
+        "web/DESIGN.md",
+        "web/VERIFICATION.md",
+        "docs/verification/s03-dynamics-discriminator.png",
+        "docs/verification/s04-scorecard.png"
+      ],
+      "requirements": "LEXI-class first screen: contract, delivery, test posture, TELOS gate; brand token #69e7ff; design system (tokens + toolchain) and verification screenshots. TOKEN RESOLUTION (contract-final): tokens.css defines --accent-cyan: #69e7ff; style.css consumes it as var(--accent-cyan, #69e7ff) — the fallback legitimately carries the literal hex, satisfying BOTH the deterministic check and token discipline; demands to remove the hex or to hardcode it bare are equally invalid. NOTE ON BINARY ASSETS: the verification .png files are PIPELINE-OWNED placeholders in this text bout — real rendering happens outside it; their byte content is out of bout scope and is not a valid blocker. All text files (index.html included) must be complete and internally consistent.",
+      "checks": [
+        {
+          "type": "file_exists",
+          "path": "web/index.html"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/site/style.css",
+          "needle": "#69e7ff"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/site/tokens.css",
+          "needle": "--accent-cyan"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/DESIGN.md",
+          "needle": "shadcn/ui"
+        },
+        {
+          "type": "file_contains",
+          "path": "web/DESIGN.md",
+          "needle": "Figma"
+        },
+        {
+          "type": "file_exists",
+          "path": "web/VERIFICATION.md"
+        },
+        {
+          "type": "file_exists",
+          "path": "docs/verification/s03-dynamics-discriminator.png"
+        },
+        {
+          "type": "file_exists",
+          "path": "docs/verification/s04-scorecard.png"
+        }
+      ],
+      "test": {
+        "cmd": "node",
+        "args": [
+          "C:\\Users\\dsmce\\telos\\.claude\\worktrees\\saas-forge-live-run\\saas-forge\\checks\\check-node.mjs",
+          "[{\"type\":\"file_exists\",\"path\":\"web/index.html\"},{\"type\":\"file_contains\",\"path\":\"web/site/style.css\",\"needle\":\"#69e7ff\"},{\"type\":\"file_contains\",\"path\":\"web/site/tokens.css\",\"needle\":\"--accent-cyan\"},{\"type\":\"file_contains\",\"path\":\"web/DESIGN.md\",\"needle\":\"shadcn/ui\"},{\"type\":\"file_contains\",\"path\":\"web/DESIGN.md\",\"needle\":\"Figma\"},{\"type\":\"file_exists\",\"path\":\"web/VERIFICATION.md\"},{\"type\":\"file_exists\",\"path\":\"docs/verification/s03-dynamics-discriminator.png\"},{\"type\":\"file_exists\",\"path\":\"docs/verification/s04-scorecard.png\"}]"
+        ]
+      },
+      "isUi": true,
+      "findingsKey": "frontend_design_findings",
+      "finding": "First-screen proof band carries the brand token and the LEXI-class contract."
+    }
+  ]
+}

--- a/docs/runs/saas-forge-plugin-seats/run-ratchet.mjs
+++ b/docs/runs/saas-forge-plugin-seats/run-ratchet.mjs
@@ -27,6 +27,7 @@ import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { openState, foldDefs, styxGenerateFiles, bankVerifyFailures, runBouts, approvalEvidenceDigest, loadKeys, pinResearch } from "../../../forge/ratchet.mjs";
+import { validateManifest, workstreamsFromManifest, defsFromManifest } from "../../../forge/manifest.mjs";
 import { computePlan, writePlan } from "../../../merkle-dag/merkle.mjs";
 import { runBuild } from "../../../merkle-dag/orchestrate.mjs";
 import { createSeatRouter } from "../../../breakout/seat_router.mjs";
@@ -140,7 +141,50 @@ try {
   const architecture = await pinResearch(workdir, "architecture",
     () => researchArchitecture({ telos, workstreams: ALL, docsFor: context7DocsFor() }), log);
 
-  const rawDefs = convergenceTaskDefs(architecture);
+  // One-time manifest emission (Batch 2 migration): materialize the spec —
+  // including the architecture-dependent checks, resolved against the PINNED
+  // research — as data. `TELOS_EMIT_MANIFEST=1 node run-ratchet.mjs`
+  if (process.env.TELOS_EMIT_MANIFEST === "1") {
+    const inlineDefs = convergenceTaskDefs(architecture);
+    const manifest = {
+      build_id: dossierMeta.build_id,
+      idea_id: dossierMeta.idea_id,
+      use_case: dossierMeta.use_case,
+      telos,
+      objective: dossierMeta.objective,
+      workstreams: WORKSTREAMS.map((ws) => {
+        const def = inlineDefs.find((d) => d.id === ws.id);
+        return {
+          id: ws.id, signer: ws.signer, lens: ws.lens, dependencies: ws.dependencies,
+          files: ws.files, requirements: def.requirements,
+          checks: ws.checks(architecture),
+          test: def.test,
+          isUi: !!ws.isUi, findingsKey: ws.findingsKey, finding: ws.finding
+        };
+      })
+    };
+    validateManifest(manifest);
+    saveJson(path.join(here, "manifest.json"), manifest);
+    console.log(`manifest emitted: ${path.join(here, "manifest.json")}`);
+    process.exit(0);
+  }
+
+  // The spec comes from manifest.json when present (declarative path, tests
+  // carried verbatim so plan hashes are stable); the in-file workstreams
+  // remain the authoring source it was emitted from.
+  const manifestPath = path.join(here, "manifest.json");
+  const manifest = loadJson(manifestPath, null);
+  let rawDefs, wsSource;
+  if (manifest) {
+    validateManifest(manifest);
+    wsSource = workstreamsFromManifest(manifest);
+    rawDefs = defsFromManifest(manifest, { checkNodePath: "unused-explicit-tests" });
+    log(`spec: loaded from manifest.json (${wsSource.length} workstreams)`);
+  } else {
+    wsSource = WORKSTREAMS.map((ws) => ({ ...ws, checks: ws.checks(architecture) }));
+    rawDefs = convergenceTaskDefs(architecture);
+    log("spec: manifest.json absent — using in-file workstreams");
+  }
   const defs = foldDefs(rawDefs, state, log);
   const defById = new Map(defs.map((d) => [d.id, d]));
   const { plan, errors } = computePlan(defs, {
@@ -177,8 +221,7 @@ try {
     // ---- Stage B: team bouts (Styx skip, closure, checkpoints — forge/) -----
     const makeFns = makeCouncilFactFns({ callTool });
     const hashById = new Map(plan.nodes.map((n) => [n.id, n.effective_hash]));
-    const wsWithChecks = WORKSTREAMS.map((ws) => ({ ...ws, checks: ws.checks(architecture) }));
-    const records = await runBouts({ workstreams: wsWithChecks, state, makeFns, defById, hashById, telosDir, log });
+    const records = await runBouts({ workstreams: wsSource, state, makeFns, defById, hashById, telosDir, log });
     summary.teams = records.map((t) => ({
       workstream: t.workstream, converged: t.converged, finalStatus: t.finalStatus,
       rounds: t.rounds?.length ?? 0, referee: t.referee ?? null

--- a/forge/manifest.mjs
+++ b/forge/manifest.mjs
@@ -1,0 +1,119 @@
+// manifest.mjs — product specs as data: the TELOS-as-a-service onramp.
+//
+// A manifest declares everything a convergence run needs — the dossier and the
+// workstreams (files, contracts, checks, seats) — so a new idea is one JSON
+// file plus a driver invocation, not a hand-authored runner. Validation is
+// FAIL-CLOSED: unknown fields, missing required fields, or unknown check types
+// reject the manifest rather than being silently ignored (a typo'd field name
+// must never quietly weaken a contract).
+//
+// Hash-stability contract: defsFromManifest must be deterministic — identical
+// manifest, identical task defs, identical plan hashes. Migrating an existing
+// run to a manifest EMITTED from its current defs therefore invalidates
+// nothing (verified by the zero-seat-call replay).
+
+const MANIFEST_FIELDS = new Set([
+  "build_id", "idea_id", "use_case", "telos", "objective",
+  "business_thesis", "target_users", "trust_mode", "workstreams"
+]);
+const WORKSTREAM_FIELDS = new Set([
+  "id", "signer", "lens", "dependencies", "files", "requirements",
+  "checks", "test", "isUi", "findingsKey", "finding"
+]);
+const CHECK_FIELDS = new Set(["type", "path", "needle", "grade"]);
+const CHECK_TYPES = new Set(["file_exists", "file_contains"]);
+const GRADES = new Set(["executable", "inspectable", "cited", "hypothesis"]);
+
+function fail(errors) {
+  const e = new Error(`manifest invalid:\n${errors.map((x) => `  - ${x}`).join("\n")}`);
+  e.errors = errors;
+  throw e;
+}
+
+/** Validate a manifest object. Throws (fail-closed) with every error listed. */
+export function validateManifest(m) {
+  const errors = [];
+  if (!m || typeof m !== "object" || Array.isArray(m)) fail(["manifest must be an object"]);
+  for (const k of Object.keys(m)) if (!MANIFEST_FIELDS.has(k)) errors.push(`unknown manifest field "${k}"`);
+  for (const k of ["build_id", "telos", "objective"]) {
+    if (typeof m[k] !== "string" || !m[k].trim()) errors.push(`"${k}" must be a non-empty string`);
+  }
+  if (!Array.isArray(m.workstreams) || m.workstreams.length === 0) {
+    errors.push(`"workstreams" must be a non-empty array`);
+    fail(errors);
+  }
+  const ids = new Set();
+  for (const ws of m.workstreams) {
+    const tag = `workstream "${ws?.id ?? "?"}"`;
+    if (!ws || typeof ws !== "object") { errors.push(`${tag}: must be an object`); continue; }
+    for (const k of Object.keys(ws)) if (!WORKSTREAM_FIELDS.has(k)) errors.push(`${tag}: unknown field "${k}"`);
+    for (const k of ["id", "signer", "lens", "requirements"]) {
+      if (typeof ws[k] !== "string" || !ws[k].trim()) errors.push(`${tag}: "${k}" must be a non-empty string`);
+    }
+    if (ids.has(ws.id)) errors.push(`duplicate workstream id "${ws.id}"`);
+    ids.add(ws.id);
+    if (!Array.isArray(ws.files) || ws.files.length === 0) errors.push(`${tag}: "files" must be a non-empty array`);
+    if (!Array.isArray(ws.dependencies)) errors.push(`${tag}: "dependencies" must be an array`);
+    for (const dep of ws.dependencies || []) {
+      if (!m.workstreams.some((w) => w?.id === dep)) errors.push(`${tag}: dependency "${dep}" is not a workstream id`);
+    }
+    if (!Array.isArray(ws.checks)) errors.push(`${tag}: "checks" must be an array`);
+    for (const c of ws.checks || []) {
+      for (const k of Object.keys(c)) if (!CHECK_FIELDS.has(k)) errors.push(`${tag}: unknown check field "${k}"`);
+      if (!CHECK_TYPES.has(c.type)) errors.push(`${tag}: unknown check type "${c.type}"`);
+      if (typeof c.path !== "string" || !c.path) errors.push(`${tag}: check missing "path"`);
+      if (c.type === "file_contains" && (typeof c.needle !== "string" || !c.needle)) errors.push(`${tag}: file_contains check missing "needle"`);
+      if (c.grade !== undefined && !GRADES.has(c.grade)) errors.push(`${tag}: unknown grade "${c.grade}"`);
+    }
+    if (ws.test !== undefined) {
+      if (!ws.test || typeof ws.test.cmd !== "string" || !Array.isArray(ws.test.args)) {
+        errors.push(`${tag}: "test" must be {cmd, args[]}`);
+      }
+    }
+  }
+  if (errors.length) fail(errors);
+  return m;
+}
+
+/**
+ * Workstreams with checks attached (the bout stage's input shape).
+ * Checks are passed through verbatim — grade fields ride along for the
+ * claim-typing layer without affecting hashes for ungraded manifests.
+ */
+export function workstreamsFromManifest(m) {
+  return m.workstreams.map((ws) => ({ ...ws, checks: ws.checks.map((c) => ({ ...c })) }));
+}
+
+/**
+ * Deterministic task defs for computePlan. A workstream's node test is its
+ * explicit {cmd,args} test, else the generic check-runner over its checks
+ * (checkNodePath — the caller supplies the absolute check-node.mjs path).
+ * Grade fields are STRIPPED from the test specs so grading (advisory
+ * metadata) never re-hashes an existing plan.
+ */
+export function defsFromManifest(m, { checkNodePath }) {
+  if (!checkNodePath) throw new Error("defsFromManifest: checkNodePath is required");
+  return m.workstreams.map((ws) => ({
+    id: ws.id,
+    files: [...ws.files],
+    requirements: ws.requirements,
+    test: ws.test
+      ? { cmd: ws.test.cmd, args: [...ws.test.args] }
+      : { cmd: "node", args: [checkNodePath, JSON.stringify(ws.checks.map(({ grade, ...c }) => c))] },
+    dependencies: [...ws.dependencies]
+  }));
+}
+
+/** Dossier metadata (gate input) from the manifest. */
+export function dossierFromManifest(m) {
+  const d = {
+    build_id: m.build_id,
+    idea_id: m.idea_id || m.build_id,
+    use_case: m.use_case || "forge-run",
+    objective: m.objective,
+    required_market_workstreams: m.workstreams.map((w) => w.id)
+  };
+  if (m.business_thesis) d.business_thesis = m.business_thesis;
+  if (Array.isArray(m.target_users)) d.target_users = m.target_users;
+  return d;
+}

--- a/forge/package.json
+++ b/forge/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "The adversarial-convergence doctrine as an engine: ratchet runs (Styx rule, blocker respec, contract closure, verify-failure banking, evidence-digest approvals) and fixed-point drivers, extracted from the gate-PASSED live runs.",
   "scripts": {
-    "check": "node --check ratchet.mjs && node --check driver.mjs && node --check scripts/test-ratchet.mjs && node --check scripts/test-driver.mjs",
-    "test": "npm run check && node scripts/test-ratchet.mjs && node scripts/test-driver.mjs"
+    "check": "node --check ratchet.mjs && node --check driver.mjs && node --check manifest.mjs && node --check scripts/test-ratchet.mjs && node --check scripts/test-driver.mjs && node --check scripts/test-manifest.mjs",
+    "test": "npm run check && node scripts/test-ratchet.mjs && node scripts/test-driver.mjs && node scripts/test-manifest.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/forge/scripts/test-manifest.mjs
+++ b/forge/scripts/test-manifest.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+// Manifest tests: fail-closed validation (unknown fields, bad checks, dangling
+// deps, duplicates), deterministic def derivation, grade fields riding along
+// without touching test specs, dossier extraction.
+
+import assert from "node:assert/strict";
+import { validateManifest, workstreamsFromManifest, defsFromManifest, dossierFromManifest } from "../manifest.mjs";
+
+const GOOD = {
+  build_id: "demo",
+  telos: "Ship it.",
+  objective: "Certify the thing.",
+  business_thesis: "Thesis.",
+  target_users: ["people"],
+  workstreams: [
+    {
+      id: "a", signer: "codex", lens: "codex", dependencies: [],
+      files: ["docs/A.md"], requirements: "REQ-A",
+      checks: [
+        { type: "file_exists", path: "docs/A.md" },
+        { type: "file_contains", path: "docs/A.md", needle: "alpha", grade: "inspectable" }
+      ]
+    },
+    {
+      id: "b", signer: "claude", lens: "grok", dependencies: ["a"],
+      files: ["evals/run.mjs"], requirements: "REQ-B",
+      checks: [{ type: "file_exists", path: "evals/run.mjs" }],
+      test: { cmd: "node", args: ["evals/run.mjs"] },
+      isUi: false, findingsKey: "accuracy_eval_findings", finding: "F"
+    }
+  ]
+};
+
+// 1. A good manifest validates (returns the manifest); every corruption fails
+//    CLOSED with a named error.
+{
+  const m = structuredClone(GOOD);
+  assert.equal(validateManifest(m), m, "valid manifest returned unchanged");
+}
+{
+  const cases = [
+    [(m) => { m.surprise = 1; }, /unknown manifest field "surprise"/],
+    [(m) => { delete m.objective; }, /"objective" must be a non-empty string/],
+    [(m) => { m.workstreams[0].sneaky = 1; }, /unknown field "sneaky"/],
+    [(m) => { m.workstreams[0].checks[0].type = "file_maybe"; }, /unknown check type/],
+    [(m) => { delete m.workstreams[0].checks[1].needle; }, /missing "needle"/],
+    [(m) => { m.workstreams[1].dependencies = ["ghost"]; }, /dependency "ghost"/],
+    [(m) => { m.workstreams[1].id = "a"; }, /duplicate workstream id/],
+    [(m) => { m.workstreams[0].checks[1].grade = "vibes"; }, /unknown grade "vibes"/],
+    [(m) => { m.workstreams[1].test = { cmd: "node" }; }, /"test" must be \{cmd, args\[\]\}/]
+  ];
+  for (const [corrupt, re] of cases) {
+    const m = structuredClone(GOOD);
+    corrupt(m);
+    assert.throws(() => validateManifest(m), re, `expected ${re}`);
+  }
+}
+
+// 2. defsFromManifest is deterministic, honors explicit tests, and strips
+//    grade fields from check-derived test specs (grading never re-hashes).
+{
+  const defs1 = defsFromManifest(structuredClone(GOOD), { checkNodePath: "/x/check-node.mjs" });
+  const defs2 = defsFromManifest(structuredClone(GOOD), { checkNodePath: "/x/check-node.mjs" });
+  assert.deepEqual(defs1, defs2, "deterministic");
+  assert.deepEqual(defs1[1].test, { cmd: "node", args: ["evals/run.mjs"] }, "explicit test honored");
+  const specs = JSON.parse(defs1[0].test.args[1]);
+  assert.deepEqual(specs[1], { type: "file_contains", path: "docs/A.md", needle: "alpha" }, "grade stripped from test spec");
+
+  const graded = structuredClone(GOOD);
+  delete graded.workstreams[0].checks[1].grade;
+  const defsUngraded = defsFromManifest(graded, { checkNodePath: "/x/check-node.mjs" });
+  assert.deepEqual(defs1, defsUngraded, "adding/removing grades does not change defs (hash-stable)");
+}
+
+// 3. workstreamsFromManifest keeps grades for the bout layer.
+{
+  const ws = workstreamsFromManifest(structuredClone(GOOD));
+  assert.equal(ws[0].checks[1].grade, "inspectable", "grades ride to the bout layer");
+}
+
+// 4. dossierFromManifest carries thesis/users and derives required workstreams.
+{
+  const d = dossierFromManifest(GOOD);
+  assert.deepEqual(d.required_market_workstreams, ["a", "b"]);
+  assert.equal(d.business_thesis, "Thesis.");
+  assert.equal(d.idea_id, "demo", "idea_id defaults to build_id");
+}
+
+console.log("test-manifest: all assertions passed");


### PR DESCRIPTION
## What

Batch 2: product specs become declarative. A new idea = one `manifest.json` (dossier + workstreams with files, contracts, checks, seats) + one driver invocation.

- **`forge/manifest.mjs`** — fail-closed validation (unknown fields/check types/deps/duplicates all reject), deterministic def derivation, dossier extraction
- Check `grade` fields validate and reach the bout layer but are stripped from test specs — grading never re-hashes an existing plan (claim typing is Batch 3)
- Both run families emit (`TELOS_EMIT_MANIFEST=1`) and load manifests; in-file specs remain the authoring source

## Verification

Both emitted manifests replayed through their **gate-PASSED workdirs**: ALL-CONVERGED, **`seat_calls: 0`** — manifest-derived defs are hash-identical to the inline derivation (any drift would have re-dispatched builds and broken the Styx skips).

forge suite: 3 test files green (ratchet, driver, manifest).

## Trust surface

Untouched — validation is fail-closed, derivation is deterministic, and grading is advisory metadata by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCUka2ejCPt7GGUwALZwp8