### PR TITLE
TELOS authz-005: Clotho Phase 1 v12 AUTHORIZED (signed council)

### DIFF
--- a/docs/runs/clotho-authorization-5/agy.json
+++ b/docs/runs/clotho-authorization-5/agy.json
@@ -1,0 +1,31 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "model": "agy",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "provenance": {
+    "provider": "local",
+    "model": "agy-checkpoint",
+    "source": "ai-peer-mcp/agy_checkpoint",
+    "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+    "answered_at": null,
+    "attestation": "local-deterministic",
+    "engine_version": "agy-checkpoint/1",
+    "tool": "agy_checkpoint"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "7323c1f90837bb4b8d6ab57c90bd8112f1daeb1b1d1fcf8b4f8d3fb1ab7d2e42",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-5/authorization-summary.json
+++ b/docs/runs/clotho-authorization-5/authorization-summary.json
@@ -1,0 +1,138 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "objective": "Authorize Argo execution of the Clotho Phase 1 implementation plan v12 (content address sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3; released by The Eye via PR #106, merge commit c5b6838b00d4c66a62906c3a20f6a39c99b48f00). v12 is the round-11 descope-and-repair of v11: The Eye ruled Clotho Phase 1 ADVISORY and NON-SANDBOXED, so v12 makes NO claim of proven loader isolation, frames the deterministic scanner (D27/D32) only as trusted-code review signals, and repairs three integrity requirements (coverage honesty D11/D35, publication-time drift D34, producer==attribution D10/AM-39). Judge v12 on ITS OWN advisory/non-sandbox terms — do NOT require it to prove loader isolation. Approve ONLY if the plan is implementation-ready and consistent with its governing spec (v2.8, advisory posture per AM-35), the repository's trust model (fail-closed, closed sets, spine read-only, advisory-only Clotho), and its own decisions and exit criteria.",
+  "plan_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "merge_anchor": "c5b6838b00d4c66a62906c3a20f6a39c99b48f00",
+  "reviewed_head": "af2b25a1f8b13949f4ebe3c1f714eb9ddd0daa23",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "trust_mode": "signed",
+  "ephemeral_signers": [
+    "claude",
+    "agy",
+    "codex"
+  ],
+  "seats": [
+    {
+      "model": "claude",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "anthropic",
+        "model": "claude-fable-5",
+        "response_id": "msg_011Cd5vKh4eC515XyB6xegkK",
+        "source": "ai-peer-mcp/claude_ask",
+        "answered_at": "2026-07-16T14:48:33.063Z",
+        "tool": "claude_ask"
+      }
+    },
+    {
+      "model": "agy",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "local",
+        "model": "agy-checkpoint",
+        "source": "ai-peer-mcp/agy_checkpoint",
+        "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+        "answered_at": null,
+        "attestation": "local-deterministic",
+        "engine_version": "agy-checkpoint/1",
+        "tool": "agy_checkpoint"
+      }
+    },
+    {
+      "model": "codex",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "openai",
+        "model": "gpt-5.6-sol",
+        "response_id": "chatcmpl-E2Hfcn4glyi02PvMMxoBZHCTPCSI0",
+        "source": "ai-peer-mcp/codex_ask",
+        "answered_at": "2026-07-16T14:55:01.345Z",
+        "tool": "codex_ask"
+      }
+    },
+    {
+      "model": "grok",
+      "role": "advisory",
+      "ok": true,
+      "signed": false,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "xai",
+        "model": "grok-4.5",
+        "response_id": "d06a8c6e-050f-9dbc-b66c-f3930761e624",
+        "source": "ai-peer-mcp/grok_ask",
+        "answered_at": "2026-07-16T14:48:22.919Z",
+        "tool": "grok_ask"
+      }
+    },
+    {
+      "model": "gemini",
+      "role": "advisory",
+      "ok": true,
+      "signed": false,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "google",
+        "model": "gemini-3.1-pro-preview",
+        "response_id": "J-9YapPwMpiGz7IP7sjt-QQ",
+        "source": "ai-peer-mcp/gemini_ask",
+        "answered_at": "2026-07-16T14:48:17.929Z",
+        "tool": "gemini_ask"
+      }
+    }
+  ],
+  "gate": {
+    "gate_status": "pass",
+    "signing_enforced": true,
+    "provenance_enforced": true,
+    "blockers": [],
+    "warnings": [],
+    "provenance": [
+      {
+        "model": "claude",
+        "has_provenance": true,
+        "provider": "anthropic",
+        "response_model": "claude-fable-5",
+        "response_id": "msg_011Cd5vKh4eC515XyB6xegkK",
+        "source": "ai-peer-mcp/claude_ask"
+      },
+      {
+        "model": "agy",
+        "has_provenance": true,
+        "provider": "local",
+        "response_model": "agy-checkpoint",
+        "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+        "source": "ai-peer-mcp/agy_checkpoint"
+      },
+      {
+        "model": "codex",
+        "has_provenance": true,
+        "provider": "openai",
+        "response_model": "gpt-5.6-sol",
+        "response_id": "chatcmpl-E2Hfcn4glyi02PvMMxoBZHCTPCSI0",
+        "source": "ai-peer-mcp/codex_ask"
+      }
+    ]
+  },
+  "authorized": true,
+  "authorization": {
+    "status": "AUTHORIZED",
+    "plan_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+    "note": "Argo execution of Clotho Phase 1 plan v12 is authorized by the signed council under the TELOS gate."
+  }
+}

