### PR TITLE
Clotho Task 0: add clotho to CI matrix (workflow-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,15 @@ jobs:
           - saas-forge
           - ai-forge
           - forge
+          - clotho
     name: ${{ matrix.package }} (node ${{ matrix.node-version }})
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # clotho's deriveRepositoryRef (Task 2) rejects a shallow clone, so its
+          # job needs full history; every other package keeps the default depth.
+          fetch-depth: ${{ matrix.package == 'clotho' && '0' || '1' }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
> **HELD — workflow-only PR.** Per v12/D12 this is human-reviewed as a workflow change. Deterministic proof = its own CI run (the new clotho job green, existing jobs unchanged/green).

## Change (confined to `.github/workflows/ci.yml`)
- Add `clotho` to the package matrix.
- Set `fetch-depth: 0` for the clotho job only (`matrix.package == 'clotho' && '0' || '1'`) — clotho's Task 2 `deriveRepositoryRef` rejects a shallow clone; all other packages keep the default depth (unchanged behavior).

## Why now
v12 sequences Task 0 immediately after the Task 1 scaffold (merged, PR #110) so the matrix names a package that already exists and passes. clotho `npm test` is green locally (scaffold: check + test-all).

## Boundaries
- No existing package command changed; no `clotho/` source changed.
- Traceable to v12 `sha256:bdc93901…`, authz-005, Eye impl-authorization (#109).
- Per the authorized per-task cadence (#109): this is its own bounded PR, human-reviewed before Task 2 begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)