### PR TITLE
feat(forge): epistemic claim typing

### DIFF
--- a/docs/runs/crossroad-threads/manifest.json
+++ b/docs/runs/crossroad-threads/manifest.json
@@ -61,7 +61,17 @@
       ],
       "isUi": false,
       "findingsKey": "architecture_findings",
-      "finding": "Commerce gap audit: what selling on its own domain actually requires."
+      "finding": "Commerce gap audit: what selling on its own domain actually requires.",
+      "claims": [
+        {
+          "statement": "No purchase path (cart/checkout/payments) exists in the current repository",
+          "grade": "cited"
+        },
+        {
+          "statement": "The order, transaction, and POD pipelines are each specified with stages, AWS placement, and failure handling",
+          "grade": "inspectable"
+        }
+      ]
     },
     {
       "id": "positioning-launch",
@@ -104,7 +114,17 @@
       ],
       "isUi": false,
       "findingsKey": "accuracy_eval_findings",
-      "finding": "Launch positioning: hypothesis-framed ICP, pricing, and differentiation for a real, shipped brand."
+      "finding": "Launch positioning: hypothesis-framed ICP, pricing, and differentiation for a real, shipped brand.",
+      "claims": [
+        {
+          "statement": "The museum conceit differentiates the brand enough to command premium tee pricing",
+          "grade": "hypothesis"
+        },
+        {
+          "statement": "Collectors of narrative apparel are the primary ICP segment",
+          "grade": "hypothesis"
+        }
+      ]
     },
     {
       "id": "launch-architecture",
@@ -156,7 +176,17 @@
       ],
       "isUi": false,
       "findingsKey": "scalability_findings",
-      "finding": "Own-domain launch architecture: hosting, DNS, CDN, basePath migration, asset strategy."
+      "finding": "Own-domain launch architecture: hosting, DNS, CDN, basePath migration, asset strategy.",
+      "claims": [
+        {
+          "statement": "The current build is coupled to the GitHub Pages basePath in next.config.ts",
+          "grade": "cited"
+        },
+        {
+          "statement": "S3+CloudFront serves the static export with commerce services as Docker containers",
+          "grade": "inspectable"
+        }
+      ]
     },
     {
       "id": "security-trust",
@@ -356,7 +386,17 @@
       ],
       "isUi": false,
       "findingsKey": "accuracy_eval_findings",
-      "finding": "Digital advertising launch plan: hypothesis-framed demographics, channel strategy, creative system, measurement."
+      "finding": "Digital advertising launch plan: hypothesis-framed demographics, channel strategy, creative system, measurement.",
+      "claims": [
+        {
+          "statement": "Meta (FB+IG) is the primary paid channel at the $250-500/mo test budget",
+          "grade": "hypothesis"
+        },
+        {
+          "statement": "The audio-tour and exhibit lore convert natively to short-video ad creative",
+          "grade": "hypothesis"
+        }
+      ]
     }
   ]
 }

