### PR TITLE
ci: authenticate Claude workflows with the subscription, not metered API credits

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate with the Claude subscription (Max), NOT metered API credits.
+          # Mint with `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Responds to @claude mentions in issues and PR comments.
           # Add `claude_args` to pass CLI options, e.g.:
           # claude_args: "--max-turns 10 --model claude-sonnet-4-6"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,7 +23,11 @@ jobs:
       - name: Automated Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate with the Claude subscription (Max), NOT metered API credits.
+          # Mint with `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          # The token is long-lived but NOT eternal — when it lapses this check fails fast
+          # (~15s, is_error with no findings), which looks identical to an exhausted balance.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Install the code-review plugin and run its skill against this PR.
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"


### PR DESCRIPTION
## Run Claude CI on the subscription, not metered API credits

Both Claude workflows authenticated with `anthropic_api_key`, so every PR review burned pay-as-you-go
credits. That balance ran out — and the failure was **silent in the worst way**:

```
Automated Claude review — 21s
  "is_error": true, "duration_ms": 360, "num_turns": 1, "total_cost_usd": 0
```

Zero cost means nothing was billed, because there was nothing left to bill. The action hides Claude's
output for security, so the check went red with **no findings and no error text** — a red that looked
like a verdict but was an empty tank. Three runs died that way (plus an ultrareview) across two
branches before the cause was found.

### Change

Both workflows switch to `claude_code_oauth_token` (secret `CLAUDE_CODE_OAUTH_TOKEN`, minted with
`claude setup-token`). CI now runs on the Claude subscription. `ANTHROPIC_API_KEY` is left in place as
a fallback until the OAuth path is proven green.

### Why this is its own PR

`claude-code-action` **refuses to run on any PR that modifies `.github/workflows/`** — a security
control against a PR rewriting the workflow to exfiltrate secrets. It skips by **exiting 0**:

```
Action skipped due to workflow validation error... Exiting due to workflow validation skip
```

So carrying this fix inside a feature PR disables that PR's own review *and turns its check green* — a
check that certifies nothing while looking authoritative. That is precisely the failure mode this repo
exists to prevent, so the workflow change is isolated here and feature PRs stay free of workflow edits.

**This PR's own review will self-skip and go green. That is expected and is not evidence of anything.**
Once merged, subsequent PRs get a real review.

### Verification

- YAML parses; no `anthropic_api_key` reference remains in either workflow.
- The token's eventual expiry is documented inline in `code-review.yml`: a lapsed token looks
  **identical** to an exhausted balance (fast `is_error`, no findings). The tell is **duration** — a
  15-second review is a corpse; a real one takes minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)