### PR TITLE
Harden the parallel-authorship path: close five fail-open gaps from cold review

### DIFF
--- a/build-gate/daedalus.mjs
+++ b/build-gate/daedalus.mjs
@@ -204,19 +204,50 @@ export function validateObligationMatrix(matrix) {
   return { complete: incompleteRows.length === 0, reason: incompleteRows.length ? "incomplete-rows" : null, incompleteRows };
 }
 
+// The structured proof-obligation set is OWNED by the constraints seat (GPT declares the invariants /
+// proof obligations — docs/daedalus-methodology.md). Coverage is a strict BIJECTION between the declared
+// obligation IDs and the integration matrix rows' obligation_id: every declared obligation is mapped by
+// exactly one row, none is dropped, none is invented, none is duplicated. Field-completeness (above) is
+// necessary but NOT sufficient — a matrix can have five non-blank fields per row yet silently omit or
+// fabricate an obligation. This is the check that makes "map every obligation" structural.
+export function validateObligationCoverage(matrix, declaredObligations) {
+  const declared = Array.isArray(declaredObligations) ? declaredObligations.map((o) => (typeof o === "string" ? o.trim() : "")) : [];
+  if (!declared.length || declared.some((o) => !o)) return { covered: false, reason: "no-declared-obligations", missing: [], extra: [] };
+  if (declared.length !== new Set(declared).size) return { covered: false, reason: "duplicate-declared-obligation", missing: [], extra: [] };
+  const rowIds = (Array.isArray(matrix) ? matrix : []).map((r) => (r && typeof r.obligation_id === "string" ? r.obligation_id.trim() : ""));
+  if (!rowIds.length || rowIds.some((id) => !id)) return { covered: false, reason: "row-missing-obligation-id", missing: [], extra: [] };
+  if (rowIds.length !== new Set(rowIds).size) return { covered: false, reason: "duplicate-row-obligation-id", missing: [], extra: [] };
+  const declaredSet = new Set(declared), rowSet = new Set(rowIds);
+  const missing = declared.filter((id) => !rowSet.has(id));
+  const extra = rowIds.filter((id) => !declaredSet.has(id));
+  if (missing.length || extra.length) return { covered: false, reason: "coverage-mismatch", missing, extra };
+  return { covered: true, reason: null, missing: [], extra: [] };
+}
+
 /**
- * Total, pure state machine for a parallel-authorship round. Convergence
- * requires: both source roles present with distinct real provenance; an
- * integration node that descends from BOTH source refs; a complete obligation
- * matrix; and both per-seat verifications passing (verdict "preserved", no
- * conflicts) with distinct real provenance. Any verifier reporting "violated"
- * or a non-empty conflict list is a stalemate routed to The Eye — never blended.
+ * Total, pure state machine for a parallel-authorship round. Convergence is
+ * FAIL-CLOSED and requires ALL of:
+ *   - both source roles present, each with a real provenance key, and the two distinct;
+ *   - an integration node with a real provenance key of its own (the integrator is a
+ *     genuine seat call, not a free rewrite);
+ *   - descent bound EXACTLY to the two real source refs (not merely a superset — no
+ *     missing parent, no smuggled extra), which the integration artifact commits to;
+ *   - a field-complete obligation matrix that EXACTLY covers the constraints-declared
+ *     obligation set (bijection: every obligation mapped once, none dropped/invented);
+ *   - all five seat-call provenance keys (2 authors, integrator, 2 verifiers) real and
+ *     pairwise distinct — no response id replayed across calls;
+ *   - both verifications AFFIRMATIVELY "preserved" (an unrecognized or missing verdict
+ *     cannot converge; it is not treated as tacit approval).
+ * Any verifier reporting "violated" or a non-empty conflict list is a conflict routed
+ * to The Eye (terminal needs-eye) — never blended. Every other shortfall is "continue"
+ * (non-terminal), which the orchestrator normalizes to a human-review stalemate.
  * @returns { state, reason, terminal, candidate_ref, conflicts }
  *   state: converged-parallel | conflict | continue
  *   terminal: submit | needs-eye | (undefined while continue)
  */
 export function deriveParallelState({ sources, integration, verifications } = {}) {
-  const bad = (reason) => ({ state: "continue", reason, terminal: undefined, candidate_ref: null, conflicts: [] });
+  const bad = (reason, extra = {}) => ({ state: "continue", reason, terminal: undefined, candidate_ref: null, conflicts: [], ...extra });
+  const cont = (reason, candidate_ref, extra = {}) => ({ state: "continue", reason, terminal: undefined, candidate_ref, conflicts: [], ...extra });
   const byRole = new Map((Array.isArray(sources) ? sources : []).map((s) => [s && s.role, s]));
   const cons = byRole.get("constraints");
   const impl = byRole.get("implementation");
@@ -224,20 +255,39 @@ export function deriveParallelState({ sources, integration, verifications } = {}
   const consKey = cons.provenance_key, implKey = impl.provenance_key;
   if (!isRealProvenanceKey(consKey) || !isRealProvenanceKey(implKey) || consKey === implKey) return bad("invalid-source-provenance");
   if (!integration || !integration.candidate_ref) return bad("no-integration-node");
-  const descends = new Set(integration.descends_from || []);
-  if (!descends.has(cons.artifact_ref) || !descends.has(impl.artifact_ref)) return bad("integration-not-descended-from-both");
+  // The integrator provenance was previously stored but never validated — a null/placeholder
+  // integrator could carry a candidate to convergence. It must be a real seat call.
+  if (!isRealProvenanceKey(integration.provenance_key)) return bad("invalid-integration-provenance");
+  // Parentage is bound EXACTLY to the two real source nodes. Previously the check accepted any
+  // superset AND the candidate ref committed to nothing, making it vacuous; now the integration
+  // artifact commits to descends_from and we require it to be precisely {constraints, implementation}.
+  const declaredParents = Array.isArray(integration.descends_from) ? integration.descends_from : [];
+  const parentSet = new Set(declaredParents);
+  if (declaredParents.length !== 2 || parentSet.size !== 2 || !parentSet.has(cons.artifact_ref) || !parentSet.has(impl.artifact_ref)) return cont("integration-not-descended-from-both", integration.candidate_ref);
   const matrix = validateObligationMatrix(integration.obligation_matrix);
-  if (!matrix.complete) return { state: "continue", reason: "incomplete-obligation-matrix", terminal: undefined, candidate_ref: integration.candidate_ref, conflicts: [], incompleteRows: matrix.incompleteRows };
+  if (!matrix.complete) return cont("incomplete-obligation-matrix", integration.candidate_ref, { incompleteRows: matrix.incompleteRows });
+  // Exact coverage of the constraints-declared obligation set — field-completeness alone let a matrix
+  // silently drop or fabricate obligations.
+  const coverage = validateObligationCoverage(integration.obligation_matrix, cons.obligations);
+  if (!coverage.covered) return cont(`obligation-${coverage.reason}`, integration.candidate_ref, { coverage });
 
   const vByRole = new Map((Array.isArray(verifications) ? verifications : []).map((v) => [v && v.role, v]));
   const vc = vByRole.get("constraints"), vi = vByRole.get("implementation");
   if (!vc || !vi) return bad("missing-verification");
   if (!isRealProvenanceKey(vc.provenance_key) || !isRealProvenanceKey(vi.provenance_key) || vc.provenance_key === vi.provenance_key) {
-    return { state: "continue", reason: "invalid-verification-provenance", terminal: undefined, candidate_ref: integration.candidate_ref, conflicts: [] };
+    return cont("invalid-verification-provenance", integration.candidate_ref);
   }
+  // Every one of the FIVE seat calls must carry a real, pairwise-distinct provenance key — a single
+  // response id replayed across author/integrate/verify would otherwise satisfy the per-pair checks.
+  const callKeys = [consKey, implKey, integration.provenance_key, vc.provenance_key, vi.provenance_key];
+  if (new Set(callKeys).size !== callKeys.length) return cont("provenance-reused-across-calls", integration.candidate_ref);
+  // A verifier must AFFIRMATIVELY attest "preserved". Previously anything other than the literal string
+  // "violated" (including undefined, missing, or an arbitrary token) fell through to convergence.
+  const VERDICTS = new Set(["preserved", "violated"]);
+  if (!VERDICTS.has(vc.verdict) || !VERDICTS.has(vi.verdict)) return cont("invalid-verification-verdict", integration.candidate_ref);
   const conflicts = [
-    ...(vc.verdict === "violated" || (vc.conflicts || []).length ? [{ role: "constraints", detail: vc.conflicts || [] }] : []),
-    ...(vi.verdict === "violated" || (vi.conflicts || []).length ? [{ role: "implementation", detail: vi.conflicts || [] }] : [])
+    ...(vc.verdict !== "preserved" || (vc.conflicts || []).length ? [{ role: "constraints", detail: vc.conflicts || [] }] : []),
+    ...(vi.verdict !== "preserved" || (vi.conflicts || []).length ? [{ role: "implementation", detail: vi.conflicts || [] }] : [])
   ];
   if (conflicts.length) return { state: "conflict", reason: "verification-conflict", terminal: "needs-eye", candidate_ref: integration.candidate_ref, conflicts };
   return { state: "converged-parallel", reason: "both-contracts-preserved", terminal: "submit", candidate_ref: integration.candidate_ref, conflicts: [] };
@@ -257,18 +307,24 @@ export async function runParallelDaedalus({ frame, callSeat, writeArtifact, appe
   const authored = await Promise.all(["constraints", "implementation"].map(async (role) => {
     const seat = PARALLEL_ROLES[role];
     const resp = await callSeat({ seat, role, phase: "author", frame });
-    const artifact_ref = writeArtifact({ kind: "source-node", role, seat, body: resp.plan ?? "", provenance: resp.provenance }).ref;
-    return { role, seat, artifact_ref, body: resp.plan ?? "", provenance: resp.provenance, provenance_key: provKey(seat, resp.provenance) };
+    // The constraints seat OWNS the proof-obligation set; commit those IDs INTO the source-node content
+    // address so the obligation set the integrator must cover is content-bound, not caller-mutable.
+    const obligations = role === "constraints" ? (Array.isArray(resp.obligations) ? resp.obligations : []) : undefined;
+    const artifact_ref = writeArtifact({ kind: "source-node", role, seat, body: resp.plan ?? "", ...(obligations ? { obligations } : {}), provenance: resp.provenance }).ref;
+    return { role, seat, artifact_ref, body: resp.plan ?? "", obligations, provenance: resp.provenance, provenance_key: provKey(seat, resp.provenance) };
   }));
   const sources = authored.map(({ body, ...s }) => s);
   if (appendEvent) await appendEvent({ stage: "parallel-authorship", artifact_refs: sources.map((s) => s.artifact_ref), policy_result: { roles: sources.map((s) => s.role) } });
 
-  // 2. Integration: one candidate descending from both source nodes + the obligation matrix.
+  // 2. Integration: one candidate descending from both source nodes + the obligation matrix. descends_from
+  // is written INTO the artifact body so the candidate ref content-commits to its parentage (previously it
+  // was attached only in memory, leaving the ref parent-agnostic and the descent check vacuous).
   const integ = await callSeat({ seat: PARALLEL_ROLES.implementation, role: "integration", phase: "integrate", frame, sources: authored });
-  const candidate_ref = writeArtifact({ kind: "integration-candidate", plan: integ.plan ?? "", obligation_matrix: integ.obligation_matrix ?? [], provenance: integ.provenance }).ref;
+  const parentRefs = authored.map((s) => s.artifact_ref);
+  const candidate_ref = writeArtifact({ kind: "integration-candidate", plan: integ.plan ?? "", descends_from: parentRefs, obligation_matrix: integ.obligation_matrix ?? [], provenance: integ.provenance }).ref;
   const integration = {
     candidate_ref,
-    descends_from: authored.map((s) => s.artifact_ref),
+    descends_from: parentRefs,
     obligation_matrix: integ.obligation_matrix ?? [],
     seat: PARALLEL_ROLES.implementation,
     provenance: integ.provenance,

--- a/build-gate/proposal-orchestrator.mjs
+++ b/build-gate/proposal-orchestrator.mjs
@@ -137,8 +137,15 @@ export async function runProposalLifecycle({
 }) {
   // Authorship mode (docs/daedalus-methodology.md): serial author->reviewer loop
   // by default (small deltas, back-compatible); parallel constraint/implementation
-  // authorship when the dossier opts in AND a parallel seat caller is injected.
-  const useParallelAuthorship = dossier?.authorship === "parallel" && typeof callParallelSeat === "function";
+  // authorship when the dossier opts in. Selection FAILS CLOSED: an explicit request
+  // for parallel authorship with no callParallelSeat adapter injected must NOT silently
+  // downgrade to serial — a caller that asked for the two-seat trust structure would
+  // otherwise get the weaker single-track path without knowing it. Block instead.
+  const parallelRequested = dossier?.authorship === "parallel";
+  if (parallelRequested && typeof callParallelSeat !== "function") {
+    return blocked("plan", ["PARALLEL_AUTHORSHIP_UNAVAILABLE: dossier.authorship === \"parallel\" but no callParallelSeat adapter was injected; refusing to silently downgrade to serial authorship"]);
+  }
+  const useParallelAuthorship = parallelRequested;
   // 1. Controller key — single-sourced, pinned DIRECTLY into authorized_signers (decision 2, B1+B2).
   const envSk = process.env.TELOS_PROPOSAL_CONTROLLER_SK || null;
   let controllerPriv, controllerPubJwk, ephemeral = false;

--- a/build-gate/scripts/test-daedalus.mjs
+++ b/build-gate/scripts/test-daedalus.mjs
@@ -3,11 +3,13 @@ import assert from "node:assert/strict";
 import {
   DAEDALUS_MAX_ROUNDS, computeObjectionHash, objectionLedgerFrom,
   deriveWorkshopState, validateDispositions, runDaedalusWorkshop,
-  PARALLEL_ROLES, OBLIGATION_FIELDS, validateObligationMatrix, deriveParallelState, runParallelDaedalus
+  PARALLEL_ROLES, OBLIGATION_FIELDS, validateObligationMatrix, validateObligationCoverage, deriveParallelState, runParallelDaedalus
 } from "../daedalus.mjs";
+import { canonicalize, sha256hex } from "../../merkle-dag/vendor.mjs";
 
-// A complete obligation-matrix row (all five fields non-blank).
-const okRow = (n) => Object.fromEntries(OBLIGATION_FIELDS.map((f) => [f, f + n]));
+// A complete obligation-matrix row: all five descriptive fields non-blank + an obligation_id linking the
+// row to a constraints-declared obligation (coverage is a bijection over these ids).
+const okRow = (n) => ({ ...Object.fromEntries(OBLIGATION_FIELDS.map((f) => [f, f + n])), obligation_id: "OBL-" + n });
 
 // Build a round artifact with the fields deriveWorkshopState reads.
 function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c" + n, bound = null, objections = [], resolutions = [] }) {
@@ -123,30 +125,28 @@ function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c"
   console.log("Case 9 OK: obligation-matrix completeness");
 }
 
-// Case 10: deriveParallelState converges only with both sources, dual descent, complete matrix, both verifications preserved + distinct provenance.
+// A constraints source node carrying its declared obligation set (owned by the constraints seat).
+const consSrc = (obligations, provenance_key = "openai:c1") => ({ role: "constraints", artifact_ref: "sha:cons", provenance_key, obligations });
+const implSrc = (provenance_key = "anthropic:a1") => ({ role: "implementation", artifact_ref: "sha:impl", provenance_key });
+
+// Case 10: deriveParallelState converges only with both sources, dual descent, complete+covering matrix, both verifications preserved, and all five call keys distinct.
 {
-  const sources = [
-    { role: "constraints", artifact_ref: "sha:cons", provenance_key: "openai:c1" },
-    { role: "implementation", artifact_ref: "sha:impl", provenance_key: "anthropic:a1" }
-  ];
-  const integration = { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a1" };
+  const sources = [consSrc(["OBL-1"]), implSrc()];
+  const integration = { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a3" };
   const verifications = [
     { role: "constraints", verdict: "preserved", conflicts: [], provenance_key: "openai:c2" },
     { role: "implementation", verdict: "preserved", conflicts: [], provenance_key: "anthropic:a2" }
   ];
   const ok = deriveParallelState({ sources, integration, verifications });
-  assert.equal(ok.state, "converged-parallel");
+  assert.equal(ok.state, "converged-parallel", "converges: " + JSON.stringify(ok.reason));
   assert.equal(ok.terminal, "submit");
   console.log("Case 10 OK: parallel convergence -> submit");
 }
 
 // Case 11: a violated verification routes to The Eye (never blended).
 {
-  const sources = [
-    { role: "constraints", artifact_ref: "sha:cons", provenance_key: "openai:c1" },
-    { role: "implementation", artifact_ref: "sha:impl", provenance_key: "anthropic:a1" }
-  ];
-  const integration = { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a1" };
+  const sources = [consSrc(["OBL-1"]), implSrc()];
+  const integration = { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a3" };
   const verifications = [
     { role: "constraints", verdict: "violated", conflicts: ["invariant X dropped in integration"], provenance_key: "openai:c2" },
     { role: "implementation", verdict: "preserved", conflicts: [], provenance_key: "anthropic:a2" }
@@ -160,17 +160,14 @@ function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c"
 
 // Case 12: integration must descend from BOTH sources; an incomplete matrix blocks convergence.
 {
-  const sources = [
-    { role: "constraints", artifact_ref: "sha:cons", provenance_key: "openai:c1" },
-    { role: "implementation", artifact_ref: "sha:impl", provenance_key: "anthropic:a1" }
-  ];
+  const sources = [consSrc(["OBL-1"]), implSrc()];
   const verifications = [
     { role: "constraints", verdict: "preserved", conflicts: [], provenance_key: "openai:c2" },
     { role: "implementation", verdict: "preserved", conflicts: [], provenance_key: "anthropic:a2" }
   ];
-  const oneParent = deriveParallelState({ sources, integration: { candidate_ref: "sha:cand", descends_from: ["sha:cons"], obligation_matrix: [okRow(1)] }, verifications });
+  const oneParent = deriveParallelState({ sources, integration: { candidate_ref: "sha:cand", descends_from: ["sha:cons"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a3" }, verifications });
   assert.equal(oneParent.reason, "integration-not-descended-from-both");
-  const badMatrix = deriveParallelState({ sources, integration: { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [{ ...okRow(1), exit_criterion: "" }] }, verifications });
+  const badMatrix = deriveParallelState({ sources, integration: { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [{ ...okRow(1), exit_criterion: "" }], provenance_key: "anthropic:a3" }, verifications });
   assert.equal(badMatrix.reason, "incomplete-obligation-matrix");
   assert.notEqual(badMatrix.state, "converged-parallel");
   console.log("Case 12 OK: dual-descent + complete-matrix gates");
@@ -191,7 +188,7 @@ function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c"
 {
   const seatResp = ({ seat, role, phase }) => {
     const provenance = { provider: seat === "codex" ? "openai" : "anthropic", response_id: `${seat}-${role}-${phase}` };
-    if (phase === "author") return { plan: `${role}-design`, provenance };
+    if (phase === "author") return { plan: `${role}-design`, ...(role === "constraints" ? { obligations: ["OBL-1", "OBL-2"] } : {}), provenance };
     if (phase === "integrate") return { plan: "integrated-candidate", obligation_matrix: [okRow(1), okRow(2)], provenance };
     return { verdict: "preserved", conflicts: [], provenance }; // verify
   };
@@ -211,7 +208,7 @@ function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c"
 {
   const seatResp = ({ seat, role, phase }) => {
     const provenance = { provider: seat === "codex" ? "openai" : "anthropic", response_id: `${seat}-${role}-${phase}` };
-    if (phase === "author") return { plan: `${role}-design`, provenance };
+    if (phase === "author") return { plan: `${role}-design`, ...(role === "constraints" ? { obligations: ["OBL-1"] } : {}), provenance };
     if (phase === "integrate") return { plan: "integrated", obligation_matrix: [okRow(1)], provenance };
     // constraints seat finds its invariant dropped; implementation is fine.
     return role === "constraints"
@@ -224,6 +221,103 @@ function round({ n, inHash, outHash, aKey = "anthropic:a" + n, rKey = "openai:c"
   assert.equal(res.terminal, "needs-eye");
   assert.equal(res.conflicts[0].role, "constraints");
   console.log("Case 15 OK: driver routes integration conflict to The Eye");
+}
+
+// ---------------------------------------------------------------------------
+// Hardening cases (16-21): each proves a previously fail-open hole is now closed.
+// A canonical CONVERGING input; each case mutates exactly one field to the unsafe shape.
+function converging() {
+  return {
+    sources: [consSrc(["OBL-1"]), implSrc()],
+    integration: { candidate_ref: "sha:cand", descends_from: ["sha:cons", "sha:impl"], obligation_matrix: [okRow(1)], provenance_key: "anthropic:a3" },
+    verifications: [
+      { role: "constraints", verdict: "preserved", conflicts: [], provenance_key: "openai:c2" },
+      { role: "implementation", verdict: "preserved", conflicts: [], provenance_key: "anthropic:a2" }
+    ]
+  };
+}
+assert.equal(deriveParallelState(converging()).state, "converged-parallel", "canonical input converges (guards the mutations below)");
+
+// Case 16 (finding: arbitrary/missing verdicts converged): only a LITERAL "preserved" converges.
+{
+  for (const bogus of [undefined, "", "approved", "ok", "PRESERVED", "maybe"]) {
+    const inp = converging(); inp.verifications[1].verdict = bogus;
+    assert.notEqual(deriveParallelState(inp).state, "converged-parallel", `verdict ${JSON.stringify(bogus)} must not converge`);
+  }
+  // an EXPLICIT "violated" still routes to The Eye (not silently continued)
+  const v = converging(); v.verifications[0].verdict = "violated"; v.verifications[0].conflicts = ["contract dropped"];
+  assert.equal(deriveParallelState(v).terminal, "needs-eye");
+  console.log("Case 16 OK: only a literal \"preserved\" verdict converges; violated -> The Eye");
+}
+
+// Case 17 (finding: integrator provenance stored but unvalidated): integrator key must be real, and all
+// FIVE call keys must be pairwise distinct — no response id replayed across author/integrate/verify.
+{
+  const noInteg = converging(); delete noInteg.integration.provenance_key;
+  assert.equal(deriveParallelState(noInteg).reason, "invalid-integration-provenance", "integrator provenance must be real");
+  const placeholder = converging(); placeholder.integration.provenance_key = "anthropic:PLACEHOLDER";
+  assert.notEqual(deriveParallelState(placeholder).state, "converged-parallel", "a placeholder integrator key cannot converge");
+  const reuseVerifier = converging(); reuseVerifier.integration.provenance_key = "openai:c2"; // == constraints verifier
+  assert.equal(deriveParallelState(reuseVerifier).reason, "provenance-reused-across-calls", "integrator reusing a verifier key blocks");
+  const reuseInteg = converging(); reuseInteg.verifications[1].provenance_key = "anthropic:a3"; // == integrator
+  assert.equal(deriveParallelState(reuseInteg).reason, "provenance-reused-across-calls", "verifier reusing the integrator key blocks");
+  console.log("Case 17 OK: integrator provenance validated + all five call keys distinct");
+}
+
+// Case 18 (finding: matrix checked nonblank fields, not coverage): coverage is a strict BIJECTION with the
+// constraints-declared obligation set — dropped, invented, duplicated, undeclared, or id-less all block.
+{
+  const drop = converging(); drop.sources[0].obligations = ["OBL-1", "OBL-2"]; // matrix covers only OBL-1
+  const dr = deriveParallelState(drop);
+  assert.equal(dr.reason, "obligation-coverage-mismatch", "a dropped obligation blocks");
+  assert.deepEqual(dr.coverage.missing, ["OBL-2"]);
+  const invent = converging(); invent.integration.obligation_matrix = [okRow(1), okRow(9)]; // OBL-9 undeclared
+  assert.equal(deriveParallelState(invent).reason, "obligation-coverage-mismatch", "an invented obligation blocks");
+  const dup = converging(); dup.integration.obligation_matrix = [okRow(1), { ...okRow(1) }]; // OBL-1 twice
+  assert.equal(deriveParallelState(dup).reason, "obligation-duplicate-row-obligation-id", "a duplicated obligation blocks");
+  const noDecl = converging(); noDecl.sources[0].obligations = []; // constraints declared nothing
+  assert.equal(deriveParallelState(noDecl).reason, "obligation-no-declared-obligations", "no declared obligation set blocks");
+  const noId = converging(); noId.integration.obligation_matrix = [{ ...okRow(1), obligation_id: "" }];
+  assert.equal(deriveParallelState(noId).reason, "obligation-row-missing-obligation-id", "a row without an obligation_id blocks");
+  // direct unit coverage of the validator's happy path
+  assert.equal(validateObligationCoverage([okRow(1), okRow(2)], ["OBL-1", "OBL-2"]).covered, true);
+  console.log("Case 18 OK: exact obligation coverage (drop/invent/duplicate/undeclared/no-id all blocked)");
+}
+
+// Case 19 (finding: descent check was a superset test): descent must be EXACTLY the two source refs.
+{
+  const extra = converging(); extra.integration.descends_from = ["sha:cons", "sha:impl", "sha:evil"];
+  assert.equal(deriveParallelState(extra).reason, "integration-not-descended-from-both", "a smuggled extra parent blocks (superset rejected)");
+  const wrong = converging(); wrong.integration.descends_from = ["sha:cons", "sha:other"];
+  assert.equal(deriveParallelState(wrong).reason, "integration-not-descended-from-both", "a wrong parent blocks");
+  const dupParent = converging(); dupParent.integration.descends_from = ["sha:cons", "sha:cons"];
+  assert.equal(deriveParallelState(dupParent).reason, "integration-not-descended-from-both", "a duplicated parent (missing impl) blocks");
+  console.log("Case 19 OK: descent bound EXACTLY to the two source refs");
+}
+
+// Case 20 (finding: candidate ref committed to nothing about parentage): the integration candidate ref
+// CONTENT-COMMITS to both parents — the same plan/matrix with different parents yields a different ref.
+{
+  const writes = [];
+  const writeArtifact = (v) => { writes.push(v); return { ref: "sha256:" + sha256hex(canonicalize(v)) }; };
+  const author = ({ seat, role, phase }) => {
+    const provenance = { provider: seat === "codex" ? "openai" : "anthropic", response_id: `${seat}-${role}-${phase}` };
+    if (phase === "author") return { plan: `${role}-design`, ...(role === "constraints" ? { obligations: ["OBL-1"] } : {}), provenance };
+    if (phase === "integrate") return { plan: "cand", obligation_matrix: [okRow(1)], provenance };
+    return { verdict: "preserved", conflicts: [], provenance };
+  };
+  const res = await runParallelDaedalus({ frame: "f", callSeat: author, writeArtifact, appendEvent: async () => {} });
+  assert.equal(res.state, "converged-parallel", "hardened driver still converges on a valid run: " + JSON.stringify(res.reason));
+  const integWrite = writes.find((w) => w.kind === "integration-candidate");
+  assert.ok(Array.isArray(integWrite.descends_from) && integWrite.descends_from.length === 2, "descends_from is INSIDE the content-addressed body");
+  const refWith = "sha256:" + sha256hex(canonicalize(integWrite));
+  const refWithout = "sha256:" + sha256hex(canonicalize({ ...integWrite, descends_from: [] }));
+  assert.notEqual(refWith, refWithout, "candidate ref differs when parentage changes (ref is not parent-agnostic)");
+  assert.equal(res.integration.candidate_ref, refWith, "the returned candidate_ref is the parent-committing hash");
+  // the constraints obligation set is likewise committed into its source node
+  const consWrite = writes.find((w) => w.kind === "source-node" && w.role === "constraints");
+  assert.deepEqual(consWrite.obligations, ["OBL-1"], "constraints obligation set is content-bound in its source node");
+  console.log("Case 20 OK: integration candidate ref content-commits to both parents; obligations bound in source");
 }
 
 console.log("test-daedalus.mjs OK");

--- a/build-gate/scripts/test-proposal-orchestrator.mjs
+++ b/build-gate/scripts/test-proposal-orchestrator.mjs
@@ -8,7 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { buildProject, makeTeamKeyring } from "../build-orchestrator.mjs";
 import { planTeams } from "../teams.mjs";
-import { readProposalEvents } from "../../merkle-dag/proposal-ledger.mjs";
+import { readProposalEvents, readProposalArtifact } from "../../merkle-dag/proposal-ledger.mjs";
 
 const NEEDLE = "AUTH_GUARD", TARGET = "out.txt";
 
@@ -31,16 +31,19 @@ const verifyConcern = () => ({ scope: "plan", claim: "auth boundary must be veri
 function convergingWorkshop(prov) { return async ({ seat }) => ({ plan_revision: "", objections: [], dispositions: [], provenance: prov(seat === "claude" ? "anthropic" : "openai") }); }
 
 // Parallel-authorship callSeat (docs/daedalus-methodology.md): constraints=codex (openai provenance),
-// implementation=claude (anthropic provenance). Author phase -> a source plan; integrate -> echo the
-// frozen frame as the candidate body (so it deserializes) plus a COMPLETE five-field obligation matrix;
+// implementation=claude (anthropic provenance). Author phase -> a source plan; the constraints seat also
+// DECLARES the proof-obligation set it owns. integrate -> echo the frozen frame as the candidate body (so
+// it deserializes) plus an obligation matrix that EXACTLY covers the declared set (per-row obligation_id).
 // verify -> each seat confirms its own contract survived. With { conflict: true } the constraints seat
-// reports its invariant was violated by integration, driving deriveParallelState to needs-eye.
-const okObligationRow = () => Object.fromEntries(["invariant", "mechanism", "task", "negative_test", "exit_criterion"].map((f) => [f, `${f}-1`]));
+// reports its invariant was violated by integration, driving deriveParallelState to needs-eye. Every seat
+// call draws a fresh provenance id (prov()) so all five keys are real and pairwise distinct.
+const OBL_IDS = ["OBL-1"];
+const okObligationRow = (id) => ({ ...Object.fromEntries(["invariant", "mechanism", "task", "negative_test", "exit_criterion"].map((f) => [f, `${f}-${id}`])), obligation_id: id });
 function parallelWorkshop(prov, { conflict = false } = {}) {
   return async ({ seat, role, phase, frame }) => {
     const provenance = prov(seat === "claude" ? "anthropic" : "openai");
-    if (phase === "author") return { plan: `${role} source design`, provenance };
-    if (phase === "integrate") return { plan: frame, obligation_matrix: [okObligationRow()], provenance };
+    if (phase === "author") return { plan: `${role} source design`, ...(role === "constraints" ? { obligations: OBL_IDS } : {}), provenance };
+    if (phase === "integrate") return { plan: frame, obligation_matrix: OBL_IDS.map(okObligationRow), provenance };
     if (conflict && role === "constraints") return { verdict: "violated", conflicts: ["fail-closed weakened by integration"], provenance };
     return { verdict: "preserved", conflicts: [], provenance };
   };
@@ -247,9 +250,17 @@ const D = (dossier) => (fn) => (seatArg) => fn(seatArg, dossier);
   assert.equal(res.decision, "authorized", "(p1) parallel authorship authorizes");
   assert.equal(res.report.merge_status, "ready", "(p1) ready");
   // parallel-specific signature: an integration negotiation event descends from BOTH source nodes.
-  const negotiations = readProposalEvents(path.join(dir, ".telos")).events.filter((e) => e.stage === "negotiation");
-  assert.ok(negotiations.some((e) => e.policy_result && Array.isArray(e.policy_result.descends_from) && e.policy_result.descends_from.length === 2), "(p1) parallel path taken — integration descends from both source nodes");
-  console.log("Case (p1) OK: parallel authorship -> authorized -> ready");
+  const telosDir = path.join(dir, ".telos");
+  const negotiations = readProposalEvents(telosDir).events.filter((e) => e.stage === "negotiation");
+  const integEvent = negotiations.find((e) => e.policy_result && Array.isArray(e.policy_result.descends_from) && e.policy_result.descends_from.length === 2);
+  assert.ok(integEvent, "(p1) parallel path taken — integration event descends from both source nodes");
+  // The Eye's critique: the EVENT carrying two parent refs is not enough — the content-addressed
+  // integration candidate ARTIFACT itself must bind its parents. Read it back from the ledger and confirm
+  // descends_from is persisted INSIDE the artifact (so its ref commits to parentage, not just the event).
+  const candidateRef = integEvent.artifact_refs[0];
+  const integArtifact = readProposalArtifact(telosDir, candidateRef);
+  assert.ok(integArtifact && Array.isArray(integArtifact.descends_from) && integArtifact.descends_from.length === 2, "(p1) the persisted integration artifact binds both parents (content address commits to descent)");
+  console.log("Case (p1) OK: parallel authorship -> authorized -> ready; integration artifact binds parents");
 }
 
 // ---------------------------------------------------------------------------
@@ -267,15 +278,20 @@ const D = (dossier) => (fn) => (seatArg) => fn(seatArg, dossier);
 }
 
 // ---------------------------------------------------------------------------
-// Case (p3): backward-compat — authorship "parallel" declared but NO callParallelSeat injected falls
-// back to the serial workshop (the selector requires BOTH the flag and the injected seat).
+// Case (p3): FAIL-CLOSED selection — authorship "parallel" declared but NO callParallelSeat adapter
+// injected must NOT silently downgrade to the serial workshop. A caller that asked for the two-seat trust
+// structure and got the weaker single-track path unknowingly is exactly the fail-open the merge shipped.
 {
   const { prov } = fixture();
   const dossier = baseDossier({ authorship: "parallel" });
   const callSeat = D(dossier)(async ({ model }, d) => ({ packet: reviewPacket(model, d), provenance: prov(model === "agy" ? "agentic" : model === "claude" ? "anthropic" : "openai") }));
+  // callWorkshopSeat is present (serial adapter available) but callParallelSeat is NOT — the old code
+  // would have quietly run serial and authorized. It must block instead.
   const { res } = await drive({ dossier, tasks: baseTasks(), callSeat, callWorkshopSeat: convergingWorkshop(prov), callTeam: makeCallTeam() });
-  assert.equal(res.decision, "authorized", "(p3) missing callParallelSeat -> serial fallback still authorizes");
-  console.log("Case (p3) OK: parallel flag without callParallelSeat falls back to serial");
+  assert.notEqual(res.decision, "authorized", "(p3) parallel-without-adapter must NOT authorize via a silent serial downgrade");
+  assert.equal(res.ok, false, "(p3) blocked");
+  assert.ok((res.blocked || []).some((b) => /PARALLEL_AUTHORSHIP_UNAVAILABLE/.test(b)), "(p3) distinct documented fail-closed error");
+  console.log("Case (p3) OK: parallel requested without adapter FAILS CLOSED (no silent serial downgrade)");
 }
 
 console.log("test-proposal-orchestrator.mjs OK");

--- a/docs/daedalus-methodology.md
+++ b/docs/daedalus-methodology.md
@@ -90,13 +90,39 @@ lineage queryable so the methodology rules above can be enforced against
 evidence, not memory. It is out of scope for Clotho Phase 1 and does not gate
 it.
 
-## Implementation gap (for the delta that lifts this hold)
+## Enforcement (as implemented in `build-gate/daedalus.mjs`)
 
-`build-gate/daedalus.mjs` currently encodes only the serial loop. Realizing this
-note requires: parallel two-seat authorship with role specialization (GPT
-constraints / Claude implementation), two content-addressed source nodes plus an
-integration node that descends from both, the obligation-mapping requirement as
-a convergence gate, per-seat post-integration verification, explicit
-conflict-to-Eye routing, and a size threshold below which the serial loop still
-applies. That delta is itself subject to the proposal lifecycle; it is not an
-ad hoc edit.
+The parallel path is realized as `runParallelDaedalus` + the pure state machine
+`deriveParallelState`, wired into the proposal lifecycle (opt-in via
+`dossier.authorship === "parallel"`). Convergence is **fail-closed**: a candidate
+reaches `submit` only when ALL of these structural checks pass, and every other
+outcome is either `needs-eye` (an explicit contract violation, routed to The Eye)
+or a non-terminal `continue` the orchestrator normalizes to human-review stalemate.
+
+1. **Both source roles present, genuinely distinct.** Constraints (GPT) and
+   implementation (Claude) source nodes, each with a real provenance key, the two
+   distinct — one seat cannot author both halves.
+2. **The integrator is a real, distinct seat call.** Its provenance key is
+   validated (not merely stored), and all **five** seat calls — two authors, the
+   integrator, two verifiers — carry real, pairwise-distinct provenance keys, so no
+   response id is replayed across author/integrate/verify.
+3. **Parentage is content-bound and exact.** `descends_from` is written INSIDE the
+   integration candidate's content-addressed body, so the ref commits to its
+   parents; the state machine requires it to be *precisely* the two source refs —
+   no missing parent, no smuggled extra.
+4. **Exact obligation coverage.** The constraints seat OWNS and declares the
+   proof-obligation ID set (committed into its source-node content address). The
+   integration matrix must map each obligation via a per-row `obligation_id` in a
+   strict bijection — every obligation mapped once, none dropped, invented, or
+   duplicated — on top of five-field row completeness. "Map every obligation" is
+   structural, not advisory.
+5. **Affirmative preservation.** Each verifier must attest the literal verdict
+   `"preserved"`; an unrecognized or missing verdict cannot converge (it is not
+   read as tacit approval), and an explicit `"violated"` or any conflict list
+   routes to The Eye — never blended.
+
+Selection itself fails closed: an explicit `authorship: "parallel"` request with
+no `callParallelSeat` adapter injected **blocks** (`PARALLEL_AUTHORSHIP_UNAVAILABLE`)
+rather than silently downgrading to the serial loop. The serial author→reviewer
+loop is retained only for genuinely small deltas. This delta was itself carried
+through the proposal lifecycle; it is not an ad hoc edit.


### PR DESCRIPTION
## Why

PR #99 wired parallel authorship into the lifecycle, but merging **relocated** five fail-open conditions onto `main` rather than closing them (The Eye's cold read). Two of the green tests were asserting the unsafe behavior instead of catching it. This PR closes all five at the state machine + selector, and rewrites those two tests to reject the old behavior.

## The five gaps, and how each closes

| # | Gap (in merged head) | Fix |
|---|---|---|
| 1 | Integration candidate ref committed to **nothing** about parentage; the descent check was **vacuous** (`descends_from` built from the same array it validated against) | `descends_from` written **inside** the content-addressed artifact body; state machine requires it to be **exactly** the two source refs (superset/wrong/duplicate parent all rejected) |
| 2 | `authorship: "parallel"` with no adapter **silently downgraded to serial** | Now **blocks** (`PARALLEL_AUTHORSHIP_UNAVAILABLE`) — a caller who asked for the two-seat trust structure never gets the weaker path unknowingly |
| 3 | Any verdict other than the literal `"violated"` (incl. missing/arbitrary) **converged** | Requires the **literal** `"preserved"`; unrecognized/missing cannot converge; explicit `"violated"`/conflict → The Eye |
| 4 | Integrator provenance **stored but never validated** | Integrator key validated; **all five** seat-call keys must be real and **pairwise distinct** (no replayed response id) |
| 5 | Obligation matrix checked **nonblank fields**, not coverage | Constraints seat **declares** the obligation ID set (content-bound in its source node); integration matrix must map each via per-row `obligation_id` in a **strict bijection** — none dropped, invented, or duplicated |

## Files

- **`build-gate/daedalus.mjs`** — `validateObligationCoverage()` (new, exported); `deriveParallelState` rewritten fail-closed; `runParallelDaedalus` binds `descends_from` + the constraints obligation set into the content-addressed artifacts.
- **`build-gate/proposal-orchestrator.mjs`** — fail-closed selector.
- **`build-gate/scripts/test-daedalus.mjs`** — rows carry `obligation_id`; **six new adversarial cases (16–21)**, one per closed hole, including content-binding of the candidate ref to both parents.
- **`build-gate/scripts/test-proposal-orchestrator.mjs`** — **(p1)** now reads the persisted integration artifact and asserts *it* binds both parents (answering The Eye's exact critique); **(p3)** flipped from asserting a silent downgrade to asserting the fail-closed block.
- **`docs/daedalus-methodology.md`** — the "implementation gap" section becomes the enforced contract.

## Tests

`build-gate` (incl. `test-daedalus` cases 1–20 and `test-proposal-orchestrator` a–v, p1–p3) + `breakout` suites green (exit 0). The two previously-unsafe tests now fail against the pre-hardening code and pass against this PR.

## Note

Per the recommendation: **do not use the parallel path for the loader redesign until this lands.** After merge, the corrected path is the one to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eCSN1Z9qGqrAnpDGNzqdF