--- a/forge/claims.mjs
+++ b/forge/claims.mjs
@@ -1,0 +1,68 @@
+// claims.mjs — epistemic claim typing: claims graded by what can settle them.
+//
+// The deepest lesson of the live runs: convergence speed tracks claim
+// verifiability, and every stall was a GRADE MISMATCH — adversaries demanding
+// executable proof of a hypothesis, or live evidence from a document. Typing
+// makes the fix structural: each claim carries the strongest truth-grade its
+// artifact can actually access, and challengers are bound to judge it at that
+// grade — no stronger (unwinnable), no weaker (rubber stamp).
+//
+//   executable   settled by RUNNING something (a test, a script) — dispute only
+//                with a failing execution
+//   inspectable  settled by LOOKING at the artifact (deterministic checks,
+//                literal content) — dispute only with a concrete text defect
+//   cited        settled by a SOURCE present in evidence — a missing/wrong
+//                citation is a valid blocker; demanding sources beyond the
+//                evidence is not
+//   hypothesis   not settleable yet (pre-market, forward-looking) — judge
+//                LABELING, assumptions, internal coherence, and the validation
+//                plan; never the truth of the claim itself
+
+export const GRADES = ["executable", "inspectable", "cited", "hypothesis"];
+
+const GRADE_RULES = {
+  executable:
+    "EXECUTABLE claims are settled by running their test. Valid blocker: a failing execution or a test that " +
+    "does not cover the claim. Invalid: stylistic doubts about code a passing test already vouches for.",
+  inspectable:
+    "INSPECTABLE claims are settled by the artifact's literal content and its deterministic checks. Valid " +
+    "blocker: a concrete text defect (contradiction, missing required content, broken example) cited by " +
+    "location. Invalid: preferences about how the content could be nicer.",
+  cited:
+    "CITED claims are settled by sources present in the evidence. Valid blocker: a claim whose citation is " +
+    "missing, wrong, or contradicted by the cited source. Invalid: demanding sources beyond the evidence " +
+    "provided to this bout.",
+  hypothesis:
+    "HYPOTHESIS claims cannot be settled yet — judge only (a) explicit labeling as hypothesis, (b) stated " +
+    "assumptions, (c) internal coherence, (d) a falsifiable validation plan. Valid blocker: an unlabeled " +
+    "forward-looking claim presented as fact, a hidden assumption, or an untestable formulation. Invalid: " +
+    "disputing the hypothesis's truth or demanding market/operational proof that does not exist yet."
+};
+
+/**
+ * Render the claim ledger + per-grade adjudication rules for a bout's contract.
+ * `claims` = [{statement, grade}]. Returns "" when there are none (bouts
+ * without declared claims keep their existing behavior byte-for-byte).
+ */
+export function renderClaimRules(claims) {
+  if (!Array.isArray(claims) || claims.length === 0) return "";
+  const byGrade = new Map();
+  for (const c of claims) {
+    if (!c || typeof c.statement !== "string" || !GRADES.includes(c.grade)) continue;
+    if (!byGrade.has(c.grade)) byGrade.set(c.grade, []);
+    byGrade.get(c.grade).push(c.statement);
+  }
+  if (byGrade.size === 0) return "";
+  const sections = [];
+  for (const grade of GRADES) {
+    const list = byGrade.get(grade);
+    if (!list) continue;
+    sections.push(
+      `[${grade.toUpperCase()}] ${GRADE_RULES[grade]}\nClaims at this grade:\n` +
+      list.map((s) => `  - ${s.slice(0, 300)}`).join("\n")
+    );
+  }
+  return "\n=== CLAIM LEDGER (each claim is judged AT ITS GRADE — demanding a stronger grade than the " +
+    "artifact can access is an invalid blocker; accepting a weaker one is a rubber stamp) ===\n" +
+    sections.join("\n\n") + "\n";
+}

--- a/forge/manifest.mjs
+++ b/forge/manifest.mjs
@@ -18,8 +18,9 @@ const MANIFEST_FIELDS = new Set([
 ]);
 const WORKSTREAM_FIELDS = new Set([
   "id", "signer", "lens", "dependencies", "files", "requirements",
-  "checks", "test", "isUi", "findingsKey", "finding"
+  "checks", "test", "isUi", "findingsKey", "finding", "claims"
 ]);
+const CLAIM_FIELDS = new Set(["statement", "grade"]);
 const CHECK_FIELDS = new Set(["type", "path", "needle", "grade"]);
 const CHECK_TYPES = new Set(["file_exists", "file_contains"]);
 const GRADES = new Set(["executable", "inspectable", "cited", "hypothesis"]);
