### PR TITLE
Wire parallel authorship into the proposal orchestrator (opt-in, serial-default)

### DIFF
--- a/build-gate/build-orchestrator.mjs
+++ b/build-gate/build-orchestrator.mjs
@@ -138,7 +138,7 @@ export function makeTeamKeyring(teams) {
  * to execution unless the council approval gate passed (fail-closed sequencing).
  *   { phase: "decompose"|"approval"|"plan"|"build", ok, ... }
  */
-export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, callWorkshopSeat, keyring, signerFor, baseDir, telosDir, marketPackets = [], source, maxRepairRounds = 8, adaptAttempts = 2, concurrency, nowMs = 0, maxRevisions }) {
+export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, callWorkshopSeat, callParallelSeat, keyring, signerFor, baseDir, telosDir, marketPackets = [], source, maxRepairRounds = 8, adaptAttempts = 2, concurrency, nowMs = 0, maxRevisions }) {
   const teams = planTeams(dossier);
 
   // PROJECT SENSE (conventions): read the real project BEFORE decompose so the
@@ -167,7 +167,7 @@ export async function buildProject({ dossier, telos, tasks, callSeat, callTeam, 
   // advisory path below is byte-identical. runProposalLifecycle owns compile/review/decision/execution.
   if (dossier?.proposal_lifecycle === true) {
     return await runProposalLifecycle({
-      dossier, taskList, teams, situation, callSeat, callWorkshopSeat, callTeam,
+      dossier, taskList, teams, situation, callSeat, callWorkshopSeat, callParallelSeat, callTeam,
       keyring, signerFor, baseDir, telosDir, marketPackets, source,
       maxRepairRounds, adaptAttempts, concurrency, nowMs, maxRevisions
     });

--- a/build-gate/daedalus.mjs
+++ b/build-gate/daedalus.mjs
@@ -270,6 +270,8 @@ export async function runParallelDaedalus({ frame, callSeat, writeArtifact, appe
     candidate_ref,
     descends_from: authored.map((s) => s.artifact_ref),
     obligation_matrix: integ.obligation_matrix ?? [],
+    seat: PARALLEL_ROLES.implementation,
+    provenance: integ.provenance,
     provenance_key: provKey(PARALLEL_ROLES.implementation, integ.provenance)
   };
   if (appendEvent) await appendEvent({ stage: "integration", artifact_refs: [candidate_ref], policy_result: { descends_from: integration.descends_from } });
@@ -278,7 +280,7 @@ export async function runParallelDaedalus({ frame, callSeat, writeArtifact, appe
   const verifications = await Promise.all(["constraints", "implementation"].map(async (role) => {
     const seat = PARALLEL_ROLES[role];
     const v = await callSeat({ seat, role, phase: "verify", frame, sources: [authored.find((s) => s.role === role)], integration: { candidate_ref, plan: integ.plan ?? "", obligation_matrix: integration.obligation_matrix } });
-    return { role, seat, verdict: v.verdict, conflicts: v.conflicts || [], provenance_key: provKey(seat, v.provenance) };
+    return { role, seat, verdict: v.verdict, conflicts: v.conflicts || [], provenance: v.provenance, provenance_key: provKey(seat, v.provenance) };
   }));
 
   const state = deriveParallelState({ sources, integration, verifications });

--- a/build-gate/proposal-orchestrator.mjs
+++ b/build-gate/proposal-orchestrator.mjs
@@ -29,7 +29,7 @@ import {
 } from "./concerns.mjs";
 import { validateProposalLifecycle } from "./proposal-gate.mjs";
 import { makeProposalRecorder, buildReviewManifest, buildRevisionBrief } from "./proposal-recorder.mjs";
-import { runDaedalusWorkshop } from "./daedalus.mjs";
+import { runDaedalusWorkshop, runParallelDaedalus } from "./daedalus.mjs";
 import { resolve as resolveCheck, isRegistered, checkContractRef } from "./check-registry.mjs";
 import { loadRiskPolicy, evaluateRiskClass, holdPolicyFor } from "./risk-policy.mjs";
 import { compileAndHashPlan, assignNodeLineages } from "../merkle-dag/planner.mjs";
@@ -106,11 +106,39 @@ function blocked(phase, reasons, extra = {}) { return { phase, ok: false, decisi
  * Injected (keyless-testable): callSeat (review council), callWorkshopSeat (Daedalus adapter), callTeam
  * (execution). signerFor resolves team keys; the controller key is single-sourced here.
  */
+// Normalize a parallel-authorship result (docs/daedalus-methodology.md) to the
+// shape the revision loop consumes from the serial workshop: converged-parallel
+// -> converged-for-submission; conflict (needs-eye) or a non-converged round ->
+// stalemate (human review / The Eye). The integration candidate's artifact
+// carries `.plan`, so final_candidate_ref resolves the same way. creation_lineage
+// records every real seat call (both source authors, the integrator, both
+// verifiers) so cold review sees the true creators.
+function normalizeParallelWorkshop(result) {
+  const converged = result.state === "converged-parallel";
+  const lineage = [
+    ...(result.sources || []).map((s) => ({ seat: s.seat, round: 1, provenance: s.provenance, artifact_ref: s.artifact_ref })),
+    ...(result.integration && result.integration.seat ? [{ seat: result.integration.seat, round: 1, provenance: result.integration.provenance, artifact_ref: result.integration.candidate_ref }] : []),
+    ...(result.verifications || []).map((v) => ({ seat: v.seat, round: 1, provenance: v.provenance, artifact_ref: result.integration && result.integration.candidate_ref }))
+  ];
+  return {
+    state: converged ? "converged-for-submission" : "stalemate",
+    reason: result.reason,
+    terminal: result.terminal,
+    final_candidate_ref: result.candidate_ref,
+    creation_lineage: lineage,
+    conflicts: result.conflicts || []
+  };
+}
+
 export async function runProposalLifecycle({
-  dossier, taskList, teams, situation = null, callSeat, callWorkshopSeat, callTeam,
+  dossier, taskList, teams, situation = null, callSeat, callWorkshopSeat, callParallelSeat, callTeam,
   keyring, signerFor: injectedSignerFor, baseDir, telosDir, marketPackets = [], source,
   maxRepairRounds = 8, adaptAttempts = 2, concurrency, nowMs = 0, maxRevisions
 }) {
+  // Authorship mode (docs/daedalus-methodology.md): serial author->reviewer loop
+  // by default (small deltas, back-compatible); parallel constraint/implementation
+  // authorship when the dossier opts in AND a parallel seat caller is injected.
+  const useParallelAuthorship = dossier?.authorship === "parallel" && typeof callParallelSeat === "function";
   // 1. Controller key — single-sourced, pinned DIRECTLY into authorized_signers (decision 2, B1+B2).
   const envSk = process.env.TELOS_PROPOSAL_CONTROLLER_SK || null;
   let controllerPriv, controllerPubJwk, ephemeral = false;
@@ -159,18 +187,19 @@ export async function runProposalLifecycle({
     // a. Daedalus workshop refines the candidate (claude/codex negotiation).
     let workshop;
     try {
-      workshop = await runDaedalusWorkshop({
-        draft: candidateBody, callSeat: callWorkshopSeat,
-        writeArtifact: recorder.writeArtifact,
-        appendEvent: (ev) => recorder.record({ stage: "negotiation", artifact_refs: ev.artifact_refs, policy_result: ev.policy_result, recorded_at: nowMs })
-      });
+      const appendEvent = (ev) => recorder.record({ stage: "negotiation", artifact_refs: ev.artifact_refs, policy_result: ev.policy_result, recorded_at: nowMs });
+      workshop = useParallelAuthorship
+        ? normalizeParallelWorkshop(await runParallelDaedalus({ frame: candidateBody, callSeat: callParallelSeat, writeArtifact: recorder.writeArtifact, appendEvent }))
+        : await runDaedalusWorkshop({ draft: candidateBody, callSeat: callWorkshopSeat, writeArtifact: recorder.writeArtifact, appendEvent });
     } catch (e) { return blocked("plan", [`daedalus workshop error: ${e.message}`]); }
     // Record each workshop creation-lineage entry as a negotiation event with that seat's provenance,
     // so cold review sees the real plan creators (else a review seat reusing a workshop-author key slips).
     for (const cl of workshop.creation_lineage || []) recorder.recordCreationCall({ seat: cl.seat, provenance: cl.provenance, recordedAt: nowMs });
     if (workshop.state === "stalemate") {
-      const { decision } = recorder.recordDecision({ planHash: draftRef, checks: naChecks(), blockers: ["workshop stalemate"], findings: [{ code: "WORKSHOP_STALEMATE", class: "hold", reparable: false, requires_human: true, ref: null }], revision: { index, maximum } });
-      return blocked("approval", ["workshop stalemate — human review required"], { decision });
+      const needsEye = workshop.terminal === "needs-eye";
+      const label = needsEye ? "workshop conflict (parallel authorship) — routed to The Eye" : `workshop stalemate${workshop.reason ? ` (${workshop.reason})` : ""}`;
+      const { decision } = recorder.recordDecision({ planHash: draftRef, checks: naChecks(), blockers: [label], findings: [{ code: needsEye ? "WORKSHOP_CONFLICT" : "WORKSHOP_STALEMATE", class: "hold", reparable: false, requires_human: true, ref: null }], revision: { index, maximum } });
+      return blocked("approval", [`${label} — human review required`], { decision });
     }
     const finalArtifact = readProposalArtifact(telosDir, workshop.final_candidate_ref);
     const finalTasks = parseTasks(finalArtifact && finalArtifact.plan);

--- a/build-gate/scripts/test-proposal-orchestrator.mjs
+++ b/build-gate/scripts/test-proposal-orchestrator.mjs
@@ -30,10 +30,26 @@ const verifyConcern = () => ({ scope: "plan", claim: "auth boundary must be veri
 // Default converging workshop; disjoint provenance per call.
 function convergingWorkshop(prov) { return async ({ seat }) => ({ plan_revision: "", objections: [], dispositions: [], provenance: prov(seat === "claude" ? "anthropic" : "openai") }); }
 
+// Parallel-authorship callSeat (docs/daedalus-methodology.md): constraints=codex (openai provenance),
+// implementation=claude (anthropic provenance). Author phase -> a source plan; integrate -> echo the
+// frozen frame as the candidate body (so it deserializes) plus a COMPLETE five-field obligation matrix;
+// verify -> each seat confirms its own contract survived. With { conflict: true } the constraints seat
+// reports its invariant was violated by integration, driving deriveParallelState to needs-eye.
+const okObligationRow = () => Object.fromEntries(["invariant", "mechanism", "task", "negative_test", "exit_criterion"].map((f) => [f, `${f}-1`]));
+function parallelWorkshop(prov, { conflict = false } = {}) {
+  return async ({ seat, role, phase, frame }) => {
+    const provenance = prov(seat === "claude" ? "anthropic" : "openai");
+    if (phase === "author") return { plan: `${role} source design`, provenance };
+    if (phase === "integrate") return { plan: frame, obligation_matrix: [okObligationRow()], provenance };
+    if (conflict && role === "constraints") return { verdict: "violated", conflicts: ["fail-closed weakened by integration"], provenance };
+    return { verdict: "preserved", conflicts: [], provenance };
+  };
+}
+
 function baseDossier(extra = {}) { return { build_id: "b1", use_case: "governance", objective: "add an auth boundary", proposal_lifecycle: true, write_targets: [TARGET], required_docs: [], ...extra }; }
 function baseTasks(writes = [TARGET]) { return [{ id: "A", writes, reads: [], requirements: "write the auth boundary", test: { cmd: "node", args: ["-e", "process.exit(0)"] } }]; }
 
-async function drive({ dossier, tasks, callSeat, callWorkshopSeat, callTeam, env }) {
+async function drive({ dossier, tasks, callSeat, callWorkshopSeat, callParallelSeat, callTeam, env }) {
   const dir = ws();
   const teams = planTeams({});
   const { keyring, signerFor } = makeTeamKeyring(teams);
@@ -41,7 +57,7 @@ async function drive({ dossier, tasks, callSeat, callWorkshopSeat, callTeam, env
   if (env && env.TELOS_PROPOSAL_CONTROLLER_SK) process.env.TELOS_PROPOSAL_CONTROLLER_SK = env.TELOS_PROPOSAL_CONTROLLER_SK;
   else delete process.env.TELOS_PROPOSAL_CONTROLLER_SK;
   try {
-    const res = await buildProject({ dossier, telos: "t", tasks, callSeat, callWorkshopSeat, callTeam, keyring, signerFor, baseDir: dir, telosDir: path.join(dir, ".telos"), nowMs: 1000, maxRevisions: 3 });
+    const res = await buildProject({ dossier, telos: "t", tasks, callSeat, callWorkshopSeat, callParallelSeat, callTeam, keyring, signerFor, baseDir: dir, telosDir: path.join(dir, ".telos"), nowMs: 1000, maxRevisions: 3 });
     return { res, dir };
   } finally {
     if (prevEnv === undefined) delete process.env.TELOS_PROPOSAL_CONTROLLER_SK; else process.env.TELOS_PROPOSAL_CONTROLLER_SK = prevEnv;
@@ -217,6 +233,49 @@ const D = (dossier) => (fn) => (seatArg) => fn(seatArg, dossier);
   const scoped = mintVerificationNodes([{ concern_ref: "sha256:bb", scope: "B", check_contract: cc, required_result: "pass" }], tasks);
   assert.deepEqual(scoped.nodes[0].baseDependencies, ["B"], "(mint) scope matching a live node -> depend on that node");
   console.log("Case (mint) OK: verification node run-last dependency derivation");
+}
+
+// ---------------------------------------------------------------------------
+// Case (p1): parallel authorship (dossier.authorship === "parallel" + injected callParallelSeat)
+// converges -> authorized -> ready. Proves the parallel workshop feeds a valid candidate through the
+// SAME downstream lifecycle (mint/compile/authorize/execute) as the serial path.
+{
+  const { prov } = fixture();
+  const dossier = baseDossier({ authorship: "parallel" });
+  const callSeat = D(dossier)(async ({ model }, d) => ({ packet: reviewPacket(model, d), provenance: prov(model === "agy" ? "agentic" : model === "claude" ? "anthropic" : "openai") }));
+  const { res, dir } = await drive({ dossier, tasks: baseTasks(), callSeat, callParallelSeat: parallelWorkshop(prov), callTeam: makeCallTeam() });
+  assert.equal(res.decision, "authorized", "(p1) parallel authorship authorizes");
+  assert.equal(res.report.merge_status, "ready", "(p1) ready");
+  // parallel-specific signature: an integration negotiation event descends from BOTH source nodes.
+  const negotiations = readProposalEvents(path.join(dir, ".telos")).events.filter((e) => e.stage === "negotiation");
+  assert.ok(negotiations.some((e) => e.policy_result && Array.isArray(e.policy_result.descends_from) && e.policy_result.descends_from.length === 2), "(p1) parallel path taken — integration descends from both source nodes");
+  console.log("Case (p1) OK: parallel authorship -> authorized -> ready");
+}
+
+// ---------------------------------------------------------------------------
+// Case (p2): a seat's contract is VIOLATED by integration -> deriveParallelState conflict (terminal
+// "needs-eye") -> normalized to stalemate -> routed to The Eye / human review, NO execution.
+{
+  const { prov } = fixture();
+  const dossier = baseDossier({ authorship: "parallel" });
+  const callSeat = D(dossier)(async ({ model }, d) => ({ packet: reviewPacket(model, d), provenance: prov("agentic") }));
+  const { res } = await drive({ dossier, tasks: baseTasks(), callSeat, callParallelSeat: parallelWorkshop(prov, { conflict: true }), callTeam: makeCallTeam() });
+  assert.equal(res.decision, "human-review-required", "(p2) parallel verification conflict -> human-review-required");
+  assert.notEqual(res.phase, "build", "(p2) no execution on conflict");
+  assert.ok((res.blocked || []).some((b) => /Eye|conflict/i.test(b)), "(p2) conflict routed to The Eye");
+  console.log("Case (p2) OK: parallel verification conflict -> The Eye / human review, no execution");
+}
+
+// ---------------------------------------------------------------------------
+// Case (p3): backward-compat — authorship "parallel" declared but NO callParallelSeat injected falls
+// back to the serial workshop (the selector requires BOTH the flag and the injected seat).
+{
+  const { prov } = fixture();
+  const dossier = baseDossier({ authorship: "parallel" });
+  const callSeat = D(dossier)(async ({ model }, d) => ({ packet: reviewPacket(model, d), provenance: prov(model === "agy" ? "agentic" : model === "claude" ? "anthropic" : "openai") }));
+  const { res } = await drive({ dossier, tasks: baseTasks(), callSeat, callWorkshopSeat: convergingWorkshop(prov), callTeam: makeCallTeam() });
+  assert.equal(res.decision, "authorized", "(p3) missing callParallelSeat -> serial fallback still authorizes");
+  console.log("Case (p3) OK: parallel flag without callParallelSeat falls back to serial");
 }
 
 console.log("test-proposal-orchestrator.mjs OK");


### PR DESCRIPTION
## What

Composes `runParallelDaedalus` — the constraints/implementation two-seat workshop from `docs/daedalus-methodology.md` — into `runProposalLifecycle`, without disturbing the serial author→reviewer path.

The methodology fix (PR #98) landed the parallel workshop primitive and its state machine. This PR **wires it into the live lifecycle** so a dossier can actually select it.

## How

- **`proposal-orchestrator.mjs`** — `normalizeParallelWorkshop()` maps a parallel result onto the exact shape the revision loop already consumes from the serial workshop:
  - `converged-parallel` → `converged-for-submission`
  - `conflict` (terminal `needs-eye`) → `stalemate`, labelled `WORKSHOP_CONFLICT` and **routed to The Eye** (distinct from serial `WORKSHOP_STALEMATE`)
  - The integration candidate carries `.plan`, so `final_candidate_ref` resolves identically and the candidate flows through the **same** mint → compile → authorize → execute downstream.
  - `creation_lineage` records every real seat call (both source authors, the integrator, both verifiers) so **cold review sees the true creators**.
- **Selection is opt-in and fail-safe:** parallel runs only when `dossier.authorship === "parallel"` **and** a `callParallelSeat` is injected. Otherwise the serial workshop runs unchanged — byte-for-byte backward-compatible.
- **`build-orchestrator.mjs`** — threads `callParallelSeat` through `buildProject` → `runProposalLifecycle`.
- **`daedalus.mjs`** — enriches the integration object + verifications with `seat`/`provenance` so lineage can be recorded.

## Tests

Three new orchestrator cases (all green; full `build-gate` + `breakout` suites pass):

- **(p1)** parallel converge → `authorized` → `ready`, asserting the integration negotiation event descends from **both** source nodes (proves the parallel path was actually taken).
- **(p2)** a seat's contract violated by integration → `human-review-required`, no execution, routed to The Eye.
- **(p3)** `authorship: "parallel"` declared but no `callParallelSeat` injected → falls back to serial.

## Trust invariants preserved

No mutable label keys an enforcement decision; the gate still reconstructs state from the ledger. Convergence still ≠ authorization — a conflict fails closed to human review, and the downstream authorization/obligation machinery is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eCSN1Z9qGqrAnpDGNzqdF