### PR TITLE
Pin content-addressed run artifacts to LF (.gitattributes)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Content-addressed artifacts — pin to LF.
+#
+# The Daedalus and TELOS-authorization runners recompute a plan's sha256 over
+# its RAW BYTES and fail closed on drift (the "PLAN DRIFT" guard). This repo runs
+# with core.autocrlf=true and no per-path override, so a fresh worktree checkout
+# silently rewrites LF -> CRLF and changes those bytes — breaking the content
+# address even though the file looks identical. authz-005 caught exactly this.
+#
+# Keep the run-evidence tree as text (diffable in review) but force LF on
+# checkout and commit so content-addressed artifacts cannot be silently
+# transformed. Scope is deliberately narrow: only docs/runs/** (matured plans,
+# round artifacts, packets, event logs) is content-addressed.
+docs/runs/** text eol=lf


### PR DESCRIPTION
Tightly-scoped repair for the CRLF checkout drift observed during authz-005.

## Problem
The Daedalus/authz runners recompute a plan's `sha256` over its **raw bytes** and fail closed on drift. The repo runs `core.autocrlf=true` with no per-path override, so a fresh worktree checkout silently rewrites LF→CRLF and **breaks the content address** even though the file looks identical. In authz-005, the released v12 (`sha256:bdc93901…`) recomputed to a different hash on a fresh checkout until the canonical LF bytes were restored. The drift guard correctly failed closed — but the checkout shouldn't transform the bytes in the first place.

## Fix
A single `.gitattributes` rule, scoped only to the content-addressed run-evidence tree:
```
docs/runs/** text eol=lf
```

## Verified
Forcing a fresh checkout of `docs/runs/clotho-daedalus-delta11/matured-plan-v12.md` under this rule yields LF bytes (0 CR) hashing to `sha256:bdc93901…` — the released content address. Before the rule, the same checkout produced CRLF and drifted.

No plan/authorization/functional content changes; committed blobs are already LF, so this only governs checkout/commit line-ending handling. Does not open Argo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)