@@ -68,6 +69,14 @@ export function validateManifest(m) {
     if (ws.test !== undefined) {
       if (!ws.test || typeof ws.test.cmd !== "string" || !Array.isArray(ws.test.args)) {
         errors.push(`${tag}: "test" must be {cmd, args[]}`);
+      }
+    }
+    if (ws.claims !== undefined) {
+      if (!Array.isArray(ws.claims)) errors.push(`${tag}: "claims" must be an array`);
+      for (const c of ws.claims || []) {
+        for (const k of Object.keys(c)) if (!CLAIM_FIELDS.has(k)) errors.push(`${tag}: unknown claim field "${k}"`);
+        if (typeof c.statement !== "string" || !c.statement.trim()) errors.push(`${tag}: claim missing "statement"`);
+        if (!GRADES.has(c.grade)) errors.push(`${tag}: claim grade "${c.grade}" is not one of ${[...GRADES].join("|")}`);
       }
     }
   }

--- a/forge/package.json
+++ b/forge/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "description": "The adversarial-convergence doctrine as an engine: ratchet runs (Styx rule, blocker respec, contract closure, verify-failure banking, evidence-digest approvals) and fixed-point drivers, extracted from the gate-PASSED live runs.",
   "scripts": {
-    "check": "node --check ratchet.mjs && node --check driver.mjs && node --check manifest.mjs && node --check scripts/test-ratchet.mjs && node --check scripts/test-driver.mjs && node --check scripts/test-manifest.mjs",
-    "test": "npm run check && node scripts/test-ratchet.mjs && node scripts/test-driver.mjs && node scripts/test-manifest.mjs"
+    "check": "node --check ratchet.mjs && node --check driver.mjs && node --check manifest.mjs && node --check claims.mjs && node --check scripts/test-ratchet.mjs && node --check scripts/test-driver.mjs && node --check scripts/test-manifest.mjs && node --check scripts/test-claims.mjs",
+    "test": "npm run check && node scripts/test-ratchet.mjs && node scripts/test-driver.mjs && node scripts/test-manifest.mjs && node scripts/test-claims.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/forge/ratchet.mjs
+++ b/forge/ratchet.mjs
@@ -31,6 +31,7 @@ import path from "node:path";
 import { generateKeypair } from "../merkle-dag/crypto.mjs";
 import { reverifyRecord } from "../breakout/verifier.mjs";
 import { runBreakout } from "../breakout/breakout.mjs";
+import { renderClaimRules } from "./claims.mjs";
 
 export const loadJson = (p, fallback) => {
   try { return JSON.parse(readFileSync(p, "utf8")); } catch { return fallback; }
@@ -176,7 +177,10 @@ export async function runBouts({ workstreams, state, makeFns, defById, hashById,
     }
     log(`bout ${ws.id}: fighting...`);
     const closure = contractClosure(state, ws.id);
-    const fns = makeFns({ workstream: ws.id, checks, baseDir: state.workdir, contract: (defById.get(ws.id)?.requirements || "") + closure });
+    // Epistemic claim typing: declared claims join the contract with per-grade
+    // adjudication rules — challengers judge each claim AT its grade.
+    const claimRules = renderClaimRules(ws.claims);
+    const fns = makeFns({ workstream: ws.id, checks, baseDir: state.workdir, contract: (defById.get(ws.id)?.requirements || "") + claimRules + closure });
     const record = await runBreakout(
       { workstream: ws.id, claimedStatus: "meets", goalStatus: "meets",
         evidence: `${ws.id} artifacts: ${ws.files.join(", ")}` },

--- a/forge/scripts/test-claims.mjs
+++ b/forge/scripts/test-claims.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+
+// Claim-typing tests: grade rules render per declared grade, claims group
+// correctly, empty/absent claims change nothing, invalid entries are ignored
+// by the renderer (validation rejects them upstream), and the bout stage
+// injects the ledger into contested contracts only.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { renderClaimRules, GRADES } from "../claims.mjs";
+import { validateManifest } from "../manifest.mjs";
+import { openState, runBouts } from "../ratchet.mjs";
+
+// 1. No claims -> empty string (existing bouts byte-identical).
+{
+  assert.equal(renderClaimRules(undefined), "");
+  assert.equal(renderClaimRules([]), "");
+  assert.equal(renderClaimRules([{ statement: "x", grade: "vibes" }]), "", "unknown grades render nothing");
+}
+
+// 2. Claims group by grade with each grade's adjudication rule, in grade order.
+{
+  const out = renderClaimRules([
+    { statement: "Pricing tiers convert at 2%", grade: "hypothesis" },
+    { statement: "schema.sql defines RLS policies", grade: "inspectable" },
+    { statement: "evals clear the 0.90 threshold", grade: "executable" },
+    { statement: "Next.js static export forbids next/image optimization", grade: "cited" }
+  ]);
+  assert.ok(out.includes("CLAIM LEDGER"));
+  for (const g of GRADES) assert.ok(out.includes(`[${g.toUpperCase()}]`), `${g} rule present`);
+  assert.ok(out.indexOf("[EXECUTABLE]") < out.indexOf("[HYPOTHESIS]"), "grade order stable");
+  assert.ok(out.includes("Pricing tiers convert at 2%"));
+  assert.ok(out.includes("never the truth of the claim") || out.includes("disputing the hypothesis's truth"), "hypothesis rule protects truth-judgment boundary");
+}
+
+// 3. Manifest validation: claims accepted with valid grades, rejected otherwise.
+{
+  const base = {
+    build_id: "b", telos: "t", objective: "o",
+    workstreams: [{
+      id: "a", signer: "codex", lens: "codex", dependencies: [], files: ["a.md"],
+      requirements: "R", checks: [{ type: "file_exists", path: "a.md" }],
+      claims: [{ statement: "S", grade: "hypothesis" }]
+    }]
+  };
+  validateManifest(structuredClone(base));
+  const bad1 = structuredClone(base);
+  bad1.workstreams[0].claims[0].grade = "vibes";
+  assert.throws(() => validateManifest(bad1), /claim grade "vibes"/);
+  const bad2 = structuredClone(base);
+  bad2.workstreams[0].claims[0].proof = "trust me";
+  assert.throws(() => validateManifest(bad2), /unknown claim field "proof"/);
+}
+
+// 4. runBouts injects the ledger into the contested contract (and only there).
+{
+  const w = mkdtempSync(path.join(os.tmpdir(), "forge-claims-"));
+  mkdirSync(path.join(w, ".telos"), { recursive: true });
+  const state = openState(w);
+  const contracts = [];
+  const makeFns = ({ contract }) => {
+    contracts.push(contract);
+    return { challenge: async () => ({ blockers: [] }), revise: async () => ({ evidence: "e", resolved: [] }) };
+  };
+  const workstreams = [{
+    id: "graded", files: ["g.md"], checks: [], lens: "claude", signer: "claude",
+    claims: [{ statement: "The moat is the museum conceit", grade: "hypothesis" }]
+  }];
+  const defById = new Map([["graded", { id: "graded", requirements: "REQ" }]]);
+  await runBouts({ workstreams, state, makeFns, defById, hashById: new Map(), telosDir: path.join(w, ".telos") });
+  assert.ok(contracts[0].startsWith("REQ"), "requirements lead the contract");
+  assert.ok(contracts[0].includes("CLAIM LEDGER"), "claim ledger joined the contract");
+  assert.ok(contracts[0].includes("museum conceit"));
+}
+
+console.log("test-claims: all assertions passed");


### PR DESCRIPTION
## What

Batch 3: claims graded by epistemic access, challengers bound to judge at the declared grade.

- `forge/claims.mjs` — four grades with adjudication rules; the CLAIM LEDGER contract section
- Manifest `claims` field, fail-closed validation, hash-neutral by construction and by test
- `runBouts` injects the ledger into contested contracts; Crossroad's manifest carries a real claim inventory

## Verification

forge suite green (4 test files); both gate-PASSED replays remain ALL-CONVERGED with `seat_calls: 0` after annotation — grading provably lives at the prompt layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCUka2ejCPt7GGUwALZwp8