### PR TITLE
ci: make the automated review auditable — post findings with --comment

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,4 +31,9 @@ jobs:
           # Install the code-review plugin and run its skill against this PR.
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # --comment POSTS findings as inline PR comments. Without it the review still runs
+          # (minutes, real cost) and then DISCARDS its conclusion: `show_full_output` is false
+          # (and must stay false — this repo is public and those logs are world-readable), so an
+          # unposted finding is unrecoverable. The check then means only "the reviewer did not
+          # crash", never "the code is fine". A review that cannot report is not an audit.
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"


### PR DESCRIPTION
## Make the automated review auditable

The review **already works**. On PR #84 it ran for real:

```
"is_error": false,  "num_turns": 8,  "duration_ms": 448347,  "total_cost_usd": 5.789
"No buffered inline comments"
```

Eight turns. Seven and a half minutes. **$5.79.** And then it threw the answer away.

### Why the green check means nothing

Two things conspire:

- **No `--comment`** in the prompt → the action posts no inline comments, submits no review. Findings
  die with the runner.
- **`show_full_output: false`** → the reasoning isn't in the logs either. And it **must stay false**:
  this repo is public, and the action warns those logs are world-readable and may contain secrets.

So the conclusion is **unrecoverable by anyone**. The check reports `success` — but that only ever
meant *"the reviewer did not crash."* It has never meant *"no findings."* A green here is a receipt
that money was spent, not evidence that code was read.

That is this project's thesis inverted. TELOS exists to make judgment **auditable** — evidence over
self-report, a gate that certifies from artifacts rather than assurances. Its own CI was paying real
money per PR to manufacture an unauditable badge.

### Change

Add `--comment` to the prompt so findings land as inline PR comments, where a human — and the next
agent — can actually read them.

```diff
- prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ ... }}"
+ prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ ... }} --comment"
```

The rationale is recorded inline in the workflow, so the next person to touch it doesn't have to
re-derive it from a `total_cost_usd` field.

### Why this is its own PR (again)

`claude-code-action` refuses to run on any PR that modifies `.github/workflows/` — a security control
against a PR rewriting the workflow to exfiltrate secrets — and it **skips by exiting 0, i.e. GREEN**.
A workflow fix carried inside a feature PR therefore disables that PR's own review while making its
badge read PASS. **This PR's own review will self-skip and go green. That is expected and is evidence
of nothing.**

### Verification

- YAML parses; built server-side on top of #85 (`a9939ab`), so it carries the subscription auth.
- The real test is empirical and comes *after* merge: the next review on #84 should post inline
  comments. **Duration remains the tell** — 15 seconds is a corpse, minutes is a real review — and
  now "posted findings" becomes a second, stronger signal.
- If `--comment` turns out to be the wrong flag position for the plugin, the symptom is unchanged
  (runs, posts nothing) and we iterate. That's a known-unknown, stated rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)