--- a/docs/runs/clotho-authorization-5/claude.json
+++ b/docs/runs/clotho-authorization-5/claude.json
@@ -1,0 +1,30 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "model": "claude",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "rationale": "Judged v12 on its own advisory, non-sandboxed terms per The Eye's binding scope decision. The plan is internally consistent, implementation-ready, and faithful to the repository trust model. Key findings: (1) Scope honesty is thorough and uniform — every reference to the D23/D27/D30/D32 scanner and the D33 closure is consistently framed as a deterministic trusted-code review signal over a frozen lexical form set, never as isolation proof; the 'unclassified, not certified absent' distinction is carried into tests, evidence schemas (verification.json), and the published provenance statement, and risk 18 states the residual authority plainly. No overclaim survives that would contradict AM-35. (2) The three round-11 repairs are complete and mutually reinforcing: coverage honesty (D11/D35) now has a closed two-value schema with the critical fail-closed default — a missing manifest yields coverage:\"unverified\" with conservatively non-empty coverageUnknown, and the contradictory pairing (unverified + empty coverageUnknown with consulted producers) is explicitly a rejected schema violation with both positive and negative units enumerated; publication-time drift (D34) closes the real gap between committed-inventory tests and the published artifact by re-deriving closures and re-checking hashes from on-disk bytes immediately before the frozen D20/D28 commit point, with drift fixtures for re-export, dynamic-import, require-style, and hash-mismatch cases; producer==attribution (D10/AM-39) binds asserted_by to the invoked weaver id at append time, ordered before appendEdge so a violating result never touches the temporary ledger, with fixtures for cross-weaver, human, model, and warning.weaver mismatches. (3) The decision set composes without contradiction: D17's existence constraint is reconciled with D14/D33 closure equality via the staged Task 4a/4b/5 inventory landing; D19's split keeps Task 3 free of committed-inventory dependencies that cannot legally exist yet; D26/D29 driver-owned counting plus the normative edge-append ordering makes 'executed' behaviorally meaningful; D31 gives the ledger weaver independent counted contract reads so skipping the doc-weaver cannot silently starve clause resolution, proven by the doc-skipped flagship negative run. (4) Task 0/1 ordering resolves the absent-package-in-matrix problem, and fetch-depth: 0 is correctly load-bearing against the D16 shallow guard, proven against real git per D18 rather than only by workflow configuration. (5) The exit criteria are executable and fail-closed: flagship acceptance requires distinct one-to-one matching over eight audited groups, a review-set artifact that prevents silent over-threading (D3), coverage-field checks in both directions, and reproduction evidence that exits nonzero on drift, attribution violation, or unclean publication. (6) Accepted risks are honest about residual windows (symlink race 15, drift window 21, cleanup residue 16) and correctly scope them as OS-level races over advisory, git-ignored data. The 'Proposed spec amendments: None' section is legitimate: the spec v2.8 overclaim correction is already mandated by The Eye's own recorded round-11 lifecycle, so no new proposal from this workshop is required; the plan integrates the amendment's consequences without designing around a known spec defect. Residual concerns are minor and non-blocking: the plan's density creates execution-fidelity risk (mitigated by per-task exit criteria and frozen normative tables in the plan body), and Task 6's 120-second wall ceiling could flake on slow runners (an operational tuning matter, not a correctness defect). I would sign this: it does what it claims, claims only what it does, and every integrity property it asserts is backed by an enumerated enforcement point and test.",
+  "provenance": {
+    "provider": "anthropic",
+    "model": "claude-fable-5",
+    "response_id": "msg_011Cd5vKh4eC515XyB6xegkK",
+    "source": "ai-peer-mcp/claude_ask",
+    "answered_at": "2026-07-16T14:48:33.063Z",
+    "tool": "claude_ask"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "f85ea739e7d19bca2f726283926aabaab02114983fbe65b4954d2e8c2cd59f1f",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-5/codex.json
+++ b/docs/runs/clotho-authorization-5/codex.json
@@ -1,0 +1,30 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "model": "codex",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "rationale": "v12 is implementation-ready on its governing advisory, non-sandboxed terms. It makes no loader-isolation claim, confines D27/D30/D32 to deterministic trusted-code review signals, and limits mechanism provenance to the supported statically declared dependency model. The round-11 integrity repairs are concrete and testable: missing-manifest queries are explicitly unverified and coverage-conservative; publication-time closure and content-address drift cause pre-publication abort; and producer attribution is checked before any returned edge is appended. Task sequencing respects inventory existence and CI constraints, publication and failure handling are unambiguous, spine components remain read-only, and the final acceptance and reproduction criteria exercise the required fail-closed behavior. I find no unresolved conflict with spec v2.8 as governed by AM-35 or any defect that must block execution as written.",
+  "provenance": {
+    "provider": "openai",
+    "model": "gpt-5.6-sol",
+    "response_id": "chatcmpl-E2Hfcn4glyi02PvMMxoBZHCTPCSI0",
+    "source": "ai-peer-mcp/codex_ask",
+    "answered_at": "2026-07-16T14:55:01.345Z",
+    "tool": "codex_ask"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "2a439d38b209694c1c5f5167e334eaa17db5075b33d8e5779b31ca0d22f1d1ac",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-5/gemini.json
+++ b/docs/runs/clotho-authorization-5/gemini.json
@@ -1,0 +1,25 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "model": "gemini",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "rationale": "Plan v12 successfully integrates The Eye's binding scope decision, properly aligning the Clotho implementation with an advisory, non-sandboxed posture. It removes overclaimed guarantees of loader isolation while retaining the deterministic lexical scanner as a valuable trusted-code review signal. Furthermore, the plan rigorously addresses the three critical integrity flaws identified in the previous round: producer-attribution binding is now strictly enforced before ledger append (D10/AM-39); publication-time drift is mechanically checked immediately prior to the atomic publication commit (D34); and coverage honesty is strictly codified through the closed-schema coverage field, preventing silent missing-evidence inferences (D11/D35). The plan is fail-closed, respects the read-only spine constraint, sets explicit boundaries around accepted risks, and provides highly specific, testable exit criteria. It is thoroughly implementation-ready.",
+  "provenance": {
+    "provider": "google",
+    "model": "gemini-3.1-pro-preview",
+    "response_id": "J-9YapPwMpiGz7IP7sjt-QQ",
+    "source": "ai-peer-mcp/gemini_ask",
+    "answered_at": "2026-07-16T14:48:17.929Z",
+    "tool": "gemini_ask"
+  }
+}

--- a/docs/runs/clotho-authorization-5/grok.json
+++ b/docs/runs/clotho-authorization-5/grok.json
@@ -1,0 +1,25 @@
+{
+  "build_id": "clotho-phase-1-authz-005",
+  "use_case": "clotho-phase-1",
+  "model": "grok",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-16T14:48:06.351Z",
+  "rationale": "v12 is implementation-ready on its own stated advisory/non-sandbox terms. The Eye's binding scope (AM-35) is enforced throughout: scanners and D27/D30/D32 mapping are framed strictly as deterministic trusted-code review signals over a frozen lexical surface, with no isolation, capability-boundary, or loader-prohibition claims remaining. The three integrity repairs land cleanly and are load-bearing—D10/AM-39 producer==attribution is enforced at the driver before any appendEdge; D11/D35 coverage honesty makes a missing/unverified manifest report every consulted producer as unknown and forbids coverageUnknown:[] under unverified; D34 publication-time re-derive/compare/abort binds the published provenance statement to on-disk bytes. Sequencing (scaffold → isolated CI matrix → registries → ledger with injected coverage → weavers with D17-compliant inventories → driver discharging D19/D26/D29/D33/D34 → flagship → evidence) is consistent with closed inventories, spine read-only, fail-closed closed sets, and atomic no-replace publication. Exit criteria, task checklists, unit obligations, and accepted-risk boundaries are concrete enough for Argo one-task-per-branch execution without further plan edits. No remaining hard inconsistency with the repository trust model or governing v2.8 advisory posture; the already-routed Eye amendment covers residual overclaim language, so this plan correctly proposes none.",
+  "provenance": {
+    "provider": "xai",
+    "model": "grok-4.5",
+    "response_id": "d06a8c6e-050f-9dbc-b66c-f3930761e624",
+    "source": "ai-peer-mcp/grok_ask",
+    "answered_at": "2026-07-16T14:48:22.919Z",
+    "tool": "grok_ask"
+  }
+}

--- a/docs/runs/clotho-authorization-5/run-authorization-5.mjs
+++ b/docs/runs/clotho-authorization-5/run-authorization-5.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// TELOS authorization run for Clotho Phase 1 plan v12 (authz-005).
+//
+// Sequence: Daedalus delta-11 (done) -> The Eye released v12 (PR #106 merged
+// c5b6838) -> TELOS AUTHORIZES (this run) -> Argo executes. A real signed
+// council over the plan's content address: claude/agy/codex REQUIRED approvers,
+// grok/gemini advisory. Every chat seat reviews the FULL plan text and returns a
+// strict JSON approval packet bound to its own real provenance; agy is the local
+// deterministic governance checkpoint derived from the dossier. The gate
+// (trust_mode "signed") certifies from packets + signatures + provenance —
+// never a seat's self-report. Fail-closed: any missing required packet, invalid
+// signature, placeholder provenance, or non-approve decision leaves v12
+// UNAUTHORIZED.
+//
+// v12 is the descope-and-repair of v11 (round-11 amendments AM-35..AM-39 + The
+// Eye's advisory/non-sandbox scope decision). Judge v12 on ITS OWN terms:
+// advisory, non-sandboxed, no claim of proven loader isolation.
+//
+// Run from Windows node (loadWin32Env pulls API keys + TELOS_SECRET_* from HKCU).
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+process.env.AI_PEER_LONG_TIMEOUT = "1";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "../../..");
+const imp = (rel) => import(pathToFileURL(path.join(ROOT, rel)).href);
+
+// Import order matters: the seat server module's loadWin32Env() (win32) fills
+// process.env with API keys AND TELOS_SECRET_* from the registry BEFORE the
+// secret check below.
+await imp("connectors/ai-peer-mcp/server.mjs");
+const { canonicalize, sha256hex } = await imp("merkle-dag/vendor.mjs");
+const { runCouncil, liveSeatCaller, agyApprovalPacket, agyCheckpointArgs } = await imp("build-gate/council.mjs");
+const { validateRecords } = await imp("build-gate/gate.mjs");
+const { spawnMcpClient } = await imp("breakout/mcp_client.mjs");
+
+// ---------- bind the exact plan under authorization ----------
+const PLAN_PATH = "docs/runs/clotho-daedalus-delta11/matured-plan-v12.md";
+const SPEC_PATH = "docs/clotho-phase-1-design.md";
+const EXPECTED_PLAN_REF = "sha256:bdc93901952312846d693e14925eac49c332e0364a4a2a158ae21b2d607e79d3";
+const MERGE_ANCHOR = "c5b6838b00d4c66a62906c3a20f6a39c99b48f00"; // PR #106 regular merge commit
+const REVIEWED_HEAD = "af2b25a1f8b13949f4ebe3c1f714eb9ddd0daa23"; // v12 reviewed head (delta-11 output)
+
+const planText = readFileSync(path.join(ROOT, PLAN_PATH), "utf8");
+const planRef = "sha256:" + sha256hex(canonicalize({ kind: "candidate", plan: planText }));
+if (planRef !== EXPECTED_PLAN_REF) {
+  console.error(`PLAN DRIFT: ${PLAN_PATH} recomputes to ${planRef}, expected ${EXPECTED_PLAN_REF}. Refusing to authorize.`);
+  process.exit(1);
+}
+
+// ---------- signing secrets: real registry values when present, else ephemeral ----------
+const EPHEMERAL_SIGNERS = [];
+for (const m of ["CLAUDE", "AGY", "CODEX"]) {
+  if (!process.env[`TELOS_SECRET_${m}`]) {
+    process.env[`TELOS_SECRET_${m}`] = randomBytes(24).toString("hex");
+    EPHEMERAL_SIGNERS.push(m.toLowerCase());
+  }
+}
+
+const BUILD_ID = "clotho-phase-1-authz-005";
+const USE_CASE = "clotho-phase-1";
+const TIMESTAMP = new Date().toISOString();
+const OBJECTIVE =
+  `Authorize Argo execution of the Clotho Phase 1 implementation plan v12 ` +
+  `(content address ${planRef}; released by The Eye via PR #106, merge commit ${MERGE_ANCHOR}). ` +
+  `v12 is the round-11 descope-and-repair of v11: The Eye ruled Clotho Phase 1 ADVISORY and NON-SANDBOXED, so v12 makes NO claim of proven loader isolation, ` +
+  `frames the deterministic scanner (D27/D32) only as trusted-code review signals, and repairs three integrity requirements (coverage honesty D11/D35, publication-time drift D34, producer==attribution D10/AM-39). ` +
+  `Judge v12 on ITS OWN advisory/non-sandbox terms — do NOT require it to prove loader isolation. ` +
+  `Approve ONLY if the plan is implementation-ready and consistent with its governing spec (v2.8, advisory posture per AM-35), the repository's ` +
+  `trust model (fail-closed, closed sets, spine read-only, advisory-only Clotho), and its own decisions and exit criteria.`;
+
+// Write targets from the plan (agy derives protected_path_check from these).
+const WRITE_TARGETS = ["clotho/", ".github/workflows/ci.yml", ".gitignore", "docs/runs/clotho-self-weave/", "docs/STATUS.md", "docs/ROADMAP.md"];
+
+const dossier = {
+  build_id: BUILD_ID,
+  use_case: USE_CASE,
+  objective: OBJECTIVE,
+  proposal_ref: planRef,
+  required_docs: [PLAN_PATH, SPEC_PATH],
+  write_targets: WRITE_TARGETS,
+  protected_paths: [],
+  trust_mode: "signed"
+};
+
+const meta = {
+  build_id: BUILD_ID,
+  use_case: USE_CASE,
+  proposal_ref: planRef,
+  timestamp: TIMESTAMP,
+  docs_reviewed: [PLAN_PATH, SPEC_PATH]
+};
+
+// ---------- strict packet schema (native structured output on every chat seat) ----------
+const PACKET_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    decision: { type: "string", enum: ["approve", "revise", "reject"] },
+    confidence: { type: "string", enum: ["low", "medium", "high"] },
+    required_edits: { type: "array", items: { type: "string" } },
+    hard_stops: { type: "array", items: { type: "string" } },
+    rationale: { type: "string" }
+  },
+  required: ["decision", "confidence", "required_edits", "hard_stops", "rationale"]
+};
+
+function parsePacket(text, model) {
+  let m = null;
+  try { m = JSON.parse(text); } catch { /* fall through */ }
+  if (m && m.phase_gate_status) return agyApprovalPacket(m, meta);
+  if (!m || typeof m !== "object") m = {};
+  return {
+    build_id: BUILD_ID,
+    use_case: USE_CASE,
+    model,
+    role: "approver",
+    docs_reviewed: meta.docs_reviewed,
+    proposal_ref: planRef,
+    decision: ["approve", "revise", "reject"].includes(m.decision) ? m.decision : "revise",
+    required_edits: Array.isArray(m.required_edits) ? m.required_edits : [],
+    hard_stops: Array.isArray(m.hard_stops) ? m.hard_stops : [],
+    confidence: ["low", "medium", "high"].includes(m.confidence) ? m.confidence : "low",
+    timestamp: TIMESTAMP,
+    rationale: typeof m.rationale === "string" ? m.rationale : "unparsable seat response (fail-closed to revise)"
+  };
+}
+
+// Gemini's responseSchema rejects `additionalProperties` — strip it for that seat.
+function stripAdditionalProperties(schema) {
+  const clone = JSON.parse(JSON.stringify(schema));
+  const walk = (node) => {
+    if (!node || typeof node !== "object") return;
+    delete node.additionalProperties;
+    for (const v of Object.values(node)) walk(v);
+  };
+  walk(clone);
+  return clone;
+}
+
+const FIELD_SEMANTICS =
+  "Field semantics (STRICT): decision 'approve' means the plan may be executed AS-IS. " +
+  "hard_stops lists ONLY conditions that must BLOCK authorization right now — if you approve unconditionally, hard_stops MUST be []. " +
+  "required_edits lists ONLY concrete changes you demand before approval — if you approve, required_edits MUST be []. " +
+  "Do NOT restate the plan's invariants, strengths, or constraints in either list; put commentary in rationale.";
+
+function promptFor(model, _role, dsr) {
+  if (model === "agy") {
+    return { tool: "agy_checkpoint", args: agyCheckpointArgs(dsr, "clotho/") };
+  }
+  return {
+    tool: `${model}_ask`,
+    args: {
+      prompt: `Objective:\n${OBJECTIVE}\n\n${FIELD_SEMANTICS}\n\n=== PLAN UNDER AUTHORIZATION (${PLAN_PATH}, ${planRef}) ===\n\n${planText}`,
+      system: `You are the ${model} seat on the TELOS authorization council. Judge the plan on the merits against the objective. Approve only what you would stake your seat's signature on. ${FIELD_SEMANTICS}`,
+      model,
+      max_tokens: 60000,
+      include_provenance: true,
+      response_schema: model === "gemini" ? stripAdditionalProperties(PACKET_SCHEMA) : PACKET_SCHEMA,
+      schema_name: "telos_approval_packet"
+    }
+  };
+}
+
+const seats = [
+  { model: "claude", role: "approver" },
+  { model: "agy", role: "approver" },
+  { model: "codex", role: "approver" },
+  { model: "grok", role: "advisory" },
+  { model: "gemini", role: "advisory" }
+];
+
+const serverPath = path.join(ROOT, "connectors/ai-peer-mcp/server.mjs");
+const { client, close } = spawnMcpClient({ command: process.execPath, serverPath });
+const killer = setTimeout(() => { console.error("AUTHZ_TIMEOUT"); process.exit(2); }, 1_800_000);
+
+try {
+  const callSeat = (seatArg) =>
+    liveSeatCaller({ client, promptFor, parsePacket: (t) => parsePacket(t, seatArg.model) })(seatArg);
+
+  const results = await runCouncil({ seats, callSeat, dossier });
+
+  mkdirSync(HERE, { recursive: true });
+  const summary = { build_id: BUILD_ID, use_case: USE_CASE, objective: OBJECTIVE, plan_ref: planRef, merge_anchor: MERGE_ANCHOR, reviewed_head: REVIEWED_HEAD, timestamp: TIMESTAMP, trust_mode: "signed", ephemeral_signers: EPHEMERAL_SIGNERS, seats: [] };
+  const packetsForGate = [];
+
+  for (const r of results) {
+    if (r.ok) {
+      writeFileSync(path.join(HERE, `${r.model}.json`), JSON.stringify(r.packet, null, 2));
+      packetsForGate.push(r.packet);
+      summary.seats.push({ model: r.model, role: r.role, ok: true, signed: !!r.signed, decision: r.packet.decision, confidence: r.packet.confidence, provenance: r.packet.provenance });
+    } else {
+      summary.seats.push({ model: r.model, role: r.role, ok: false, reason: r.reason });
+    }
+  }
+
+  const gate = validateRecords(dossier, packetsForGate);
+  summary.gate = {
+    gate_status: gate.gate_status,
+    signing_enforced: gate.headline_checks?.signing_enforced,
+    provenance_enforced: gate.headline_checks?.provenance_enforced,
+    blockers: gate.blockers,
+    warnings: gate.warnings,
+    provenance: gate.provenance
+  };
+
+  const requiredSeats = seats.filter((s) => s.role === "approver").map((s) => s.model);
+  const approvals = summary.seats.filter((s) => requiredSeats.includes(s.model) && s.ok && s.decision === "approve");
+  const gatePassed = gate.gate_status === "pass";
+  summary.authorized = gatePassed && approvals.length === requiredSeats.length;
+  summary.authorization = summary.authorized
+    ? { status: "AUTHORIZED", plan_ref: planRef, note: "Argo execution of Clotho Phase 1 plan v12 is authorized by the signed council under the TELOS gate." }
+    : { status: "NOT_AUTHORIZED", note: "Fail-closed: see gate.blockers and seat decisions." };
+
+  writeFileSync(path.join(HERE, "authorization-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify({ authorized: summary.authorized, gate_status: gate.gate_status, blockers: gate.blockers.length, seats: summary.seats.map((s) => ({ model: s.model, ok: s.ok, decision: s.decision ?? null })) }, null, 2));
+  process.exit(summary.authorized ? 0 : 3);
+} catch (error) {
+  console.error("AUTHZ_ERROR: " + (error?.message || String(error)));
+  process.exitCode = 1;
+} finally {
+  clearTimeout(killer);
+  close();
+}


### PR DESCRIPTION
Records the TELOS authorization gate result for the released **v12** candidate. **Merging this records the gate result; it does not open Argo or start implementation** — that remains a separate human (The Eye) decision.

## Verdict: **AUTHORIZED**
- `gate_status=pass`, **0 blockers**, `signing_enforced=true`, `provenance_enforced=true`
- Plan under authorization: `sha256:bdc93901…` (v12), released via PR #106, merge anchor `c5b6838…`, reviewed head `af2b25a1…`

| seat | role | decision | provenance |
|---|---|---|---|
| claude | approver | **approve** / high (signed) | claude-fable-5 `msg_011Cd5vKh4eC515XyB6xegkK` |
| agy | approver | **approve** / high (signed) | agy-checkpoint (local deterministic) |
| codex | approver | **approve** / high (signed) | gpt-5.6-sol `chatcmpl-E2Hfcn4glyi02PvMMxoBZHCTPCSI0` |
| grok | advisory | approve / high | grok-4.5 |
| gemini | advisory | approve / high | gemini-3.1-pro-preview |

Signers were ephemeral (`["claude","agy","codex"]`, as in authz-004); the gate still enforces signing + real provenance.

## Significance
Codex — the required seat that dissented across authz-001…004 — now **approves** v12 on its advisory/non-sandboxed terms: no loader-isolation claim, the deterministic scanner (D27/D30/D32) confined to trusted-code review signals, and the three integrity repairs (coverage honesty D11/D35, publication-time drift D34, producer==attribution D10/AM-39) judged concrete and testable. The round-11 descope-and-repair resolved the standoff without producing any loader-evasion content.

## Boundary
Argo remains **closed**. Opening it / starting implementation is the next human-gated decision and is not performed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)