### PR TITLE
docs: distinguish CI credentials from local-dev env vars

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,13 @@ This is the core invariant of the project. When changing gate, signing, or prove
   env-only; when unset, the autonomous proposal-lifecycle entry point uses an ephemeral per-run key.
   Runtime `.telos/` artifacts are ephemeral and git-ignored — never commit them, `*.pem`, or
   `.env*` files.
+- **CI credentials are a SEPARATE thing from the env vars above.** The API keys listed above are
+  LOCAL-dev env vars. The repository's only GitHub Actions secret is `CLAUDE_CODE_OAUTH_TOKEN` (a
+  Claude subscription token, minted with `claude setup-token`), which funds the automated review
+  workflows; `ANTHROPIC_API_KEY` was removed as a repo secret once subscription auth was proven, so
+  CI has no metered fallback. Do not read a local env var's name as evidence of a CI credential — in
+  a job log, `ANTHROPIC_API_KEY:` may appear DECLARED AND EMPTY beside the token that actually
+  authenticated.
 - Prefer failing closed: if evidence is absent or ambiguous, block rather than approve.
 
 ## Pull requests


### PR DESCRIPTION
## Distinguish CI credentials from local-dev env vars

`CLAUDE.md`'s secrets section listed `ANTHROPIC_API_KEY` / `XAI_API_KEY` / `OPENAI_API_KEY` /
`GEMINI_API_KEY` as env vars, but said nothing about CI — leaving the two conflatable. They're now
genuinely different things:

- **Local dev:** those API keys, in your env / OS registry.
- **CI:** exactly one Actions secret, `CLAUDE_CODE_OAUTH_TOKEN` (Claude subscription, minted with
  `claude setup-token`). `ANTHROPIC_API_KEY` was **deleted as a repo secret** once subscription auth
  was proven, so CI has **no metered fallback**.

It also records a trap that cost real time today. The action resolves:

```yaml
ANTHROPIC_API_KEY: ${{ inputs.anthropic_api_key || env.ANTHROPIC_API_KEY }}
```

With the workflow no longer passing it, the job env shows **`ANTHROPIC_API_KEY:` declared and empty**
right next to `CLAUDE_CODE_OAUTH_TOKEN: ***`. Grepping a log for the name matches the empty variable
and reads like a live credential. **A match is not a value.** (Relatedly: `total_cost_usd` is non-zero
even on subscription, so cost doesn't identify the payer either.)

### Secondary purpose

This PR also **verifies the review still runs** after the `ANTHROPIC_API_KEY` secret deletion. It
deliberately touches **no workflow file**, so it won't self-skip. Expected: the review runs for
**minutes** on the subscription and posts findings (or passes cleanly) — not a ~15s corpse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)