### PR TITLE
seats: blacklist Claude Code product-identity impersonation

### DIFF
--- a/connectors/ai-peer-mcp/server.mjs
+++ b/connectors/ai-peer-mcp/server.mjs
@@ -431,8 +431,26 @@ function claudeAuth() {
   return { mode: "api-key", headers: { "x-api-key": requireEnv("ANTHROPIC_API_KEY") } };
 }
 
+// Blacklisted: this seat is a third-party harness and must NEVER impersonate the
+// Claude Code product identity. Anthropic's Authentication and Credential Use
+// policy scopes Free/Pro/Max OAuth to Claude Code and claude.ai only; injecting
+// the "You are Claude Code" identity to make a subscription-OAuth token accept
+// this application's traffic is prohibited credential misuse. The guard makes the
+// prohibition structural — a system prompt asserting the reserved product
+// identity is rejected before any request is built — so the seat can only ever
+// authenticate as itself (plain bearer or api-key), never by pretending to be
+// the CLI. The plain-bearer path (a legitimately API-scoped token) is unaffected.
+const BLACKLISTED_PRODUCT_IDENTITY = /you are claude code,?\s+anthropic'?s official cli/i;
+function assertNoProductImpersonation(system) {
+  const text = Array.isArray(system) ? system.map((b) => (b && b.text) || "").join("\n") : (system || "");
+  if (BLACKLISTED_PRODUCT_IDENTITY.test(text)) {
+    throw new Error("Refusing to send the Claude Code product identity: this seat must not impersonate Claude Code to a subscription-scoped OAuth token (Anthropic Authentication and Credential Use policy). Use a legitimately API-scoped credential.");
+  }
+}
+
 export async function askClaude(args) {
   requireString(args.prompt, "prompt");
+  assertNoProductImpersonation(args.system);
   const auth = claudeAuth();
   const rawModel = args.model || process.env.ANTHROPIC_MODEL;
   if (!rawModel) {


### PR DESCRIPTION
Codifies the line reached under cost pressure: the claude seat must never impersonate the Claude Code product identity to route a subscription-OAuth token into this third-party harness.

`assertNoProductImpersonation()` rejects any system prompt asserting the reserved "You are Claude Code, Anthropic's official CLI" identity (string or array form) before a request is built. The seat authenticates only as itself. Grounded in Anthropic's Authentication and Credential Use policy (Feb 2026, enforced Apr 4 2026): Free/Pro/Max OAuth is scoped to Claude Code / claude.ai, not third-party products.

The legitimate paths are unaffected — a plain API-scoped bearer token (`ANTHROPIC_AUTH_TOKEN`) and the metered `ANTHROPIC_API_KEY` both work as before. Only the impersonation string is blacklisted.

Verified: ai-peer-mcp suite green; normal seat prompts pass; product identity rejected in both system forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eCSN1Z9qGqrAnpDGNzqdF