### PR TITLE
ci: land Claude workflow fixes on the default branch (subscription auth + auditable findings)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Run Claude Code
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate with the Claude subscription (Max), NOT metered API credits.
+          # Mint with `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Responds to @claude mentions in issues and PR comments.
           # Add `claude_args` to pass CLI options, e.g.:
           # claude_args: "--max-turns 10 --model claude-sonnet-4-6"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -23,8 +23,17 @@ jobs:
       - name: Automated Claude review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Authenticate with the Claude subscription (Max), NOT metered API credits.
+          # Mint with `claude setup-token` and store as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          # The token is long-lived but NOT eternal — when it lapses this check fails fast
+          # (~15s, is_error with no findings), which looks identical to an exhausted balance.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Install the code-review plugin and run its skill against this PR.
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
-          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # --comment POSTS findings as inline PR comments. Without it the review still runs
+          # (minutes, real cost) and then DISCARDS its conclusion: `show_full_output` is false
+          # (and must stay false — this repo is public and those logs are world-readable), so an
+          # unposted finding is unrecoverable. The check then means only "the reviewer did not
+          # crash", never "the code is fine". A review that cannot report is not an audit.
+          prompt: "/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment"


### PR DESCRIPTION
## Land the Claude workflow fixes where validation actually reads them

`claude-code-action` validates that a PR's workflow file is **identical to the copy on the repository's
default branch**:

```
Workflow validation failed. The workflow file must exist and have identical content to the
version on the repository's DEFAULT BRANCH.
```

That's stricter than "PRs that change workflows get skipped" — a PR whose *base* carries a different
workflow is skipped too. And it skips by **exiting 0 — GREEN**.

So #85 and #86, merged into `contracts/proposal-lifecycle`, don't take effect. Worse: they made every
PR on that base **differ from `main`**, which *disabled* the reviewer that was previously working —
while its check reported PASS. A working reviewer was turned off and the badge kept saying pass.

This PR ports both fixes to `main`.

### 1. Subscription auth, not metered credits

`anthropic_api_key` → `claude_code_oauth_token` (`CLAUDE_CODE_OAUTH_TOKEN`, minted via
`claude setup-token`).

When that API balance emptied, reviews died in ~20s:

```
"is_error": true,  "duration_ms": 360,  "num_turns": 1,  "total_cost_usd": 0
```

Zero cost = nothing billed = nothing left to bill. With output hidden, the check went red with **no
findings and no error text** — a red that looked like a verdict but was an empty tank.

### 2. `--comment`, so the review can actually report

Observed on #84 — the review works and then throws the answer away:

```
"is_error": false,  "num_turns": 8,  "duration_ms": 448347,  "total_cost_usd": 5.789
"No buffered inline comments"
```

Eight turns, 7m28s, **$5.79**, conclusion discarded. `show_full_output` must stay `false` (this repo is
public; those logs are world-readable and may contain secrets), so an unposted finding is
**unrecoverable by anyone**. That green only ever meant *"the reviewer did not crash"* — never *"no
findings."*

**A review that cannot report is not an audit.** This repo's entire argument is that judgment must be
certified from artifacts, not assurances. Its own CI was spending real money per PR to emit a badge
with no artifact behind it.

### Expectations

- **This PR's own review will self-skip and go green.** Expected. Evidence of nothing.
- Once merged, PRs get a review that runs for **minutes** and **posts inline findings**. Duration
  remains the cheap tell: ~15s is a corpse, minutes is real.
- `--comment`'s exact flag position is unverified against the plugin's skill definition (not readable
  from here). If findings still don't post, the symptom is unchanged and we iterate — stated rather
  than assumed.
- `ANTHROPIC_API_KEY` is left in place as a fallback until the OAuth path is proven green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)