### PR TITLE
Clotho Task 3: thread-ledger.mjs — signed append-only thread ledger (held for TELOS review)

### DIFF
--- a/clotho/scripts/test-all.mjs
+++ b/clotho/scripts/test-all.mjs
@@ -18,7 +18,8 @@ const SELF = path.relative(ROOT, fileURLToPath(import.meta.url)).split(path.sep)
 // Committed ordered test list (POSIX-relative to clotho/). Grows one entry per
 // task as real tests land.
 const TESTS = [
-  "scripts/test-registry.mjs"
+  "scripts/test-registry.mjs",
+  "scripts/test-ledger.mjs"
 ];
 
 function collectTestFiles(dir) {

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -183,7 +183,13 @@ try {
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }]; }, /carry exactly/],       // missing required id
     [(c) => { c.weavers[3].inspected_source_counts = [{ inventory_id: "doc-files", count: 0 }, { inventory_id: "extra", count: 0 }]; }, /carry exactly/], // extra id
     [(c) => { c.orchestrator_refs = ["file:/abs@" + HEX40A]; }, /canonical POSIX/],                    // absolute path
-    [(c) => { c.weavers[0].implementation_refs = ["file:../escape.mjs@" + HEX40A]; }, /canonical POSIX/] // traversal
+    [(c) => { c.weavers[0].implementation_refs = ["file:../escape.mjs@" + HEX40A]; }, /canonical POSIX/], // traversal
+    [(c) => { c.weavers[0].inspected_source_counts[0].count = 1.5; }, /safe integer/],                 // non-integer count
+    [(c) => { c.weavers[0].inspected_source_counts[0].count = 2 ** 53; }, /safe integer/],             // unsafe integer count
+    [(c) => { c.weavers[0].inspected_source_counts[0].extra = 1; }, /exactly \{inventory_id, count\}/], // extra count field
+    [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }, { inventory_id: "package-files", count: 1 }]; }, /sorted and unique/], // duplicate
+    [(c) => { c.weavers[0].implementation_refs = []; }, /nonempty array/],                             // empty implementation_refs
+    [(c) => { c.inventories_consumed = [{ id: "x", source_ref: "git:" + HEX40A }]; }, /'file:' content address/] // malformed inventories_consumed ref
   ];
   for (const [mut, re] of covBad) {
     const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
@@ -329,9 +335,13 @@ try {
       for (let i = 2; i < allLines.length; i++) yield allLines[i] + "\n";
     }
     const it = readEdges(p, { openReadStream: () => gated() });
-    const first = await it.next(); // must resolve while the gate still blocks
+    // race iterator.next() against a short timeout: the edge must arrive first,
+    // proving readEdges yields before the stream ends (the gate is still open).
+    const timeout = new Promise((r) => { setTimeout(() => r("TIMEOUT"), 1000); });
+    const first = await Promise.race([it.next(), timeout]);
+    assert.notEqual(first, "TIMEOUT", "edge yielded before EOF (won the race vs timeout)");
     assert.equal(first.done, false);
-    assert.equal(first.value.edge_kind, "introduced-by", "edge yielded before EOF");
+    assert.equal(first.value.edge_kind, "introduced-by");
     release();
     const rest = [];
     for (let x = await it.next(); !x.done; x = await it.next()) rest.push(x.value);
@@ -453,6 +463,58 @@ try {
     async function* s() { for (const ln of lines) yield ln + "\n"; }
     const v = await verifyLedger(p, { openReadStream: () => s() });
     assert.equal(v.ok, true, "streamed verify ok: " + JSON.stringify(v.errors));
+  }
+
+  // ---- 12. D22 descriptor-close failure, endpoint matrix, misc -------------
+  {
+    // a descriptor-close failure poisons permanently (no idempotent success)
+    let closes = 0;
+    const openFile = () => ({ write() {}, close() { closes++; throw new Error("close boom"); } });
+    const l = createLedger(newPath(), { ...opts, openFile });
+    l.appendEdge(anEdge());
+    assert.throws(() => l.close(coverage()), /boom/);
+    assert.throws(() => l.close(coverage()), /poisoned/, "a failed close is never idempotent-success");
+    assert.throws(() => l.appendEdge(anEdge()), /poisoned/);
+    assert.equal(closes, 1, "descriptor closed once, not leaked or double-closed");
+  }
+  {
+    // close after abort throws
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.abort();
+    assert.throws(() => l.close(coverage()), /poisoned/);
+  }
+  {
+    // every permitted depends-on endpoint verifies; a wrong one is rejected
+    const p = newPath(); const l = createLedger(p, opts);
+    const dep = (fromL, toL) => ({ edge_kind: "depends-on", from_node: deriveNodeId(fromL), to_node: deriveNodeId(toL), from_locator: fromL, to_locator: toL, source_ref: SR, asserted_by: "clotho-code-weaver", assertion_status: "deterministic-extraction" });
+    l.appendEdge(dep(csLoc, csLoc));
+    l.appendEdge(dep(csLoc, rfLoc));
+    l.appendEdge(dep(rfLoc, csLoc));
+    l.appendEdge(dep(rfLoc, rfLoc));
+    l.close(coverage({ codeState: "executed" }));
+    assert.equal((await verifyLedger(p)).ok, true, "depends-on matrix verifies");
+    const l2 = createLedger(newPath(), opts);
+    assert.throws(() => l2.appendEdge(dep(csLoc, commitLoc)), /valid depends-on endpoint/);
+  }
+  {
+    // misplaced/duplicate header (a header where a record belongs)
+    const { p, lines } = build3();
+    writeFileSync(p, [lines[0], lines[0], lines[2]].join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /duplicate header/.test(x)));
+  }
+  {
+    // removal of a complete tail record PLUS the trailer
+    const p = newPath(); const l = createLedger(p, opts);
+    l.appendEdge(anEdge()); l.appendEdge(dependsEdge()); l.close(coverage({ codeState: "executed" }));
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n"); // header, e1, e2, trailer
+    writeFileSync(p, lines.slice(0, 2).join("\n") + "\n"); // keep header + e1 only
+    assert.ok((await expectFail(p)).errors.some((x) => /no final trailer/.test(x)));
+  }
+  {
+    // an invalid-UTF-8 line is rejected (byte-exact verification)
+    const { p, lines } = build3();
+    const bad = Buffer.concat([Buffer.from(lines[0] + "\n", "utf8"), Buffer.from([0xff, 0x0a]), Buffer.from(lines[2] + "\n", "utf8")]);
+    writeFileSync(p, bad);
+    assert.ok((await expectFail(p)).errors.some((x) => /UTF-8/.test(x)));
   }
 
   console.log("test-ledger: all assertions passed");

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -32,13 +32,18 @@ function anEdge() {
 function dependsEdge() {
   return { edge_kind: "depends-on", from_node: deriveNodeId(rfLoc), to_node: deriveNodeId(csLoc), from_locator: rfLoc, to_locator: csLoc, source_ref: SR, asserted_by: "clotho-code-weaver", assertion_status: "deterministic-extraction" };
 }
+const WEAVER_ORDER = ["clotho-git-weaver", "clotho-code-weaver", "clotho-test-weaver", "clotho-doc-weaver", "clotho-ledger-weaver"];
+const REQ = {
+  "clotho-git-weaver": ["package-files", "package-symbols"],
+  "clotho-code-weaver": ["package-modules"],
+  "clotho-test-weaver": ["package-manifests", "test-files"],
+  "clotho-doc-weaver": ["doc-files"],
+  "clotho-ledger-weaver": ["contract-files", "ledger-sources", "run-sources"]
+};
 function coverage({ gitState = "executed", codeState = "skipped" } = {}) {
-  const w = (id, state, invId) => ({ id, version: 1, implementation_refs: ["file:clotho/weavers/x.mjs@" + HEX40A], state, inspected_source_counts: [{ inventory_id: invId, count: state === "executed" ? 2 : 0 }] });
-  return {
-    weavers: [w("clotho-git-weaver", gitState, "git-sources"), w("clotho-code-weaver", codeState, "code-sources"), w("clotho-test-weaver", "skipped", "test-sources"), w("clotho-doc-weaver", "skipped", "doc-sources"), w("clotho-ledger-weaver", "skipped", "contract-files")],
-    orchestrator_refs: ["file:clotho/weave.mjs@" + HEX40A],
-    inventories_consumed: [{ id: "git-sources", source_ref: "file:clotho/inventory.mjs@" + HEX40A }]
-  };
+  const stateFor = (id) => id === "clotho-git-weaver" ? gitState : (id === "clotho-code-weaver" ? codeState : "skipped");
+  const w = (id) => { const state = stateFor(id); return { id, version: 1, implementation_refs: ["file:clotho/weavers/x.mjs@" + HEX40A], state, inspected_source_counts: REQ[id].map((inv) => ({ inventory_id: inv, count: state === "executed" ? 2 : 0 })) }; };
+  return { weavers: WEAVER_ORDER.map(w), orchestrator_refs: ["file:clotho/weave.mjs@" + HEX40A], inventories_consumed: [{ id: "git-sources", source_ref: "file:clotho/inventory.mjs@" + HEX40A }] };
 }
 
 // A minimal independent signer to build signed-but-adversarial fixtures.
@@ -58,7 +63,7 @@ function buildSignedLedger(p, { edges = [], statuses = [], manifest }) {
     lines.push(prevLine);
     return record_hash;
   };
-  for (const e of edges) hashes.push(sign({ ...e, woven_at: WOVEN }));
+  for (const e of edges) hashes.push(sign({ ...e, woven_at: e.woven_at ?? WOVEN }));
   for (const s of statuses) sign({ ...s, woven_at: WOVEN });
   if (manifest) sign({ clotho_weave_trailer: manifest, woven_at: WOVEN });
   writeFileSync(p, lines.join("\n") + "\n");
@@ -174,7 +179,9 @@ try {
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "a", count: -1 }]; }, /nonnegative/],
     [(c) => { c.weavers[0].implementation_refs = ["git:" + HEX40A]; }, /file:<path>@/],
     [(c) => { c.orchestrator_refs = []; }, /nonempty/],
-    [(c) => { c.weavers[0].extra = 1; }, /unexpected field/]
+    [(c) => { c.weavers[0].extra = 1; }, /unexpected field/],
+    [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }]; }, /carry exactly/],       // missing required id
+    [(c) => { c.weavers[3].inspected_source_counts = [{ inventory_id: "doc-files", count: 0 }, { inventory_id: "extra", count: 0 }]; }, /carry exactly/] // extra id
   ];
   for (const [mut, re] of covBad) {
     const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
@@ -294,6 +301,21 @@ try {
     const p = newPath();
     buildSignedLedger(p, { edges: [anEdge()], manifest: coverage({ gitState: "skipped" }) });
     assert.equal((await verifyLedger(p)).ok, false, "signed skipped-weaver-with-edge fails verify");
+  }
+  {
+    // a signed edge whose woven_at differs from the header fails verification
+    const p = newPath();
+    buildSignedLedger(p, { edges: [{ ...anEdge(), woven_at: "2020-01-01T00:00:00.000Z" }], manifest: coverage() });
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false, "wrong woven_at fails verify");
+    assert.ok(v.errors.some((x) => /woven_at/.test(x)));
+  }
+  {
+    // a signed manifest carrying the wrong inventory ids fails verification
+    const p = newPath();
+    const c = coverage(); c.weavers[0].inspected_source_counts = [{ inventory_id: "nope", count: 2 }, { inventory_id: "zzz", count: 2 }];
+    buildSignedLedger(p, { edges: [anEdge()], manifest: c });
+    assert.equal((await verifyLedger(p)).ok, false, "wrong inventory ids fail verify");
   }
   {
     // a signed ledger with a valid human supersedes edge verifies ok

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -7,7 +7,7 @@
 // independently-signed adversarial fixtures, and incremental streaming readEdges.
 
 import assert from "node:assert/strict";
-import { generateKeyPairSync, sign as edSign, createHash } from "node:crypto";
+import { generateKeyPairSync, sign as edSign, createHash, createPublicKey } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -91,6 +91,28 @@ try {
     assert.equal(v.records.length, 3);
     assert.ok(v.header && v.manifest);
     assert.ok(!v.records.some((r) => r.clotho_weave_header || r.clotho_weave_trailer));
+  }
+
+  // ---- 1b. signKey must be a PRIVATE Ed25519 key; a public KeyObject (same
+  // asymmetricKeyType) is refused at creation, BEFORE any file I/O -----------
+  {
+    const p = newPath();
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    // A public KeyObject reports asymmetricKeyType "ed25519" but type "public";
+    // it must be rejected immediately without touching the injected file handle.
+    let opened = 0;
+    const spyOpen = () => { opened++; return { write() { throw new Error("must not write"); }, close() {} }; };
+    assert.throws(() => createLedger(p, { ...opts, signKey: publicKey, openFile: spyOpen }), /Ed25519 private key/);
+    assert.equal(opened, 0, "createLedger must reject a public key before opening the file");
+    assert.throws(() => readFileSync(p), /ENOENT/, "no ledger file may be created on rejection");
+    // A DER-imported public key object is likewise refused.
+    const pubImported = createPublicKey({ key: publicKey.export({ type: "spki", format: "der" }), format: "der", type: "spki" });
+    assert.throws(() => createLedger(p, { ...opts, signKey: pubImported, openFile: spyOpen }), /Ed25519 private key/);
+    assert.equal(opened, 0);
+    // Positive control: an injected PRIVATE KeyObject is accepted and verifies.
+    const l = createLedger(p, { ...opts, signKey: privateKey });
+    l.appendEdge(anEdge()); l.close(coverage());
+    assert.equal((await verifyLedger(p)).ok, true, "injected private KeyObject must succeed");
   }
 
   // ---- 2. verify trust boundary: tamper -> ok:false, records truncated ------
@@ -189,6 +211,8 @@ try {
     [(c) => { c.weavers[0].inspected_source_counts[0].extra = 1; }, /unexpected field/], // extra count field
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }, { inventory_id: "package-files", count: 1 }]; }, /sorted and unique/], // duplicate
     [(c) => { c.weavers[0].implementation_refs = []; }, /nonempty array/],                             // empty implementation_refs
+    [(c) => { delete c.weavers[0].implementation_refs; }, /missing field 'implementation_refs'/],       // implementation_refs property ABSENT
+    [(c) => { delete c.orchestrator_refs; }, /missing field 'orchestrator_refs'/],                      // orchestrator_refs property ABSENT
     [(c) => { c.inventories_consumed = [{ id: "x", source_ref: "git:" + HEX40A }]; }, /'file:' content address/] // malformed inventories_consumed ref
   ];
   for (const [mut, re] of covBad) {
@@ -576,7 +600,9 @@ try {
     (c) => { c.weavers[1].inspected_source_counts[0].count = 3; },                                               // skipped nonzero
     (c) => { c.weavers[0].state = "failed"; },                                                                   // failed state
     (c) => { c.weavers[0].implementation_refs = []; },                                                           // empty impl_refs
-    (c) => { c.orchestrator_refs = []; }                                                                          // empty orchestrator_refs
+    (c) => { c.orchestrator_refs = []; },                                                                         // empty orchestrator_refs
+    (c) => { delete c.weavers[0].implementation_refs; },                                                          // implementation_refs property ABSENT
+    (c) => { delete c.orchestrator_refs; }                                                                        // orchestrator_refs property ABSENT
   ]) {
     assert.equal(await verifyBadCoverage(mut), false, "signed invalid-manifest fixture must fail verify");
   }

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -1,208 +1,308 @@
 #!/usr/bin/env node
-// test-ledger.mjs — Task 3. Signed thread-ledger lifecycle and verification
-// against injected fixture coverage (D19): header/append/status/close/abort,
-// chain + Ed25519 signatures, verifyLedger success + tamper/truncation, the D24
-// inspected_source_counts schema, skipped-weaver-with-edges rejection, descriptor
-// discipline, and readEdges. Plain node:assert/strict; fresh Node process.
+// test-ledger.mjs — Task 3. Signed thread-ledger lifecycle + verification against
+// injected fixture coverage (D19). Covers the frozen unit surface: append/status/
+// close/abort, chain + Ed25519 signatures, verifyLedger trust boundary (records
+// only-before-first-failure, edge+status only), the D24 counts schema, exact
+// weaver-id order, descriptor closure via an injected file handle (D22),
+// independently-signed adversarial fixtures, and incremental streaming readEdges.
 
 import assert from "node:assert/strict";
+import { generateKeyPairSync, sign as edSign, createHash } from "node:crypto";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { createLedger, verifyLedger, readEdges } from "../thread-ledger.mjs";
-import { deriveNodeId } from "../registry.mjs";
+import { deriveNodeId, canonicalJson } from "../registry.mjs";
 
 const HEX40A = "0123456789abcdef0123456789abcdef01234567";
 const REPO_HEAD = "fedcba9876543210fedcba9876543210fedcba98";
 const REPO = "git-root:" + HEX40A;
 const SR = "git:" + HEX40A;
+const WOVEN = "2026-07-16T00:00:00.000Z";
+const opts = { wovenAt: WOVEN, repoHead: REPO_HEAD, repositoryRef: REPO };
 
 const csLoc = { kind: "code-symbol", locator: { repository_ref: REPO, path: "clotho/registry.mjs", symbol: "deriveNodeId", blob_sha: HEX40A } };
+const rfLoc = { kind: "repository-file", locator: { repository_ref: REPO, path: "clotho/registry.mjs", blob_sha: HEX40A } };
 const commitLoc = { kind: "commit", locator: { sha: REPO_HEAD } };
 
 function anEdge() {
-  return {
-    edge_kind: "introduced-by",
-    from_node: deriveNodeId(csLoc),
-    to_node: deriveNodeId(commitLoc),
-    from_locator: csLoc,
-    to_locator: commitLoc,
-    source_ref: SR,
-    asserted_by: "clotho-git-weaver",
-    assertion_status: "deterministic-extraction"
-  };
+  return { edge_kind: "introduced-by", from_node: deriveNodeId(csLoc), to_node: deriveNodeId(commitLoc), from_locator: csLoc, to_locator: commitLoc, source_ref: SR, asserted_by: "clotho-git-weaver", assertion_status: "deterministic-extraction" };
 }
-
-function coverage({ gitState = "executed" } = {}) {
-  const w = (id, state, invId) => ({
-    id, version: 1, implementation_refs: ["file:clotho/weavers/x.mjs@" + HEX40A],
-    state, inspected_source_counts: [{ inventory_id: invId, count: state === "executed" ? 2 : 0 }]
-  });
+function dependsEdge() {
+  return { edge_kind: "depends-on", from_node: deriveNodeId(rfLoc), to_node: deriveNodeId(csLoc), from_locator: rfLoc, to_locator: csLoc, source_ref: SR, asserted_by: "clotho-code-weaver", assertion_status: "deterministic-extraction" };
+}
+function coverage({ gitState = "executed", codeState = "skipped" } = {}) {
+  const w = (id, state, invId) => ({ id, version: 1, implementation_refs: ["file:clotho/weavers/x.mjs@" + HEX40A], state, inspected_source_counts: [{ inventory_id: invId, count: state === "executed" ? 2 : 0 }] });
   return {
-    weavers: [
-      w("clotho-git-weaver", gitState, "git-sources"),
-      w("clotho-code-weaver", "skipped", "code-sources"),
-      w("clotho-test-weaver", "skipped", "test-sources"),
-      w("clotho-doc-weaver", "skipped", "doc-sources"),
-      w("clotho-ledger-weaver", "skipped", "contract-files")
-    ],
+    weavers: [w("clotho-git-weaver", gitState, "git-sources"), w("clotho-code-weaver", codeState, "code-sources"), w("clotho-test-weaver", "skipped", "test-sources"), w("clotho-doc-weaver", "skipped", "doc-sources"), w("clotho-ledger-weaver", "skipped", "contract-files")],
     orchestrator_refs: ["file:clotho/weave.mjs@" + HEX40A],
     inventories_consumed: [{ id: "git-sources", source_ref: "file:clotho/inventory.mjs@" + HEX40A }]
   };
 }
 
+// A minimal independent signer to build signed-but-adversarial fixtures.
+const hexOf = (s) => createHash("sha256").update(Buffer.from(s, "utf8")).digest("hex");
+function buildSignedLedger(p, { edges = [], statuses = [], manifest }) {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const pub = publicKey.export({ type: "spki", format: "der" }).toString("base64");
+  const header = { clotho_weave_header: { pub_key: pub, woven_at: WOVEN, repo_head: REPO_HEAD, repository_ref: REPO, weave_version: 1 } };
+  let prevLine = canonicalJson(header);
+  const lines = [prevLine];
+  const hashes = [];
+  const sign = (payload) => {
+    const prev_hash = hexOf(prevLine);
+    const record_hash = hexOf(canonicalJson({ ...payload, prev_hash }));
+    const signature = edSign(null, Buffer.from(record_hash, "hex"), privateKey).toString("base64");
+    prevLine = canonicalJson({ ...payload, prev_hash, record_hash, signature });
+    lines.push(prevLine);
+    return record_hash;
+  };
+  for (const e of edges) hashes.push(sign({ ...e, woven_at: WOVEN }));
+  for (const s of statuses) sign({ ...s, woven_at: WOVEN });
+  if (manifest) sign({ clotho_weave_trailer: manifest, woven_at: WOVEN });
+  writeFileSync(p, lines.join("\n") + "\n");
+  return { hashes };
+}
+
 const work = mkdtempSync(path.join(tmpdir(), "clotho-ledger-"));
 let n = 0;
 const newPath = () => path.join(work, `l${n++}.jsonl`);
-const opts = { wovenAt: "2026-07-16T00:00:00.000Z", repoHead: REPO_HEAD, repositoryRef: REPO };
 
 try {
-  // ---- 1. happy path: header + edge + status + close, then verify ok --------
+  // ---- 1. happy path + injected key: header, edges, status, close, verify ok
   {
     const p = newPath();
-    const l = createLedger(p, opts);
-    assert.equal(l.header.clotho_weave_header.repository_ref, REPO);
+    const { privateKey } = generateKeyPairSync("ed25519");
+    const l = createLedger(p, { ...opts, signKey: privateKey });
     assert.equal(l.header.clotho_weave_header.weave_version, 1);
     const e = l.appendEdge(anEdge());
-    assert.match(e.record_hash, /^[0-9a-f]{64}$/);
-    assert.ok(typeof e.signature === "string" && e.signature.length > 0);
+    l.appendEdge(dependsEdge());
     l.appendStatus({ status_of: e.record_hash, new_status: "human-authorized", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
-    l.close(coverage());
+    l.close(coverage({ codeState: "executed" }));
     const v = await verifyLedger(p);
-    assert.equal(v.ok, true, "verify ok: " + JSON.stringify(v.errors));
+    assert.equal(v.ok, true, "verify: " + JSON.stringify(v.errors));
+    // records = edges + status only (no header, no trailer)
+    assert.equal(v.records.length, 3);
     assert.ok(v.header && v.manifest);
-    assert.equal(v.manifest.weavers.length, 5);
+    assert.ok(!v.records.some((r) => r.clotho_weave_header || r.clotho_weave_trailer));
   }
 
-  // ---- 2. tamper: flip a byte in a signed line -> verify fails --------------
+  // ---- 2. verify trust boundary: tamper -> ok:false, records truncated ------
   {
     const p = newPath();
     const l = createLedger(p, opts);
-    const e = l.appendEdge(anEdge());
-    l.close(coverage());
-    let raw = readFileSync(p, "utf8");
-    raw = raw.replace(e.source_ref, "git:" + "f".repeat(40)); // change a signed payload byte on disk
+    const e = l.appendEdge(anEdge()); l.close(coverage());
+    let raw = readFileSync(p, "utf8").replace(e.source_ref, "git:" + "f".repeat(40));
     writeFileSync(p, raw);
     const v = await verifyLedger(p);
-    assert.equal(v.ok, false, "tamper must fail verify");
-    assert.ok(v.errors.some((x) => /record_hash mismatch|invalid signature|not canonical/.test(x)));
+    assert.equal(v.ok, false);
+    assert.equal(v.records.length, 0, "no record trusted on/after the failing line");
   }
 
-  // ---- 3. truncation: drop the trailer -> verify fails ----------------------
-  {
+  // ---- 3. trailer removal / partial final line / middle removal ------------
+  for (const mutate of [
+    (lines) => lines.slice(0, -1),                        // drop trailer
+    (lines) => { const c = [...lines]; c[1] = c[1].slice(0, 10); return c; } // corrupt edge line
+  ]) {
     const p = newPath();
     const l = createLedger(p, opts);
-    l.appendEdge(anEdge());
-    l.close(coverage());
+    l.appendEdge(anEdge()); l.close(coverage());
     const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
-    writeFileSync(p, lines.slice(0, -1).join("\n") + "\n"); // remove trailer
+    writeFileSync(p, mutate(lines).join("\n") + "\n");
     const v = await verifyLedger(p);
     assert.equal(v.ok, false);
-    assert.ok(v.errors.some((x) => /no final trailer/.test(x)));
-  }
-
-  // ---- 4. appendStatus rejections ------------------------------------------
-  {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    const e = l.appendEdge(anEdge());
-    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "human-authorized", asserted_by: "model:x", assertion_status: "human-authorized", source_ref: SR }), /asserted by 'human'/);
-    // that poisoned the ledger (append failure); a fresh ledger for more cases
   }
   {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    const e = l.appendEdge(anEdge());
-    assert.throws(() => l.appendStatus({ status_of: "f".repeat(64), new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /reference an earlier edge/);
+    // missing final LF
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const raw = readFileSync(p, "utf8"); writeFileSync(p, raw.slice(0, -1));
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /final LF/.test(x)));
   }
   {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    const e = l.appendEdge(anEdge());
-    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "approved", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /new_status/);
-  }
-
-  // ---- 5. close coverage / D24 validation ----------------------------------
-  {
-    // exactly five weavers
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    const c = coverage(); c.weavers = c.weavers.slice(0, 4);
-    assert.throws(() => l.close(c), /exactly five/);
+    // empty ledger
+    const p = newPath(); writeFileSync(p, "");
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /empty/.test(x)));
   }
   {
-    // nonzero count on a skipped weaver
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    const c = coverage(); c.weavers[1].inspected_source_counts = [{ inventory_id: "code-sources", count: 3 }];
-    assert.throws(() => l.close(c), /skipped weaver must carry zero counts/);
-  }
-  {
-    // unsorted / duplicate counts
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    const c = coverage(); c.weavers[0].inspected_source_counts = [{ inventory_id: "z", count: 1 }, { inventory_id: "a", count: 1 }];
-    assert.throws(() => l.close(c), /sorted and unique/);
-  }
-  {
-    // 'failed' state rejected (never in published manifest)
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    const c = coverage(); c.weavers[0].state = "failed";
-    assert.throws(() => l.close(c), /executed\|skipped/);
-  }
-  {
-    // a weaver that produced edges cannot be recorded skipped
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    assert.throws(() => l.close(coverage({ gitState: "skipped" })), /produced edges/);
-  }
-  {
-    // implementation_refs must be file: content addresses
-    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
-    const c = coverage(); c.weavers[0].implementation_refs = ["git:" + HEX40A];
-    assert.throws(() => l.close(c), /file:<path>@/);
-  }
-
-  // ---- 6. lifecycle: exclusive creation, abort, append-after-close ----------
-  {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    l.appendEdge(anEdge());
-    l.close(coverage());
-    assert.throws(() => l.appendEdge(anEdge()), /closed/);
-    assert.doesNotThrow(() => l.abort(), "abort() after close is a no-op");
-    // exclusive creation refuses an existing path
-    assert.throws(() => createLedger(p, opts), /refusing to overwrite/);
-  }
-  {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    l.abort();
-    assert.throws(() => l.appendEdge(anEdge()), /poisoned|aborted/);
-    l.abort(); // idempotent
-  }
-
-  // ---- 7. readEdges yields only edges --------------------------------------
-  {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    const e = l.appendEdge(anEdge());
-    l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
-    l.close(coverage());
-    const edges = [];
-    for await (const ed of readEdges(p)) edges.push(ed);
-    assert.equal(edges.length, 1, "one edge (header/status/trailer excluded)");
-    assert.equal(edges[0].edge_kind, "introduced-by");
-  }
-
-  // ---- 8. CRLF and missing final LF are verification errors -----------------
-  {
-    const p = newPath();
-    const l = createLedger(p, opts);
-    l.appendEdge(anEdge());
-    l.close(coverage());
-    const good = readFileSync(p, "utf8");
-    writeFileSync(p, good.replace(/\n/g, "\r\n"));
+    // CRLF
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    writeFileSync(p, readFileSync(p, "utf8").replace(/\n/g, "\r\n"));
     const v = await verifyLedger(p);
     assert.equal(v.ok, false);
     assert.ok(v.errors.some((x) => /CRLF/.test(x)));
+  }
+
+  // ---- 4. appendStatus: human accept/reject/supersede; reject model/weaver --
+  {
+    const p = newPath(); const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    for (const st of ["human-authorized", "rejected", "superseded"]) {
+      l.appendStatus({ status_of: e.record_hash, new_status: st, asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
+    }
+    l.close(coverage());
+    assert.equal((await verifyLedger(p)).ok, true);
+  }
+  for (const bad of [
+    { patch: { asserted_by: "model:x" }, re: /'human'/ },
+    { patch: { asserted_by: "clotho-git-weaver" }, re: /'human'/ },
+    { patch: { new_status: "approved" }, re: /new_status/ },
+    { patch: { assertion_status: "deterministic-extraction" }, re: /human-authorized/ }
+  ]) {
+    const p = newPath(); const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR, ...bad.patch }), bad.re);
+  }
+  {
+    // status_of unknown / references a non-edge
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: "f".repeat(64), new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /reference an earlier edge/);
+  }
+
+  // ---- 5. close coverage / D24 rejections ----------------------------------
+  const covBad = [
+    [(c) => { c.weavers = c.weavers.slice(0, 4); }, /exactly five/],
+    [(c) => { c.weavers[1].id = "not-a-weaver"; }, /expected id clotho-code-weaver/],
+    [(c) => { const t = c.weavers[0]; c.weavers[0] = c.weavers[1]; c.weavers[1] = t; }, /expected id/],  // wrong order
+    [(c) => { c.weavers[0].state = "failed"; }, /executed\|skipped/],
+    [(c) => { c.weavers[1].inspected_source_counts = [{ inventory_id: "code-sources", count: 3 }]; }, /zero counts/],
+    [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "z", count: 1 }, { inventory_id: "a", count: 1 }]; }, /sorted and unique/],
+    [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "a", count: -1 }]; }, /nonnegative/],
+    [(c) => { c.weavers[0].implementation_refs = ["git:" + HEX40A]; }, /file:<path>@/],
+    [(c) => { c.orchestrator_refs = []; }, /nonempty/],
+    [(c) => { c.weavers[0].extra = 1; }, /unexpected field/]
+  ];
+  for (const [mut, re] of covBad) {
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); mut(c);
+    assert.throws(() => l.close(c), re);
+  }
+  {
+    // a weaver that asserted an edge cannot be recorded skipped
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    assert.throws(() => l.close(coverage({ gitState: "skipped" })), /asserted an edge/);
+  }
+
+  // ---- 6. lifecycle: exclusive creation, append-after-close, abort ---------
+  {
+    const p = newPath(); const l = createLedger(p, opts);
+    l.appendEdge(anEdge()); l.close(coverage());
+    assert.throws(() => l.appendEdge(anEdge()), /closed/);
+    assert.doesNotThrow(() => l.abort());
+    assert.throws(() => createLedger(p, opts), /refusing to overwrite/);
+  }
+  {
+    const p = newPath(); const l = createLedger(p, opts);
+    l.abort();
+    assert.throws(() => l.appendEdge(anEdge()), /poisoned|aborted/);
+    l.abort();
+  }
+
+  // ---- 7. descriptor closure via an INJECTED file handle (D22) -------------
+  function spyFile() {
+    const calls = { closes: 0 };
+    return { calls, openFile: () => ({ write() {}, close() { calls.closes++; } }) };
+  }
+  {
+    // append failure closes the descriptor
+    const s = spyFile();
+    const l = createLedger(newPath(), { ...opts, openFile: s.openFile });
+    assert.throws(() => l.appendStatus({ status_of: "z", new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }));
+    assert.equal(s.calls.closes, 1, "append failure closes fd");
+  }
+  {
+    // close failure closes the descriptor
+    const s = spyFile();
+    const l = createLedger(newPath(), { ...opts, openFile: s.openFile });
+    l.appendEdge(anEdge());
+    assert.throws(() => l.close({ bad: true }));
+    assert.equal(s.calls.closes, 1, "close failure closes fd");
+  }
+  {
+    // explicit abort closes the descriptor exactly once, idempotently
+    const s = spyFile();
+    const l = createLedger(newPath(), { ...opts, openFile: s.openFile });
+    l.appendEdge(anEdge());
+    l.abort(); l.abort();
+    assert.equal(s.calls.closes, 1, "abort closes fd once");
+  }
+  {
+    // successful close closes the descriptor
+    const s = spyFile();
+    const l = createLedger(newPath(), { ...opts, openFile: s.openFile });
+    l.appendEdge(anEdge()); l.close(coverage());
+    assert.equal(s.calls.closes, 1, "close closes fd");
+  }
+
+  // ---- 8. readEdges yields edges+status+trailer (not header) ----------------
+  {
+    const p = newPath(); const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
+    l.close(coverage());
+    const out = [];
+    for await (const r of readEdges(p)) out.push(r);
+    assert.equal(out.length, 3, "edge + status + trailer (header skipped)");
+    assert.ok(out.some((r) => r.edge_kind === "introduced-by"));
+    assert.ok(out.some((r) => "status_of" in r));
+    assert.ok(out.some((r) => r.clotho_weave_trailer));
+  }
+
+  // ---- 9. readEdges is incremental: yields before the stream ends ----------
+  {
+    const p = newPath(); const l = createLedger(p, opts);
+    l.appendEdge(anEdge()); l.close(coverage());
+    const allLines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n"); // header, edge, trailer
+    let release;
+    const gate = new Promise((r) => { release = r; });
+    async function* gated() {
+      yield allLines[0] + "\n"; // header
+      yield allLines[1] + "\n"; // first edge
+      await gate;               // pause before releasing the rest
+      for (let i = 2; i < allLines.length; i++) yield allLines[i] + "\n";
+    }
+    const it = readEdges(p, { openReadStream: () => gated() });
+    const first = await it.next(); // must resolve while the gate still blocks
+    assert.equal(first.done, false);
+    assert.equal(first.value.edge_kind, "introduced-by", "edge yielded before EOF");
+    release();
+    const rest = [];
+    for (let x = await it.next(); !x.done; x = await it.next()) rest.push(x.value);
+    assert.ok(rest.some((r) => r.clotho_weave_trailer), "trailer after release");
+  }
+
+  // ---- 10. independently-signed adversarial fixtures fail verification ------
+  {
+    // a properly-signed manifest with state 'failed'
+    const p = newPath();
+    buildSignedLedger(p, { edges: [anEdge()], manifest: (() => { const c = coverage(); c.weavers[0].state = "failed"; return c; })() });
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false, "signed failed-state manifest fails verify");
+  }
+  {
+    // a signed skipped weaver carrying a nonzero count
+    const p = newPath();
+    buildSignedLedger(p, { edges: [], manifest: (() => { const c = coverage(); c.weavers[1].inspected_source_counts = [{ inventory_id: "code-sources", count: 5 }]; return c; })() });
+    assert.equal((await verifyLedger(p)).ok, false, "signed skipped-but-read manifest fails verify");
+  }
+  {
+    // a signed ledger whose manifest marks a weaver skipped though it asserted an edge
+    const p = newPath();
+    buildSignedLedger(p, { edges: [anEdge()], manifest: coverage({ gitState: "skipped" }) });
+    assert.equal((await verifyLedger(p)).ok, false, "signed skipped-weaver-with-edge fails verify");
+  }
+  {
+    // a signed ledger with a valid human supersedes edge verifies ok
+    const p = newPath();
+    const oldRf = { kind: "repository-file", locator: { repository_ref: REPO, path: "old.mjs", blob_sha: HEX40A } };
+    const newRf = { kind: "repository-file", locator: { repository_ref: REPO, path: "new.mjs", blob_sha: "f".repeat(40) } };
+    const sup = { edge_kind: "supersedes", from_node: deriveNodeId(oldRf), to_node: deriveNodeId(newRf), from_locator: oldRf, to_locator: newRf, source_ref: SR, asserted_by: "human", assertion_status: "human-authorized" };
+    buildSignedLedger(p, { edges: [sup], manifest: coverage() });
+    assert.equal((await verifyLedger(p)).ok, true, "human supersedes verifies: " + JSON.stringify((await verifyLedger(p)).errors));
   }
 
   console.log("test-ledger: all assertions passed");

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -206,6 +206,19 @@ try {
   {
     // createLedger validates an injected repositoryRef
     assert.throws(() => createLedger(newPath(), { ...opts, repositoryRef: "not-a-ref" }), /git-root/);
+    // type-strict: a non-string repoHead/repositoryRef is rejected (no regex coercion of arrays)
+    assert.throws(() => createLedger(newPath(), { ...opts, repoHead: [REPO_HEAD] }), /repo_head/);
+    assert.throws(() => createLedger(newPath(), { ...opts, repositoryRef: [REPO] }), /repository_ref/);
+  }
+  for (const [field, value] of [["repo_head", 123], ["repository_ref", ["x"]], ["woven_at", 5], ["pub_key", 1]]) {
+    // verifyLedger rejects a non-string header field rather than coercing it
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    const h0 = JSON.parse(lines[0]).clotho_weave_header; h0[field] = value;
+    lines[0] = canonicalJson({ clotho_weave_header: h0 }); writeFileSync(p, lines.join("\n") + "\n");
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => new RegExp(`header|${field}`).test(x)), `non-string ${field} rejected`);
   }
   for (const mutate of [(h) => ({ ...h, extra: 1 }), (h) => ({ ...h, repository_ref: "git-root:xyz" })]) {
     const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -177,11 +177,13 @@ try {
     [(c) => { c.weavers[1].inspected_source_counts = [{ inventory_id: "code-sources", count: 3 }]; }, /zero counts/],
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "z", count: 1 }, { inventory_id: "a", count: 1 }]; }, /sorted and unique/],
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "a", count: -1 }]; }, /nonnegative/],
-    [(c) => { c.weavers[0].implementation_refs = ["git:" + HEX40A]; }, /file:<path>@/],
+    [(c) => { c.weavers[0].implementation_refs = ["git:" + HEX40A]; }, /'file:' content address/],
     [(c) => { c.orchestrator_refs = []; }, /nonempty/],
     [(c) => { c.weavers[0].extra = 1; }, /unexpected field/],
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }]; }, /carry exactly/],       // missing required id
-    [(c) => { c.weavers[3].inspected_source_counts = [{ inventory_id: "doc-files", count: 0 }, { inventory_id: "extra", count: 0 }]; }, /carry exactly/] // extra id
+    [(c) => { c.weavers[3].inspected_source_counts = [{ inventory_id: "doc-files", count: 0 }, { inventory_id: "extra", count: 0 }]; }, /carry exactly/], // extra id
+    [(c) => { c.orchestrator_refs = ["file:/abs@" + HEX40A]; }, /canonical POSIX/],                    // absolute path
+    [(c) => { c.weavers[0].implementation_refs = ["file:../escape.mjs@" + HEX40A]; }, /canonical POSIX/] // traversal
   ];
   for (const [mut, re] of covBad) {
     const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
@@ -208,6 +210,18 @@ try {
     const v = await verifyLedger(p);
     assert.equal(v.ok, false);
     assert.ok(v.errors.some((x) => /header/.test(x)), "header shape error reported");
+  }
+  {
+    // a header pub_key that parses but is not canonical base64 is rejected
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    const h0 = JSON.parse(lines[0]).clotho_weave_header;
+    h0.pub_key = "\n" + h0.pub_key; // decodes to the same key but is non-canonical
+    lines[0] = canonicalJson({ clotho_weave_header: h0 });
+    writeFileSync(p, lines.join("\n") + "\n");
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /pub_key/.test(x)), "non-canonical pub_key rejected");
   }
   {
     // a record after the trailer: not final -> manifest is not trusted

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -186,7 +186,7 @@ try {
     [(c) => { c.weavers[0].implementation_refs = ["file:../escape.mjs@" + HEX40A]; }, /canonical POSIX/], // traversal
     [(c) => { c.weavers[0].inspected_source_counts[0].count = 1.5; }, /safe integer/],                 // non-integer count
     [(c) => { c.weavers[0].inspected_source_counts[0].count = 2 ** 53; }, /safe integer/],             // unsafe integer count
-    [(c) => { c.weavers[0].inspected_source_counts[0].extra = 1; }, /exactly \{inventory_id, count\}/], // extra count field
+    [(c) => { c.weavers[0].inspected_source_counts[0].extra = 1; }, /unexpected field/], // extra count field
     [(c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }, { inventory_id: "package-files", count: 1 }]; }, /sorted and unique/], // duplicate
     [(c) => { c.weavers[0].implementation_refs = []; }, /nonempty array/],                             // empty implementation_refs
     [(c) => { c.inventories_consumed = [{ id: "x", source_ref: "git:" + HEX40A }]; }, /'file:' content address/] // malformed inventories_consumed ref
@@ -528,6 +528,27 @@ try {
     const bad = Buffer.concat([Buffer.from(lines[0] + "\n", "utf8"), Buffer.from([0xff, 0x0a]), Buffer.from(lines[2] + "\n", "utf8")]);
     writeFileSync(p, bad);
     assert.ok((await expectFail(p)).errors.some((x) => /UTF-8/.test(x)));
+  }
+
+  // ---- 12b. strict own-enumerable schema (pollution / non-enumerable) ------
+  {
+    // close() coverage: an enumerable field inherited via Object.prototype is rejected
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    Object.defineProperty(Object.prototype, "__evil__", { value: 1, enumerable: true, configurable: true });
+    try {
+      assert.throws(() => l.close(coverage()), /inherited enumerable/);
+    } finally { delete Object.prototype.__evil__; }
+  }
+  {
+    // close() coverage: a non-enumerable required field cannot pass
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); Object.defineProperty(c, "weavers", { enumerable: false });
+    assert.throws(() => l.close(c), /own-enumerable/);
+  }
+  {
+    // appendStatus: a symbol-keyed status input is rejected
+    const p = newPath(); const l = createLedger(p, opts); const e = l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR, [Symbol("x")]: 1 }), /symbol/);
   }
 
   // ---- 13. frozen matrix completion ----------------------------------------

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -424,6 +424,30 @@ try {
     await expectFail(p);
   }
   {
+    // a signed status record whose status_of references a STATUS hash (not an
+    // edge) is rejected: the back-reference scope is closed to edges only.
+    const p = newPath();
+    const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+    const pub = publicKey.export({ type: "spki", format: "der" }).toString("base64");
+    let prev = canonicalJson({ clotho_weave_header: { pub_key: pub, woven_at: WOVEN, repo_head: REPO_HEAD, repository_ref: REPO, weave_version: 1 } });
+    const lines = [prev];
+    const sign = (payload) => { const prev_hash = hexOf(prev); const record_hash = hexOf(canonicalJson({ ...payload, prev_hash })); const signature = edSign(null, Buffer.from(record_hash, "hex"), privateKey).toString("base64"); prev = canonicalJson({ ...payload, prev_hash, record_hash, signature }); lines.push(prev); return record_hash; };
+    const eh = sign({ ...anEdge(), woven_at: WOVEN });
+    const sh = sign({ status_of: eh, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR, woven_at: WOVEN });
+    sign({ status_of: sh, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR, woven_at: WOVEN }); // refs a status hash
+    sign({ clotho_weave_trailer: coverage(), woven_at: WOVEN });
+    writeFileSync(p, lines.join("\n") + "\n");
+    assert.equal((await verifyLedger(p)).ok, false, "status referencing a status hash is rejected");
+  }
+  {
+    // a non-canonical (whitespace-padded) signature is rejected even though it
+    // decodes to the same bytes
+    const { p, lines } = build3();
+    const t = JSON.parse(lines[2]); t.signature = " " + t.signature;
+    lines[2] = canonicalJson(t); writeFileSync(p, lines.join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /signature/.test(x)));
+  }
+  {
     // verifyLedger consumes an injected stream incrementally (no whole-file buffering)
     const { p, lines } = build3();
     async function* s() { for (const ln of lines) yield ln + "\n"; }

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -353,6 +353,54 @@ try {
     assert.equal((await verifyLedger(p)).ok, true, "human supersedes verifies: " + JSON.stringify((await verifyLedger(p)).errors));
   }
 
+  // ---- 11. more adversarial on-disk tampering + incremental verify ---------
+  const build3 = () => { const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage()); return { p, lines: readFileSync(p, "utf8").replace(/\n$/, "").split("\n") }; };
+  const expectFail = async (p) => { const v = await verifyLedger(p); assert.equal(v.ok, false); return v; };
+  {
+    const { p, lines } = build3(); // header, edge, trailer
+    writeFileSync(p, [lines[0], lines[0], ...lines.slice(1)].join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /duplicate header/.test(x)));
+  }
+  {
+    const { p, lines } = build3();
+    writeFileSync(p, [...lines, lines[2]].join("\n") + "\n"); // duplicate trailer
+    assert.equal((await expectFail(p)).manifest, null);
+  }
+  {
+    const { p, lines } = build3();
+    writeFileSync(p, [lines[0], lines[2]].join("\n") + "\n"); // middle edge removed -> chain breaks
+    await expectFail(p);
+  }
+  {
+    const { p, lines } = build3();
+    writeFileSync(p, [lines[0], "null", lines[2]].join("\n") + "\n"); // null record
+    assert.ok((await expectFail(p)).errors.some((x) => /JSON object/.test(x)));
+  }
+  {
+    const { p, lines } = build3(); // altered signature on the trailer (last line)
+    const t = JSON.parse(lines[2]); t.signature = (t.signature[0] === "A" ? "B" : "A") + t.signature.slice(1);
+    lines[2] = canonicalJson(t); writeFileSync(p, lines.join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /signature|record_hash/.test(x)));
+  }
+  {
+    const { p, lines } = build3(); // altered record_hash on the trailer
+    const t = JSON.parse(lines[2]); t.record_hash = "0".repeat(64);
+    lines[2] = canonicalJson(t); writeFileSync(p, lines.join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /record_hash|signature/.test(x)));
+  }
+  {
+    const p = newPath();
+    buildSignedLedger(p, { edges: [{ ...anEdge(), edge_kind: "references" }], manifest: coverage() }); // signed unknown kind
+    await expectFail(p);
+  }
+  {
+    // verifyLedger consumes an injected stream incrementally (no whole-file buffering)
+    const { p, lines } = build3();
+    async function* s() { for (const ln of lines) yield ln + "\n"; }
+    const v = await verifyLedger(p, { openReadStream: () => s() });
+    assert.equal(v.ok, true, "streamed verify ok: " + JSON.stringify(v.errors));
+  }
+
   console.log("test-ledger: all assertions passed");
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -530,6 +530,16 @@ try {
     assert.ok((await expectFail(p)).errors.some((x) => /UTF-8/.test(x)));
   }
 
+  {
+    // version is any integer label (incl. beyond safe-integer); non-integer rejected
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers[0].version = 2 ** 53;
+    assert.doesNotThrow(() => l.close(c), "an integer version beyond safe-integer is accepted");
+    const p2 = newPath(); const l2 = createLedger(p2, opts); l2.appendEdge(anEdge());
+    const c2 = coverage(); c2.weavers[0].version = 1.5;
+    assert.throws(() => l2.close(c2), /must be an integer/);
+  }
+
   // ---- 12b. strict own-enumerable schema (pollution / non-enumerable) ------
   {
     // close() coverage: an enumerable field inherited via Object.prototype is rejected

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -235,6 +235,22 @@ try {
     l.abort();
   }
 
+  // ---- 6b. appendEdge re-derives/checks endpoint ids; close() idempotency --
+  {
+    // a caller from_node that mismatches the locator-derived id is rejected
+    const p = newPath(); const l = createLedger(p, opts);
+    assert.throws(() => l.appendEdge({ ...anEdge(), from_node: "0".repeat(64) }), /from_node .* does not match derived/);
+  }
+  {
+    // close() is idempotent after a successful close: same trailer, no re-write
+    const p = newPath(); const l = createLedger(p, opts);
+    l.appendEdge(anEdge());
+    const r1 = l.close(coverage());
+    const r2 = l.close(coverage());
+    assert.equal(r2.record_hash, r1.record_hash, "second close returns the same trailer record");
+    assert.equal((await verifyLedger(p)).ok, true, "no duplicate trailer written");
+  }
+
   // ---- 7. descriptor closure via an INJECTED file handle (D22) -------------
   function spyFile() {
     const calls = { closes: 0 };

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -530,6 +530,107 @@ try {
     assert.ok((await expectFail(p)).errors.some((x) => /UTF-8/.test(x)));
   }
 
+  // ---- 13. frozen matrix completion ----------------------------------------
+  // Independently-signed D24 rejections (valid signature, invalid manifest).
+  const verifyBadCoverage = async (mut) => { const p = newPath(); const c = coverage(); mut(c); buildSignedLedger(p, { edges: [anEdge()], manifest: c }); return (await verifyLedger(p)).ok; };
+  for (const mut of [
+    (c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 2 }]; },            // missing id
+    (c) => { c.weavers[0].inspected_source_counts.push({ inventory_id: "zz", count: 1 }); },                     // extra id
+    (c) => { c.weavers[0].inspected_source_counts[0].extra = 1; },                                               // extra field
+    (c) => { c.weavers[0].inspected_source_counts.reverse(); },                                                  // unsorted
+    (c) => { c.weavers[0].inspected_source_counts = [{ inventory_id: "package-files", count: 1 }, { inventory_id: "package-files", count: 1 }]; }, // duplicate
+    (c) => { c.weavers[0].inspected_source_counts[0].count = -1; },                                              // negative
+    (c) => { c.weavers[0].inspected_source_counts[0].count = 1.5; },                                             // non-integer
+    (c) => { c.weavers[0].inspected_source_counts[0].count = 2 ** 53; },                                         // unsafe
+    (c) => { c.weavers[1].inspected_source_counts[0].count = 3; },                                               // skipped nonzero
+    (c) => { c.weavers[0].state = "failed"; },                                                                   // failed state
+    (c) => { c.weavers[0].implementation_refs = []; },                                                           // empty impl_refs
+    (c) => { c.orchestrator_refs = []; }                                                                          // empty orchestrator_refs
+  ]) {
+    assert.equal(await verifyBadCoverage(mut), false, "signed invalid-manifest fixture must fail verify");
+  }
+  {
+    // locator repository_ref disagreement is rejected at append
+    const p = newPath(); const l = createLedger(p, opts);
+    const wrong = { kind: "code-symbol", locator: { ...csLoc.locator, repository_ref: "git-root:" + "a".repeat(40) } };
+    const e = { edge_kind: "introduced-by", from_node: deriveNodeId(wrong), to_node: deriveNodeId(commitLoc), from_locator: wrong, to_locator: commitLoc, source_ref: SR, asserted_by: "clotho-git-weaver", assertion_status: "deterministic-extraction" };
+    assert.throws(() => l.appendEdge(e), /does not match/);
+  }
+  {
+    // assertion-status/producer coupling enforced at append
+    const p = newPath(); const l = createLedger(p, opts);
+    assert.throws(() => l.appendEdge({ ...anEdge(), assertion_status: "human-authorized" }), /requires deterministic-extraction/);
+  }
+  {
+    // to_node id mismatch, appendStatus-after-close, close-with-no-coverage
+    const p = newPath(); const l = createLedger(p, opts);
+    assert.throws(() => l.appendEdge({ ...anEdge(), to_node: "0".repeat(64) }), /to_node .* does not match derived/);
+  }
+  {
+    const p = newPath(); const l = createLedger(p, opts); const e = l.appendEdge(anEdge()); l.close(coverage());
+    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /closed/);
+  }
+  {
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    assert.throws(() => l.close(undefined), /coverage/);
+    assert.throws(() => l.appendEdge(anEdge()), /poisoned/);
+  }
+  {
+    // a signed status referencing a non-edge (arbitrary) hash is rejected
+    const p = newPath();
+    buildSignedLedger(p, { edges: [anEdge()], statuses: [{ status_of: "a".repeat(64), new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }], manifest: coverage() });
+    assert.equal((await verifyLedger(p)).ok, false);
+  }
+  {
+    // no-header ledger, non-canonical line, and 'record precedes a valid header'
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    writeFileSync(p, lines.slice(1).join("\n") + "\n"); // drop the header
+    assert.ok((await expectFail(p)).errors.some((x) => /header/.test(x)));
+  }
+  {
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    lines[1] = lines[1].replace(/^\{/, "{ "); // valid JSON, non-canonical (leading space)
+    writeFileSync(p, lines.join("\n") + "\n");
+    assert.ok((await expectFail(p)).errors.some((x) => /not canonical/.test(x)));
+  }
+  {
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    lines[0] = "{}"; // malformed first line -> every later record 'precedes a valid header'
+    writeFileSync(p, lines.join("\n") + "\n");
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.equal(v.records.length, 0, "no records trusted when the header is invalid");
+  }
+  {
+    // records-content on tail defects: prior trusted edge remains before the invariant
+    const p = newPath(); const l = createLedger(p, opts); const e = l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    writeFileSync(p, lines.slice(0, -1).join("\n") + "\n"); // drop trailer
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.equal(v.records.length, 1, "the edge before the missing trailer is still returned");
+    assert.equal(v.manifest, null);
+  }
+  {
+    // createLedger: distinct generated keys, parent-dir creation, invalid wovenAt
+    const a = createLedger(newPath(), opts); const b = createLedger(newPath(), opts);
+    assert.notEqual(a.header.clotho_weave_header.pub_key, b.header.clotho_weave_header.pub_key, "distinct generated keypairs");
+    const sub = path.join(work, "nested", "deep", "l.jsonl");
+    const l = createLedger(sub, opts); l.appendEdge(anEdge()); l.close(coverage());
+    assert.equal((await verifyLedger(sub)).ok, true, "parent directories created for the requested file");
+    assert.throws(() => createLedger(newPath(), { ...opts, wovenAt: "not-a-date" }), /invalid wovenAt/);
+  }
+  {
+    // D22: descriptor closure across each write stage (header/edge/trailer)
+    const spy = (failOn) => { const s = { calls: 0, closes: 0 }; return { s, openFile: () => ({ write() { s.calls++; if (s.calls === failOn) throw new Error("write boom"); }, close() { s.closes++; } }) }; };
+    const hdr = spy(1); assert.throws(() => createLedger(newPath(), { ...opts, openFile: hdr.openFile }), /write boom/); assert.equal(hdr.s.closes, 1);
+    const edge = spy(2); const le = createLedger(newPath(), { ...opts, openFile: edge.openFile }); assert.throws(() => le.appendEdge(anEdge()), /write boom/); assert.equal(edge.s.closes, 1);
+    const trl = spy(3); const lt = createLedger(newPath(), { ...opts, openFile: trl.openFile }); lt.appendEdge(anEdge()); assert.throws(() => lt.close(coverage()), /write boom/); assert.equal(trl.s.closes, 1);
+  }
+
   console.log("test-ledger: all assertions passed");
 } finally {
   rmSync(work, { recursive: true, force: true });

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+// test-ledger.mjs — Task 3. Signed thread-ledger lifecycle and verification
+// against injected fixture coverage (D19): header/append/status/close/abort,
+// chain + Ed25519 signatures, verifyLedger success + tamper/truncation, the D24
+// inspected_source_counts schema, skipped-weaver-with-edges rejection, descriptor
+// discipline, and readEdges. Plain node:assert/strict; fresh Node process.
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createLedger, verifyLedger, readEdges } from "../thread-ledger.mjs";
+import { deriveNodeId } from "../registry.mjs";
+
+const HEX40A = "0123456789abcdef0123456789abcdef01234567";
+const REPO_HEAD = "fedcba9876543210fedcba9876543210fedcba98";
+const REPO = "git-root:" + HEX40A;
+const SR = "git:" + HEX40A;
+
+const csLoc = { kind: "code-symbol", locator: { repository_ref: REPO, path: "clotho/registry.mjs", symbol: "deriveNodeId", blob_sha: HEX40A } };
+const commitLoc = { kind: "commit", locator: { sha: REPO_HEAD } };
+
+function anEdge() {
+  return {
+    edge_kind: "introduced-by",
+    from_node: deriveNodeId(csLoc),
+    to_node: deriveNodeId(commitLoc),
+    from_locator: csLoc,
+    to_locator: commitLoc,
+    source_ref: SR,
+    asserted_by: "clotho-git-weaver",
+    assertion_status: "deterministic-extraction"
+  };
+}
+
+function coverage({ gitState = "executed" } = {}) {
+  const w = (id, state, invId) => ({
+    id, version: 1, implementation_refs: ["file:clotho/weavers/x.mjs@" + HEX40A],
+    state, inspected_source_counts: [{ inventory_id: invId, count: state === "executed" ? 2 : 0 }]
+  });
+  return {
+    weavers: [
+      w("clotho-git-weaver", gitState, "git-sources"),
+      w("clotho-code-weaver", "skipped", "code-sources"),
+      w("clotho-test-weaver", "skipped", "test-sources"),
+      w("clotho-doc-weaver", "skipped", "doc-sources"),
+      w("clotho-ledger-weaver", "skipped", "contract-files")
+    ],
+    orchestrator_refs: ["file:clotho/weave.mjs@" + HEX40A],
+    inventories_consumed: [{ id: "git-sources", source_ref: "file:clotho/inventory.mjs@" + HEX40A }]
+  };
+}
+
+const work = mkdtempSync(path.join(tmpdir(), "clotho-ledger-"));
+let n = 0;
+const newPath = () => path.join(work, `l${n++}.jsonl`);
+const opts = { wovenAt: "2026-07-16T00:00:00.000Z", repoHead: REPO_HEAD, repositoryRef: REPO };
+
+try {
+  // ---- 1. happy path: header + edge + status + close, then verify ok --------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    assert.equal(l.header.clotho_weave_header.repository_ref, REPO);
+    assert.equal(l.header.clotho_weave_header.weave_version, 1);
+    const e = l.appendEdge(anEdge());
+    assert.match(e.record_hash, /^[0-9a-f]{64}$/);
+    assert.ok(typeof e.signature === "string" && e.signature.length > 0);
+    l.appendStatus({ status_of: e.record_hash, new_status: "human-authorized", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
+    l.close(coverage());
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, true, "verify ok: " + JSON.stringify(v.errors));
+    assert.ok(v.header && v.manifest);
+    assert.equal(v.manifest.weavers.length, 5);
+  }
+
+  // ---- 2. tamper: flip a byte in a signed line -> verify fails --------------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    l.close(coverage());
+    let raw = readFileSync(p, "utf8");
+    raw = raw.replace(e.source_ref, "git:" + "f".repeat(40)); // change a signed payload byte on disk
+    writeFileSync(p, raw);
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false, "tamper must fail verify");
+    assert.ok(v.errors.some((x) => /record_hash mismatch|invalid signature|not canonical/.test(x)));
+  }
+
+  // ---- 3. truncation: drop the trailer -> verify fails ----------------------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    l.appendEdge(anEdge());
+    l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    writeFileSync(p, lines.slice(0, -1).join("\n") + "\n"); // remove trailer
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /no final trailer/.test(x)));
+  }
+
+  // ---- 4. appendStatus rejections ------------------------------------------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "human-authorized", asserted_by: "model:x", assertion_status: "human-authorized", source_ref: SR }), /asserted by 'human'/);
+    // that poisoned the ledger (append failure); a fresh ledger for more cases
+  }
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: "f".repeat(64), new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /reference an earlier edge/);
+  }
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    assert.throws(() => l.appendStatus({ status_of: e.record_hash, new_status: "approved", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR }), /new_status/);
+  }
+
+  // ---- 5. close coverage / D24 validation ----------------------------------
+  {
+    // exactly five weavers
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers = c.weavers.slice(0, 4);
+    assert.throws(() => l.close(c), /exactly five/);
+  }
+  {
+    // nonzero count on a skipped weaver
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers[1].inspected_source_counts = [{ inventory_id: "code-sources", count: 3 }];
+    assert.throws(() => l.close(c), /skipped weaver must carry zero counts/);
+  }
+  {
+    // unsorted / duplicate counts
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers[0].inspected_source_counts = [{ inventory_id: "z", count: 1 }, { inventory_id: "a", count: 1 }];
+    assert.throws(() => l.close(c), /sorted and unique/);
+  }
+  {
+    // 'failed' state rejected (never in published manifest)
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers[0].state = "failed";
+    assert.throws(() => l.close(c), /executed\|skipped/);
+  }
+  {
+    // a weaver that produced edges cannot be recorded skipped
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    assert.throws(() => l.close(coverage({ gitState: "skipped" })), /produced edges/);
+  }
+  {
+    // implementation_refs must be file: content addresses
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge());
+    const c = coverage(); c.weavers[0].implementation_refs = ["git:" + HEX40A];
+    assert.throws(() => l.close(c), /file:<path>@/);
+  }
+
+  // ---- 6. lifecycle: exclusive creation, abort, append-after-close ----------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    l.appendEdge(anEdge());
+    l.close(coverage());
+    assert.throws(() => l.appendEdge(anEdge()), /closed/);
+    assert.doesNotThrow(() => l.abort(), "abort() after close is a no-op");
+    // exclusive creation refuses an existing path
+    assert.throws(() => createLedger(p, opts), /refusing to overwrite/);
+  }
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    l.abort();
+    assert.throws(() => l.appendEdge(anEdge()), /poisoned|aborted/);
+    l.abort(); // idempotent
+  }
+
+  // ---- 7. readEdges yields only edges --------------------------------------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    const e = l.appendEdge(anEdge());
+    l.appendStatus({ status_of: e.record_hash, new_status: "rejected", asserted_by: "human", assertion_status: "human-authorized", source_ref: SR });
+    l.close(coverage());
+    const edges = [];
+    for await (const ed of readEdges(p)) edges.push(ed);
+    assert.equal(edges.length, 1, "one edge (header/status/trailer excluded)");
+    assert.equal(edges[0].edge_kind, "introduced-by");
+  }
+
+  // ---- 8. CRLF and missing final LF are verification errors -----------------
+  {
+    const p = newPath();
+    const l = createLedger(p, opts);
+    l.appendEdge(anEdge());
+    l.close(coverage());
+    const good = readFileSync(p, "utf8");
+    writeFileSync(p, good.replace(/\n/g, "\r\n"));
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /CRLF/.test(x)));
+  }
+
+  console.log("test-ledger: all assertions passed");
+} finally {
+  rmSync(work, { recursive: true, force: true });
+}

--- a/clotho/scripts/test-ledger.mjs
+++ b/clotho/scripts/test-ledger.mjs
@@ -194,6 +194,32 @@ try {
     assert.throws(() => l.close(coverage({ gitState: "skipped" })), /asserted an edge/);
   }
 
+  // ---- 5c. header / repository_ref shape + non-final trailer ---------------
+  {
+    // createLedger validates an injected repositoryRef
+    assert.throws(() => createLedger(newPath(), { ...opts, repositoryRef: "not-a-ref" }), /git-root/);
+  }
+  for (const mutate of [(h) => ({ ...h, extra: 1 }), (h) => ({ ...h, repository_ref: "git-root:xyz" })]) {
+    const p = newPath(); const l = createLedger(p, opts); l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n");
+    const h0 = JSON.parse(lines[0]).clotho_weave_header;
+    lines[0] = canonicalJson({ clotho_weave_header: mutate(h0) });
+    writeFileSync(p, lines.join("\n") + "\n");
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.ok(v.errors.some((x) => /header/.test(x)), "header shape error reported");
+  }
+  {
+    // a record after the trailer: not final -> manifest is not trusted
+    const p = newPath(); const l = createLedger(p, opts);
+    l.appendEdge(anEdge()); l.close(coverage());
+    const lines = readFileSync(p, "utf8").replace(/\n$/, "").split("\n"); // header, edge, trailer
+    writeFileSync(p, [...lines, lines[1]].join("\n") + "\n");            // stray record after trailer
+    const v = await verifyLedger(p);
+    assert.equal(v.ok, false);
+    assert.equal(v.manifest, null, "manifest not trusted when the trailer is not final");
+  }
+
   // ---- 6. lifecycle: exclusive creation, append-after-close, abort ---------
   {
     const p = newPath(); const l = createLedger(p, opts);

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -29,7 +29,6 @@ import {
 const HEX40 = /^[0-9a-f]{40}$/;
 const HEX64 = /^[0-9a-f]{64}$/;
 const REPO_REF = /^git-root:[0-9a-f]{40}$/;
-const FILE_REF = /^file:(.+)@([0-9a-f]{40})$/;
 const HEADER_FIELDS = ["pub_key", "woven_at", "repo_head", "repository_ref", "weave_version"];
 const PUBLISHED_STATES = new Set(["executed", "skipped"]);
 const STATUS_TRANSITIONS = new Set(["human-authorized", "rejected", "superseded"]);
@@ -76,8 +75,12 @@ function defaultOpenFile(ledgerPath) {
 
 // ---- schema validators -------------------------------------------------------
 
+// A content-address ref must be a 'file:<repo-relative-path>@<40-hex>' with a
+// canonical POSIX path (no absolute/traversal/backslash/NUL) — delegated to
+// registry.validateSourceRef, the single authoritative source-ref validator.
 function requireFileRef(ref, label) {
-  if (typeof ref !== "string" || !FILE_REF.test(ref)) throw new TypeError(`${label}: expected 'file:<path>@<40-hex>', got ${JSON.stringify(ref)}`);
+  if (typeof ref !== "string" || !ref.startsWith("file:")) throw new TypeError(`${label}: expected a 'file:' content address, got ${JSON.stringify(ref)}`);
+  try { validateSourceRef(ref); } catch (e) { throw new TypeError(`${label}: ${e.message}`); }
 }
 
 function requireInspectedSourceCounts(counts, state, requiredIds, label) {
@@ -275,6 +278,7 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
         if (typeof h.repository_ref !== "string" || !REPO_REF.test(h.repository_ref)) throw new Error("repository_ref must be 'git-root:<40-hex>'");
         pubKey = publicKeyFromB64(h.pub_key);
         if (pubKey.asymmetricKeyType !== "ed25519") throw new Error("pub_key must be an Ed25519 SPKI key");
+        if (publicKeyB64(pubKey) !== h.pub_key) throw new Error("pub_key is not canonical SPKI base64");
         if (h.weave_version !== 1) throw new Error("weave_version must be 1");
         if (!HEX40.test(h.repo_head)) throw new Error("repo_head must be 40-hex");
         if (new Date(h.woven_at).toISOString() !== h.woven_at) throw new Error("woven_at not canonical ISO");

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -172,7 +172,7 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
   if (openFile === defaultOpenFile) mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
   const handle = openFile(ledgerPath); // wx is the atomic existence gate
 
-  const state = { open: true, closed: false, poisoned: false, prevLine: null, edgeHashes: new Set(), weaverEdgeIds: new Set() };
+  const state = { open: true, closed: false, poisoned: false, closeResult: null, prevLine: null, edgeHashes: new Set(), weaverEdgeIds: new Set() };
 
   const closeHandle = () => { if (state.open) { try { handle.close(); } finally { state.open = false; } } };
   const poison = (err) => { state.poisoned = true; closeHandle(); return err; };
@@ -193,6 +193,9 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
     appendEdge(edgeInput) {
       guard();
       try {
+        // validateEdgeInput re-derives from_node/to_node from the supplied
+        // locators via deriveNodeId and rejects any mismatch (never silently
+        // overwrites — the mismatch is the thing to detect).
         validateEdgeInput(edgeInput, { repositoryRef: repo_ref });
         const record = chainAndSign({ ...edgeInput, woven_at });
         writeLine(record);
@@ -211,11 +214,13 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
       } catch (e) { throw poison(e); }
     },
     close(coverage) {
-      guard();
+      if (state.closed) return state.closeResult; // idempotent ONLY after a successful close
+      guard();                                    // still throws after abort/poison
       try {
         validateCoverage(coverage, state.weaverEdgeIds);
         const record = chainAndSign({ clotho_weave_trailer: coverage, woven_at });
         writeLine(record);
+        state.closeResult = record;
         state.closed = true;
         closeHandle();
         return record;

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -189,9 +189,9 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
 
   const woven_at = new Date(wovenAt ?? Date.now()).toISOString();
   const repo_head = repoHead ?? String(git(["rev-parse", "HEAD"])).trim();
-  if (!HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit, got ${JSON.stringify(repo_head)}`);
+  if (typeof repo_head !== "string" || !HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit string, got ${JSON.stringify(repo_head)}`);
   const repo_ref = repositoryRef ?? deriveRepositoryRef(git);
-  if (!REPO_REF.test(repo_ref)) throw new TypeError(`createLedger: repository_ref must be 'git-root:<40-hex>', got ${JSON.stringify(repo_ref)}`);
+  if (typeof repo_ref !== "string" || !REPO_REF.test(repo_ref)) throw new TypeError(`createLedger: repository_ref must be a 'git-root:<40-hex>' string, got ${JSON.stringify(repo_ref)}`);
 
   if (openFile === defaultOpenFile) mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
   const handle = openFile(ledgerPath); // wx is the atomic existence gate
@@ -300,13 +300,14 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
       try {
         for (const k of Object.keys(h)) if (!HEADER_FIELDS.includes(k)) throw new Error(`unexpected field '${k}'`);
         for (const k of HEADER_FIELDS) if (!(k in h)) throw new Error(`missing field '${k}'`);
-        if (typeof h.repository_ref !== "string" || !REPO_REF.test(h.repository_ref)) throw new Error("repository_ref must be 'git-root:<40-hex>'");
+        if (typeof h.repository_ref !== "string" || !REPO_REF.test(h.repository_ref)) throw new Error("repository_ref must be a 'git-root:<40-hex>' string");
+        if (typeof h.pub_key !== "string") throw new Error("pub_key must be a string");
         pubKey = publicKeyFromB64(h.pub_key);
         if (pubKey.asymmetricKeyType !== "ed25519") throw new Error("pub_key must be an Ed25519 SPKI key");
         if (publicKeyB64(pubKey) !== h.pub_key) throw new Error("pub_key is not canonical SPKI base64");
         if (h.weave_version !== 1) throw new Error("weave_version must be 1");
-        if (!HEX40.test(h.repo_head)) throw new Error("repo_head must be 40-hex");
-        if (new Date(h.woven_at).toISOString() !== h.woven_at) throw new Error("woven_at not canonical ISO");
+        if (typeof h.repo_head !== "string" || !HEX40.test(h.repo_head)) throw new Error("repo_head must be a 40-hex string");
+        if (typeof h.woven_at !== "string" || new Date(h.woven_at).toISOString() !== h.woven_at) throw new Error("woven_at not canonical ISO");
         header = h; repoRef = h.repository_ref;
       } catch (e) { fail(`header: ${e.message}`); }
       prevBytes = lineBuf;

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -50,6 +50,7 @@ const REQUIRED_INVENTORY_IDS = {
 // ---- crypto + line helpers ---------------------------------------------------
 
 const hexOf = (str) => createHash("sha256").update(Buffer.from(str, "utf8")).digest("hex");
+const hexOfBytes = (buf) => createHash("sha256").update(buf).digest("hex");
 const publicKeyB64 = (pub) => pub.export({ type: "spki", format: "der" }).toString("base64");
 const publicKeyFromB64 = (b64) => createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
 // Decode `str` only if it is CANONICAL standard base64 of exactly `expectedLen`
@@ -77,7 +78,18 @@ function defaultOpenFile(ledgerPath) {
     throw e;
   }
   return {
-    write(line) { writeSync(fd, line + "\n"); fsyncSync(fd); },
+    write(line) {
+      // All-or-error: write every byte of the complete LF-terminated line (a
+      // short write is a failure, not a silently-truncated record), then fsync.
+      const buf = Buffer.from(line + "\n", "utf8");
+      let off = 0;
+      while (off < buf.length) {
+        const n = writeSync(fd, buf, off, buf.length - off);
+        if (!(n > 0)) throw new Error("short write to ledger");
+        off += n;
+      }
+      fsyncSync(fd);
+    },
     close() { closeSync(fd); }
   };
 }
@@ -231,10 +243,10 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
       try {
         validateCoverage(coverage, state.weaverEdgeIds);
         const record = chainAndSign({ clotho_weave_trailer: coverage, woven_at });
-        writeLine(record);
-        state.closeResult = record;
-        state.closed = true;
-        closeHandle();
+        writeLine(record);   // write trailer + fsync
+        closeHandle();       // flush + close the descriptor — must succeed first
+        state.closeResult = record;   // report success ONLY after the close succeeds
+        state.closed = true;          // (a close failure leaves the ledger poisoned, never "closed")
         return record;
       } catch (e) { throw poison(e); }
     },
@@ -261,26 +273,30 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
 
   let pubKey = null;
   let repoRef = null;
-  let prevLine = null;
+  let prevBytes = null;
   let lineIndex = 0;
   let sawCR = false;
   const edgeHashes = new Set();
   const weaverEdgeIds = new Set();
   let trailerSeen = false;
 
-  // Process exactly one complete line (no trailing LF). Never throws.
-  const processLine = (line) => {
+  // Process exactly one complete line as RAW BYTES (no trailing LF). Strict
+  // UTF-8 (no replacement); the chain hashes the exact prior line bytes. Never
+  // throws.
+  const processLine = (lineBuf) => {
     const i = lineIndex++;
+    let line;
+    try { line = new TextDecoder("utf-8", { fatal: true }).decode(lineBuf); } catch { fail(`line ${i + 1}: invalid UTF-8`); prevBytes = lineBuf; return; }
     let obj;
-    try { obj = JSON.parse(line); } catch { fail(`line ${i + 1}: not valid JSON`); prevLine = line; return; }
-    if (obj === null || typeof obj !== "object" || Array.isArray(obj)) { fail(`line ${i + 1}: record must be a JSON object`); prevLine = line; return; }
+    try { obj = JSON.parse(line); } catch { fail(`line ${i + 1}: not valid JSON`); prevBytes = lineBuf; return; }
+    if (obj === null || typeof obj !== "object" || Array.isArray(obj)) { fail(`line ${i + 1}: record must be a JSON object`); prevBytes = lineBuf; return; }
     let canon;
-    try { canon = canonicalJson(obj); } catch { fail(`line ${i + 1}: not canonicalizable`); prevLine = line; return; }
-    if (canon !== line) { fail(`line ${i + 1}: not canonical JSON`); prevLine = line; return; }
+    try { canon = canonicalJson(obj); } catch { fail(`line ${i + 1}: not canonicalizable`); prevBytes = lineBuf; return; }
+    if (canon !== line) { fail(`line ${i + 1}: not canonical JSON`); prevBytes = lineBuf; return; }
 
     if (i === 0) {
       const h = obj.clotho_weave_header;
-      if (Object.keys(obj).length !== 1 || h === null || typeof h !== "object" || Array.isArray(h)) { fail("line 1: header envelope must be exactly {clotho_weave_header:{...}}"); prevLine = line; return; }
+      if (Object.keys(obj).length !== 1 || h === null || typeof h !== "object" || Array.isArray(h)) { fail("line 1: header envelope must be exactly {clotho_weave_header:{...}}"); prevBytes = lineBuf; return; }
       try {
         for (const k of Object.keys(h)) if (!HEADER_FIELDS.includes(k)) throw new Error(`unexpected field '${k}'`);
         for (const k of HEADER_FIELDS) if (!(k in h)) throw new Error(`missing field '${k}'`);
@@ -293,18 +309,18 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
         if (new Date(h.woven_at).toISOString() !== h.woven_at) throw new Error("woven_at not canonical ISO");
         header = h; repoRef = h.repository_ref;
       } catch (e) { fail(`header: ${e.message}`); }
-      prevLine = line;
+      prevBytes = lineBuf;
       return;
     }
 
-    if (header === null) { fail(`line ${i + 1}: record precedes a valid header`); prevLine = line; return; }
-    if (obj.clotho_weave_header) { fail(`line ${i + 1}: duplicate header`); prevLine = line; return; }
-    if (trailerSeen) { fail(`line ${i + 1}: record after trailer (trailer must be final)`); prevLine = line; return; }
+    if (header === null) { fail(`line ${i + 1}: record precedes a valid header`); prevBytes = lineBuf; return; }
+    if (obj.clotho_weave_header) { fail(`line ${i + 1}: duplicate header`); prevBytes = lineBuf; return; }
+    if (trailerSeen) { fail(`line ${i + 1}: record after trailer (trailer must be final)`); prevBytes = lineBuf; return; }
 
     const { prev_hash, record_hash, signature, ...payload } = obj;
     let lineOk = true;
     const bad = (m) => { fail(m); lineOk = false; };
-    if (typeof prev_hash !== "string" || prev_hash !== hexOf(prevLine)) bad(`line ${i + 1}: broken chain (prev_hash mismatch)`);
+    if (typeof prev_hash !== "string" || prev_hash !== hexOfBytes(prevBytes)) bad(`line ${i + 1}: broken chain (prev_hash mismatch)`);
     let expectHash = null;
     try { expectHash = hexOf(canonicalJson({ ...payload, prev_hash })); } catch { /* payload not canonicalizable */ }
     if (typeof record_hash !== "string" || record_hash !== expectHash) bad(`line ${i + 1}: record_hash mismatch`);
@@ -330,21 +346,22 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
         records.push(obj);
       }
     }
-    prevLine = line;
+    prevBytes = lineBuf;
   };
 
-  // Consume the ledger incrementally; buffer only a partial line. Never throws.
-  let buf = "";
+  // Consume the ledger incrementally as raw bytes; split on the LF byte and
+  // buffer only a partial line. Never throws.
+  let buf = Buffer.alloc(0);
   try {
-    const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath, { encoding: "utf8" });
+    const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath);
     for await (const chunk of stream) {
-      const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-      if (s.includes("\r")) sawCR = true;
-      buf += s;
+      const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8");
+      if (b.includes(0x0d)) sawCR = true;
+      buf = buf.length ? Buffer.concat([buf, b]) : b;
       let nl;
-      while ((nl = buf.indexOf("\n")) !== -1) {
-        processLine(buf.slice(0, nl));
-        buf = buf.slice(nl + 1);
+      while ((nl = buf.indexOf(0x0a)) !== -1) {
+        processLine(buf.subarray(0, nl));
+        buf = buf.subarray(nl + 1);
       }
     }
   } catch (e) {
@@ -380,17 +397,20 @@ function withoutWovenAt(payload) {
 // successful verifyLedger result.
 
 export async function* readEdges(ledgerPath, { openReadStream } = {}) {
-  const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath, { encoding: "utf8" });
-  let buf = "";
+  const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath);
+  let buf = Buffer.alloc(0);
   let lineNo = 0;
   for await (const chunk of stream) {
-    buf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8");
+    buf = buf.length ? Buffer.concat([buf, b]) : b;
     let nl;
-    while ((nl = buf.indexOf("\n")) !== -1) {
-      const line = buf.slice(0, nl);
-      buf = buf.slice(nl + 1);
+    while ((nl = buf.indexOf(0x0a)) !== -1) {
+      const lineBuf = buf.subarray(0, nl);
+      buf = buf.subarray(nl + 1);
       lineNo++;
       if (lineNo === 1) continue; // skip header
+      let line;
+      try { line = new TextDecoder("utf-8", { fatal: true }).decode(lineBuf); } catch { continue; }
       let obj;
       try { obj = JSON.parse(line); } catch { continue; }
       yield obj;

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -189,7 +189,14 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
   let privateKey;
   if (signKey !== undefined) {
     privateKey = (typeof signKey === "string" || Buffer.isBuffer(signKey)) ? createPrivateKey(signKey) : signKey;
-    if (!privateKey || privateKey.asymmetricKeyType !== "ed25519") throw new TypeError("createLedger: signKey must be an Ed25519 private key");
+    // `asymmetricKeyType` names the algorithm, not the role: a PUBLIC Ed25519
+    // KeyObject also reports "ed25519". Require `.type === "private"` too, so a
+    // non-private key is refused at creation — before deriving the public key,
+    // making directories, opening the path, or writing the header — rather than
+    // silently succeeding until the first sign().
+    if (!privateKey || typeof privateKey !== "object" || privateKey.type !== "private" || privateKey.asymmetricKeyType !== "ed25519") {
+      throw new TypeError("createLedger: signKey must be an Ed25519 private key");
+    }
   } else {
     privateKey = generateKeyPairSync("ed25519").privateKey;
   }

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -187,12 +187,16 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
   }
   const pubB64 = publicKeyB64(createPublicKey(privateKey));
 
-  const woven_at = new Date(wovenAt ?? Date.now()).toISOString();
+  let woven_at;
+  try { woven_at = new Date(wovenAt ?? Date.now()).toISOString(); }
+  catch { throw new TypeError(`createLedger: invalid wovenAt ${JSON.stringify(wovenAt)}`); }
   const repo_head = repoHead ?? String(git(["rev-parse", "HEAD"])).trim();
   if (typeof repo_head !== "string" || !HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit string, got ${JSON.stringify(repo_head)}`);
   const repo_ref = repositoryRef ?? deriveRepositoryRef(git);
   if (typeof repo_ref !== "string" || !REPO_REF.test(repo_ref)) throw new TypeError(`createLedger: repository_ref must be a 'git-root:<40-hex>' string, got ${JSON.stringify(repo_ref)}`);
 
+  // Only the default handle owns filesystem I/O; it creates parent directories
+  // for its requested file. An injected openFile owns its own path pre-existence.
   if (openFile === defaultOpenFile) mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
   const handle = openFile(ledgerPath); // wx is the atomic existence gate
 
@@ -275,7 +279,6 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
   let repoRef = null;
   let prevBytes = null;
   let lineIndex = 0;
-  let sawCR = false;
   const edgeHashes = new Set();
   const weaverEdgeIds = new Set();
   let trailerSeen = false;
@@ -285,6 +288,10 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
   // throws.
   const processLine = (lineBuf) => {
     const i = lineIndex++;
+    // CR is detected at the line level (a canonical JSON line never contains a
+    // raw CR), so a CRLF/embedded-CR failure is attributed to its exact line and
+    // truncates trust at the first failing line like any other defect.
+    if (lineBuf.includes(0x0d)) { fail(`line ${i + 1}: contains a raw CR (CRLF not permitted; lines end in LF)`); prevBytes = lineBuf; return; }
     let line;
     try { line = new TextDecoder("utf-8", { fatal: true }).decode(lineBuf); } catch { fail(`line ${i + 1}: invalid UTF-8`); prevBytes = lineBuf; return; }
     let obj;
@@ -357,7 +364,6 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
     const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath);
     for await (const chunk of stream) {
       const b = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, "utf8");
-      if (b.includes(0x0d)) sawCR = true;
       buf = buf.length ? Buffer.concat([buf, b]) : b;
       let nl;
       while ((nl = buf.indexOf(0x0a)) !== -1) {
@@ -369,12 +375,14 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
     return { ok: false, header, manifest: null, records, errors: [...errors, `read failed: ${e.message}`] };
   }
 
-  if (sawCR) errors.push("CRLF is not permitted; lines must end in LF");
-  if (buf.length > 0) errors.push("ledger must end with a final LF"); // an unterminated final record is never trusted
-  if (lineIndex === 0 && buf.length === 0) errors.push("empty ledger");
-  if (!trailerSeen) errors.push("ledger has no final trailer");
-  // never confer trust on a manifest from an invalid ledger (non-final trailer,
-  // trailing garbage, any failure): null it whenever any error was recorded.
+  // Stream-level defects flow through the SAME fail() channel as per-line
+  // defects. `records` holds only the trusted edge/status records that appeared
+  // before the first failing line or trailer-level invariant; a tail defect
+  // (missing trailer, partial final line) leaves those prior trusted records in
+  // `records` with ok:false, per the spec's "or trailer-level invariant" clause.
+  if (buf.length > 0) fail("ledger must end with a final LF (unterminated final record is never trusted)");
+  if (lineIndex === 0 && buf.length === 0) fail("empty ledger");
+  if (!trailerSeen) fail("ledger has no final trailer");
   if (errors.length > 0) manifest = null;
   return { ok: errors.length === 0, header, manifest, records, errors };
 }

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -52,6 +52,15 @@ const REQUIRED_INVENTORY_IDS = {
 const hexOf = (str) => createHash("sha256").update(Buffer.from(str, "utf8")).digest("hex");
 const publicKeyB64 = (pub) => pub.export({ type: "spki", format: "der" }).toString("base64");
 const publicKeyFromB64 = (b64) => createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
+// Decode `str` only if it is CANONICAL standard base64 of exactly `expectedLen`
+// bytes (Buffer.from is lenient — it silently ignores whitespace and accepts
+// non-canonical encodings), else null.
+function decodeCanonicalB64(str, expectedLen) {
+  if (typeof str !== "string") return null;
+  const buf = Buffer.from(str, "base64");
+  if (buf.length !== expectedLen || buf.toString("base64") !== str) return null;
+  return buf;
+}
 
 function defaultGit(args) {
   return execFileSync("git", args, { shell: false, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
@@ -300,8 +309,9 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
     try { expectHash = hexOf(canonicalJson({ ...payload, prev_hash })); } catch { /* payload not canonicalizable */ }
     if (typeof record_hash !== "string" || record_hash !== expectHash) bad(`line ${i + 1}: record_hash mismatch`);
     let sigOk = false;
-    try { sigOk = typeof signature === "string" && !!pubKey && edVerify(null, Buffer.from(record_hash || "", "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
-    if (!sigOk) bad(`line ${i + 1}: invalid signature`);
+    const sigBuf = decodeCanonicalB64(signature, 64); // Ed25519 sig = 64 bytes, canonical base64
+    try { sigOk = !!sigBuf && !!pubKey && edVerify(null, Buffer.from(record_hash || "", "hex"), pubKey, sigBuf); } catch { sigOk = false; }
+    if (!sigOk) bad(`line ${i + 1}: invalid or non-canonical signature`);
     if (payload.woven_at !== header.woven_at) bad(`line ${i + 1}: woven_at does not equal the header woven_at`);
 
     if (obj.clotho_weave_trailer) {

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -156,7 +156,7 @@ function validateCoverage(coverage, weaverEdgeIds) {
     const w = weavers[i];
     requireExactOwnKeys(w, ["id", "version", "implementation_refs", "state", "inspected_source_counts"], "coverage weaver");
     if (w.id !== WEAVER_ORDER[i]) throw new TypeError(`coverage weaver[${i}]: expected id ${WEAVER_ORDER[i]}, got ${JSON.stringify(w.id)}`);
-    if (!Number.isSafeInteger(w.version)) throw new TypeError(`coverage weaver[${w.id}].version: safe integer`);
+    if (!Number.isInteger(w.version)) throw new TypeError(`coverage weaver[${w.id}].version: must be an integer`); // a human-readable label; not the D24 count's safe-integer restriction
     if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver[${w.id}].state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
     if (!Array.isArray(w.implementation_refs) || w.implementation_refs.length === 0) throw new TypeError(`coverage weaver[${w.id}].implementation_refs: nonempty array`);
     for (const r of w.implementation_refs) requireFileRef(r, `coverage weaver[${w.id}].implementation_refs`);

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -2,9 +2,9 @@
 // Task 3). Zero dependencies: Node stdlib only.
 //
 // A weave owns ONE timestamp and ONE Ed25519 keypair, and owns every envelope
-// and accounting fact (D5): weavers never emit time, signatures, hashes, chain
-// fields, or counts. Records are canonical-JSON lines chained by hash and signed
-// over the raw record-hash digest.
+// and accounting fact (D5): weavers never emit time, signatures, record hashes,
+// chain fields, or counts. Records are canonical-JSON lines chained by hash and
+// signed over the raw record-hash digest.
 //
 // Signing uses node:crypto directly rather than merkle-dag/crypto.mjs, whose
 // envelope (sig:{alg,value,signed_fields}) and non-chained records do not
@@ -13,52 +13,58 @@
 //
 // Task 3 validates GENERIC ledger integrity only — schema, signatures, chain,
 // content-reference shapes, published states, record/coverage consistency —
-// against injected fixture coverage; it depends on no committed inventory (D19),
-// which cannot exist until Task 4a.
+// against injected fixture coverage; it depends on no committed inventory (D19).
+// Equality of coverage refs/counts with committed inventories is the Task 5
+// driver's job.
 
 import { createHash, generateKeyPairSync, sign as edSign, verify as edVerify, createPublicKey, createPrivateKey } from "node:crypto";
-import { openSync, writeSync, fsyncSync, closeSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { openSync, writeSync, fsyncSync, closeSync, readFileSync, mkdirSync, createReadStream } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 import {
-  canonicalJson, validateEdgeInput, validateSourceRef, deriveRepositoryRef, ASSERTION_STATUS
+  canonicalJson, validateEdgeInput, validateSourceRef, deriveRepositoryRef
 } from "./registry.mjs";
 
 const HEX40 = /^[0-9a-f]{40}$/;
 const HEX64 = /^[0-9a-f]{64}$/;
+const FILE_REF = /^file:(.+)@([0-9a-f]{40})$/;
 const PUBLISHED_STATES = new Set(["executed", "skipped"]);
 const STATUS_TRANSITIONS = new Set(["human-authorized", "rejected", "superseded"]);
-const FILE_REF = /^file:(.+)@([0-9a-f]{40})$/;
+// The five weaver ids in their stable declared (inventory) order. Task 3's
+// coverage carries exactly these five, in this order (v12 Task 3).
+const WEAVER_ORDER = ["clotho-git-weaver", "clotho-code-weaver", "clotho-test-weaver", "clotho-doc-weaver", "clotho-ledger-weaver"];
 
-// ---- crypto helpers ----------------------------------------------------------
+// ---- crypto + line helpers ---------------------------------------------------
 
-function digestOf(str) {
-  return createHash("sha256").update(Buffer.from(str, "utf8")).digest(); // 32-byte Buffer
-}
-function hexOf(str) {
-  return createHash("sha256").update(Buffer.from(str, "utf8")).digest("hex");
-}
-function publicKeyB64(publicKey) {
-  return publicKey.export({ type: "spki", format: "der" }).toString("base64");
-}
-function publicKeyFromB64(b64) {
-  return createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
-}
+const hexOf = (str) => createHash("sha256").update(Buffer.from(str, "utf8")).digest("hex");
+const publicKeyB64 = (pub) => pub.export({ type: "spki", format: "der" }).toString("base64");
+const publicKeyFromB64 = (b64) => createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
 
-// ---- default git identity (injected in tests / by the Task 5 driver) --------
-// The weaver-facing no-shell git wrapper is a separate Task 4a deliverable; here
-// we only need the ledger's own identity when the caller does not inject it.
 function defaultGit(args) {
   return execFileSync("git", args, { shell: false, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
 }
 
-// ---- validation helpers ------------------------------------------------------
+// Default file handle: exclusive create (wx is the sole atomic existence gate —
+// no TOCTOU pre-check), fsync on every write, single close.
+function defaultOpenFile(ledgerPath) {
+  let fd;
+  try {
+    fd = openSync(ledgerPath, "wx");
+  } catch (e) {
+    if (e && e.code === "EEXIST") throw new Error(`createLedger: refusing to overwrite existing path ${ledgerPath}`);
+    throw e;
+  }
+  return {
+    write(line) { writeSync(fd, line + "\n"); fsyncSync(fd); },
+    close() { closeSync(fd); }
+  };
+}
+
+// ---- schema validators -------------------------------------------------------
 
 function requireFileRef(ref, label) {
-  if (typeof ref !== "string" || !FILE_REF.test(ref)) {
-    throw new TypeError(`${label}: expected 'file:<path>@<40-hex>', got ${JSON.stringify(ref)}`);
-  }
+  if (typeof ref !== "string" || !FILE_REF.test(ref)) throw new TypeError(`${label}: expected 'file:<path>@<40-hex>', got ${JSON.stringify(ref)}`);
 }
 
 function requireInspectedSourceCounts(counts, state, label) {
@@ -67,9 +73,7 @@ function requireInspectedSourceCounts(counts, state, label) {
   for (const entry of counts) {
     if (entry === null || typeof entry !== "object" || Array.isArray(entry)) throw new TypeError(`${label}: count entry must be an object`);
     const keys = Object.keys(entry);
-    if (keys.length !== 2 || !("inventory_id" in entry) || !("count" in entry)) {
-      throw new TypeError(`${label}: count entry must be exactly {inventory_id, count}`);
-    }
+    if (keys.length !== 2 || !("inventory_id" in entry) || !("count" in entry)) throw new TypeError(`${label}: count entry must be exactly {inventory_id, count}`);
     if (typeof entry.inventory_id !== "string" || entry.inventory_id.length === 0) throw new TypeError(`${label}: inventory_id must be a nonempty string`);
     if (!Number.isSafeInteger(entry.count) || entry.count < 0) throw new TypeError(`${label}: count must be a nonnegative safe integer`);
     if (prevId !== null && entry.inventory_id <= prevId) throw new TypeError(`${label}: inspected_source_counts must be sorted and unique by inventory_id`);
@@ -78,37 +82,29 @@ function requireInspectedSourceCounts(counts, state, label) {
   }
 }
 
-// Validate the structure of a coverage object (D19: generic — no committed
-// inventory dependency). `weaverEdgeIds` is the set of weaver ids that actually
-// asserted an edge in this ledger; a skipped weaver may not have produced edges.
+// Structure-only coverage validation (D19). `weaverEdgeIds` is the set of weaver
+// ids that asserted an edge; a weaver with edges may not be recorded 'skipped'.
 function validateCoverage(coverage, weaverEdgeIds) {
   if (coverage === null || typeof coverage !== "object" || Array.isArray(coverage)) throw new TypeError("coverage: must be an object");
-  const keys = Object.keys(coverage);
   const expected = ["weavers", "orchestrator_refs", "inventories_consumed"];
-  for (const k of keys) if (!expected.includes(k)) throw new TypeError(`coverage: unexpected field '${k}'`);
+  for (const k of Object.keys(coverage)) if (!expected.includes(k)) throw new TypeError(`coverage: unexpected field '${k}'`);
   for (const k of expected) if (!(k in coverage)) throw new TypeError(`coverage: missing field '${k}'`);
 
   const { weavers, orchestrator_refs, inventories_consumed } = coverage;
   if (!Array.isArray(weavers) || weavers.length !== 5) throw new TypeError("coverage.weavers: must be exactly five entries");
-  const seenIds = new Set();
-  for (const w of weavers) {
+  for (let i = 0; i < 5; i++) {
+    const w = weavers[i];
     if (w === null || typeof w !== "object" || Array.isArray(w)) throw new TypeError("coverage weaver: must be an object");
-    const wkeys = Object.keys(w);
     const wexpected = ["id", "version", "implementation_refs", "state", "inspected_source_counts"];
-    for (const k of wkeys) if (!wexpected.includes(k)) throw new TypeError(`coverage weaver: unexpected field '${k}'`);
+    for (const k of Object.keys(w)) if (!wexpected.includes(k)) throw new TypeError(`coverage weaver: unexpected field '${k}'`);
     for (const k of wexpected) if (!(k in w)) throw new TypeError(`coverage weaver: missing field '${k}'`);
-    if (typeof w.id !== "string" || w.id.length === 0) throw new TypeError("coverage weaver.id: nonempty string");
-    if (seenIds.has(w.id)) throw new TypeError(`coverage weaver.id: duplicate ${w.id}`);
-    seenIds.add(w.id);
-    if (!Number.isSafeInteger(w.version)) throw new TypeError("coverage weaver.version: safe integer");
-    if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver.state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
-    if (!Array.isArray(w.implementation_refs) || w.implementation_refs.length === 0) throw new TypeError("coverage weaver.implementation_refs: nonempty array");
-    for (const r of w.implementation_refs) requireFileRef(r, "coverage weaver.implementation_refs");
+    if (w.id !== WEAVER_ORDER[i]) throw new TypeError(`coverage weaver[${i}]: expected id ${WEAVER_ORDER[i]}, got ${JSON.stringify(w.id)}`);
+    if (!Number.isSafeInteger(w.version)) throw new TypeError(`coverage weaver[${w.id}].version: safe integer`);
+    if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver[${w.id}].state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
+    if (!Array.isArray(w.implementation_refs) || w.implementation_refs.length === 0) throw new TypeError(`coverage weaver[${w.id}].implementation_refs: nonempty array`);
+    for (const r of w.implementation_refs) requireFileRef(r, `coverage weaver[${w.id}].implementation_refs`);
     requireInspectedSourceCounts(w.inspected_source_counts, w.state, `coverage weaver[${w.id}]`);
-    // A weaver that produced edges in this ledger cannot be recorded skipped.
-    if (w.state === "skipped" && weaverEdgeIds.has(w.id)) {
-      throw new TypeError(`coverage weaver[${w.id}]: recorded 'skipped' but produced edges in this ledger`);
-    }
+    if (w.state === "skipped" && weaverEdgeIds.has(w.id)) throw new TypeError(`coverage weaver[${w.id}]: recorded 'skipped' but asserted an edge in this ledger`);
   }
   if (!Array.isArray(orchestrator_refs) || orchestrator_refs.length === 0) throw new TypeError("coverage.orchestrator_refs: nonempty array");
   for (const r of orchestrator_refs) requireFileRef(r, "coverage.orchestrator_refs");
@@ -122,63 +118,54 @@ function validateCoverage(coverage, weaverEdgeIds) {
   }
 }
 
+function validateStatusInput(statusInput, edgeHashes) {
+  if (statusInput === null || typeof statusInput !== "object" || Array.isArray(statusInput)) throw new TypeError("statusInput: object");
+  const expected = ["status_of", "new_status", "asserted_by", "assertion_status", "source_ref"];
+  for (const k of Object.keys(statusInput)) if (!expected.includes(k)) throw new TypeError(`statusInput: unexpected field '${k}'`);
+  for (const k of expected) if (!(k in statusInput)) throw new TypeError(`statusInput: missing field '${k}'`);
+  if (typeof statusInput.status_of !== "string" || !HEX64.test(statusInput.status_of)) throw new TypeError("statusInput.status_of: 64-hex record hash");
+  if (!edgeHashes.has(statusInput.status_of)) throw new TypeError("statusInput.status_of: must reference an earlier edge record in this ledger");
+  if (!STATUS_TRANSITIONS.has(statusInput.new_status)) throw new TypeError(`statusInput.new_status: must be one of ${[...STATUS_TRANSITIONS].join("|")}`);
+  if (statusInput.asserted_by !== "human") throw new TypeError("statusInput.asserted_by: status transitions must be asserted by 'human'");
+  if (statusInput.assertion_status !== "human-authorized") throw new TypeError("statusInput.assertion_status: must be 'human-authorized'");
+  validateSourceRef(statusInput.source_ref);
+}
+
 // ---- createLedger ------------------------------------------------------------
 
-export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositoryRef, git = defaultGit } = {}) {
-  if (existsSync(ledgerPath)) throw new Error(`createLedger: refusing to overwrite existing path ${ledgerPath}`);
-
-  // one signing keypair
+export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositoryRef, git = defaultGit, openFile = defaultOpenFile } = {}) {
   let privateKey;
   if (signKey !== undefined) {
-    privateKey = typeof signKey === "string" || Buffer.isBuffer(signKey) ? createPrivateKey(signKey) : signKey;
+    privateKey = (typeof signKey === "string" || Buffer.isBuffer(signKey)) ? createPrivateKey(signKey) : signKey;
     if (!privateKey || privateKey.asymmetricKeyType !== "ed25519") throw new TypeError("createLedger: signKey must be an Ed25519 private key");
   } else {
     privateKey = generateKeyPairSync("ed25519").privateKey;
   }
-  const publicKey = createPublicKey(privateKey);
-  const pubB64 = publicKeyB64(publicKey);
+  const pubB64 = publicKeyB64(createPublicKey(privateKey));
 
-  // one canonical timestamp, one head, one ref
   const woven_at = new Date(wovenAt ?? Date.now()).toISOString();
-  const repo_head = (repoHead ?? String(git(["rev-parse", "HEAD"])).trim());
+  const repo_head = repoHead ?? String(git(["rev-parse", "HEAD"])).trim();
   if (!HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit, got ${JSON.stringify(repo_head)}`);
   const repo_ref = repositoryRef ?? deriveRepositoryRef(git);
 
-  mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
-  const fd = openSync(ledgerPath, "wx");
+  if (openFile === defaultOpenFile) mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
+  const handle = openFile(ledgerPath); // wx is the atomic existence gate
 
-  const state = { fd, open: true, closed: false, poisoned: false, prevLine: null, edgeHashes: new Set(), weaverEdgeIds: new Set(), woven_at, repo_ref };
+  const state = { open: true, closed: false, poisoned: false, prevLine: null, edgeHashes: new Set(), weaverEdgeIds: new Set() };
 
-  function closeFd() {
-    if (state.open) { try { closeSync(fd); } finally { state.open = false; } }
-  }
-  function poison(err) {
-    state.poisoned = true;
-    closeFd();
-    return err;
-  }
-  function guard() {
-    if (state.poisoned) throw new Error("ledger is poisoned/aborted");
-    if (state.closed) throw new Error("ledger is closed");
-  }
-  function writeLine(obj) {
-    const line = canonicalJson(obj);
-    writeSync(fd, line + "\n");
-    fsyncSync(fd);
-    state.prevLine = line;
-  }
-  function chainAndSign(payload) {
+  const closeHandle = () => { if (state.open) { try { handle.close(); } finally { state.open = false; } } };
+  const poison = (err) => { state.poisoned = true; closeHandle(); return err; };
+  const guard = () => { if (state.poisoned) throw new Error("ledger is poisoned/aborted"); if (state.closed) throw new Error("ledger is closed"); };
+  const writeLine = (obj) => { const line = canonicalJson(obj); handle.write(line); state.prevLine = line; };
+  const chainAndSign = (payload) => {
     const prev_hash = hexOf(state.prevLine);
     const record_hash = hexOf(canonicalJson({ ...payload, prev_hash }));
     const signature = edSign(null, Buffer.from(record_hash, "hex"), privateKey).toString("base64");
     return { ...payload, prev_hash, record_hash, signature };
-  }
+  };
 
-  // header — first line, immediately
   const header = { clotho_weave_header: { pub_key: pubB64, woven_at, repo_head, repository_ref: repo_ref, weave_version: 1 } };
-  try {
-    writeLine(header);
-  } catch (e) { throw poison(e); }
+  try { writeLine(header); } catch (e) { throw poison(e); }
 
   return {
     header,
@@ -186,8 +173,7 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
       guard();
       try {
         validateEdgeInput(edgeInput, { repositoryRef: repo_ref });
-        const payload = { ...edgeInput, woven_at };
-        const record = chainAndSign(payload);
+        const record = chainAndSign({ ...edgeInput, woven_at });
         writeLine(record);
         state.edgeHashes.add(record.record_hash);
         if (edgeInput.assertion_status === "deterministic-extraction") state.weaverEdgeIds.add(edgeInput.asserted_by);
@@ -197,19 +183,8 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
     appendStatus(statusInput) {
       guard();
       try {
-        if (statusInput === null || typeof statusInput !== "object" || Array.isArray(statusInput)) throw new TypeError("statusInput: object");
-        const keys = Object.keys(statusInput);
-        const expected = ["status_of", "new_status", "asserted_by", "assertion_status", "source_ref"];
-        for (const k of keys) if (!expected.includes(k)) throw new TypeError(`statusInput: unexpected field '${k}'`);
-        for (const k of expected) if (!(k in statusInput)) throw new TypeError(`statusInput: missing field '${k}'`);
-        if (typeof statusInput.status_of !== "string" || !HEX64.test(statusInput.status_of)) throw new TypeError("statusInput.status_of: 64-hex record hash");
-        if (!state.edgeHashes.has(statusInput.status_of)) throw new TypeError("statusInput.status_of: must reference an earlier edge record in this ledger");
-        if (!STATUS_TRANSITIONS.has(statusInput.new_status)) throw new TypeError(`statusInput.new_status: must be one of ${[...STATUS_TRANSITIONS].join("|")}`);
-        if (statusInput.asserted_by !== "human") throw new TypeError("statusInput.asserted_by: status transitions must be asserted by 'human'");
-        if (statusInput.assertion_status !== "human-authorized") throw new TypeError("statusInput.assertion_status: must be 'human-authorized'");
-        validateSourceRef(statusInput.source_ref);
-        const payload = { ...statusInput, woven_at };
-        const record = chainAndSign(payload);
+        validateStatusInput(statusInput, state.edgeHashes);
+        const record = chainAndSign({ ...statusInput, woven_at });
         writeLine(record);
         return record;
       } catch (e) { throw poison(e); }
@@ -218,117 +193,141 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
       guard();
       try {
         validateCoverage(coverage, state.weaverEdgeIds);
-        const payload = { clotho_weave_trailer: coverage, woven_at };
-        const record = chainAndSign(payload);
+        const record = chainAndSign({ clotho_weave_trailer: coverage, woven_at });
         writeLine(record);
         state.closed = true;
-        closeFd();
+        closeHandle();
         return record;
       } catch (e) { throw poison(e); }
     },
     abort() {
-      if (state.closed) return; // no-op after a successful close
+      if (state.closed) return;               // no-op after a successful close
       state.poisoned = true;
-      closeFd();
+      closeHandle();
     }
   };
 }
 
 // ---- verifyLedger ------------------------------------------------------------
+// `records` contains ONLY trusted signed edge and status records (never the
+// header or trailer). On the first failing line it stops conferring trust: no
+// record on or after that line is added, and ok is false.
 
 export async function verifyLedger(ledgerPath) {
   const errors = [];
   const records = [];
   let header = null;
   let manifest = null;
-  const push = (m) => errors.push(m);
+  let trustBroken = false;
+  const fail = (m) => { errors.push(m); trustBroken = true; };
 
   let raw;
-  try { raw = readFileSync(ledgerPath, "utf8"); } catch (e) { return { ok: false, records, errors: [`read failed: ${e.message}`] }; }
+  try { raw = readFileSync(ledgerPath, "utf8"); } catch (e) { return { ok: false, header: null, manifest: null, records, errors: [`read failed: ${e.message}`] }; }
 
-  if (raw.includes("\r")) push("CRLF is not permitted; lines must end in LF");
-  if (raw.length === 0 || !raw.endsWith("\n")) push("ledger must end with a final LF");
-  const lines = raw.length ? raw.replace(/\n$/, "").split("\n") : [];
+  if (raw.length === 0) return { ok: false, header: null, manifest: null, records, errors: ["empty ledger"] };
+  if (raw.includes("\r")) errors.push("CRLF is not permitted; lines must end in LF");
+  if (!raw.endsWith("\n")) errors.push("ledger must end with a final LF");
+  const lines = raw.replace(/\n$/, "").split("\n");
 
   let pubKey = null;
   let repoRef = null;
   let prevLine = null;
   const edgeHashes = new Set();
+  const weaverEdgeIds = new Set();
   let trailerSeen = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     let obj;
-    try { obj = JSON.parse(line); } catch { push(`line ${i + 1}: not valid JSON`); continue; }
-    if (canonicalJson(obj) !== line) { push(`line ${i + 1}: not canonical JSON`); continue; }
+    try { obj = JSON.parse(line); } catch { fail(`line ${i + 1}: not valid JSON`); continue; }
+    if (canonicalJson(obj) !== line) { fail(`line ${i + 1}: not canonical JSON`); continue; }
 
     if (i === 0) {
-      if (!obj.clotho_weave_header) { push("line 1: missing header"); break; }
-      const h = obj.clotho_weave_header;
-      header = h;
+      if (!obj.clotho_weave_header) { fail("line 1: missing header"); break; }
+      header = obj.clotho_weave_header;
       try {
-        pubKey = publicKeyFromB64(h.pub_key);
-        repoRef = h.repository_ref;
-        if (h.weave_version !== 1) push("header: weave_version must be 1");
-        if (!HEX40.test(h.repo_head)) push("header: repo_head must be 40-hex");
-        if (new Date(h.woven_at).toISOString() !== h.woven_at) push("header: woven_at not canonical ISO");
-      } catch (e) { push(`header: ${e.message}`); }
+        pubKey = publicKeyFromB64(header.pub_key);
+        repoRef = header.repository_ref;
+        if (header.weave_version !== 1) fail("header: weave_version must be 1");
+        if (!HEX40.test(header.repo_head)) fail("header: repo_head must be 40-hex");
+        if (new Date(header.woven_at).toISOString() !== header.woven_at) fail("header: woven_at not canonical ISO");
+      } catch (e) { fail(`header: ${e.message}`); }
       prevLine = line;
       continue;
     }
-    if (obj.clotho_weave_header) { push(`line ${i + 1}: duplicate header`); continue; }
-    if (trailerSeen) { push(`line ${i + 1}: record after trailer (trailer must be final)`); continue; }
+    if (obj.clotho_weave_header) { fail(`line ${i + 1}: duplicate header`); continue; }
+    if (trailerSeen) { fail(`line ${i + 1}: record after trailer (trailer must be final)`); continue; }
 
-    // chain + signature envelope
     const { prev_hash, record_hash, signature, ...payload } = obj;
-    if (typeof prev_hash !== "string" || prev_hash !== hexOf(prevLine)) push(`line ${i + 1}: broken chain (prev_hash mismatch)`);
-    if (typeof record_hash !== "string" || record_hash !== hexOf(canonicalJson({ ...payload, prev_hash }))) push(`line ${i + 1}: record_hash mismatch`);
+    let lineOk = true;
+    const bad = (m) => { fail(m); lineOk = false; };
+    if (typeof prev_hash !== "string" || prev_hash !== hexOf(prevLine)) bad(`line ${i + 1}: broken chain (prev_hash mismatch)`);
+    if (typeof record_hash !== "string" || record_hash !== hexOf(canonicalJson({ ...payload, prev_hash }))) bad(`line ${i + 1}: record_hash mismatch`);
     let sigOk = false;
-    try { sigOk = typeof signature === "string" && pubKey && edVerify(null, Buffer.from(record_hash, "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
-    if (!sigOk) push(`line ${i + 1}: invalid signature`);
+    try { sigOk = typeof signature === "string" && !!pubKey && edVerify(null, Buffer.from(record_hash || "", "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
+    if (!sigOk) bad(`line ${i + 1}: invalid signature`);
 
     if (obj.clotho_weave_trailer) {
       manifest = obj.clotho_weave_trailer;
-      try { validateCoverage(manifest, new Set()); } catch (e) { push(`trailer: ${e.message}`); }
+      try { validateCoverage(manifest, weaverEdgeIds); } catch (e) { bad(`trailer: ${e.message}`); }
       trailerSeen = true;
+      // trailer is never added to `records`
     } else if ("status_of" in payload) {
-      if (!edgeHashes.has(payload.status_of)) push(`line ${i + 1}: status_of does not reference an earlier edge`);
-      if (payload.asserted_by !== "human" || payload.assertion_status !== "human-authorized") push(`line ${i + 1}: status must be human-authorized adjudication`);
-      if (!STATUS_TRANSITIONS.has(payload.new_status)) push(`line ${i + 1}: invalid new_status`);
+      try { validateStatusInput(payload_forStatus(payload), edgeHashes); } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
+      if (lineOk && !trustBroken) records.push(obj);
     } else {
-      // edge record: re-validate structure/endpoints against the header repo ref
       try {
-        const { woven_at, ...edgeInput } = payload;
+        const edgeInput = withoutWovenAt(payload);
         validateEdgeInput(edgeInput, { repositoryRef: repoRef });
-      } catch (e) { push(`line ${i + 1}: ${e.message}`); }
-      edgeHashes.add(record_hash);
+        if (lineOk) {
+          edgeHashes.add(record_hash);
+          if (payload.assertion_status === "deterministic-extraction") weaverEdgeIds.add(payload.asserted_by);
+        }
+      } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
+      if (lineOk && !trustBroken) records.push(obj);
     }
-    records.push(obj);
     prevLine = line;
   }
 
-  if (lines.length > 0 && !trailerSeen) push("ledger has no final trailer");
+  if (!trailerSeen) errors.push("ledger has no final trailer");
   return { ok: errors.length === 0, header, manifest, records, errors };
 }
 
+// a status payload includes woven_at; validateStatusInput expects exactly the
+// 5 caller fields, so drop the ledger-owned woven_at before structural checks.
+function payload_forStatus(payload) {
+  const { woven_at, ...rest } = payload;
+  return rest;
+}
+function withoutWovenAt(payload) {
+  const { woven_at, ...rest } = payload;
+  return rest;
+}
+
 // ---- readEdges ---------------------------------------------------------------
-// Yields edge records structurally (not trust-conferring — callers verify).
+// Streams the ledger via fs.createReadStream (or an injected stream) with an
+// incremental line splitter, skips ONLY the header, and yields every subsequent
+// signed record (edges, status records, and the trailer) without buffering the
+// whole file. Structural parsing only — not trust-conferring; callers query a
+// successful verifyLedger result.
 
 export async function* readEdges(ledgerPath, { openReadStream } = {}) {
-  let text;
-  if (openReadStream) {
-    let buf = "";
-    for await (const chunk of openReadStream(ledgerPath)) buf += chunk.toString("utf8");
-    text = buf;
-  } else {
-    text = readFileSync(ledgerPath, "utf8");
+  const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath, { encoding: "utf8" });
+  let buf = "";
+  let lineNo = 0;
+  for await (const chunk of stream) {
+    buf += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    let nl;
+    while ((nl = buf.indexOf("\n")) !== -1) {
+      const line = buf.slice(0, nl);
+      buf = buf.slice(nl + 1);
+      lineNo++;
+      if (lineNo === 1) continue; // skip header
+      let obj;
+      try { obj = JSON.parse(line); } catch { continue; }
+      yield obj;
+    }
   }
-  const lines = text.length ? text.replace(/\n$/, "").split("\n") : [];
-  for (const line of lines) {
-    let obj;
-    try { obj = JSON.parse(line); } catch { continue; }
-    if (obj.clotho_weave_header || obj.clotho_weave_trailer) continue;
-    if ("status_of" in obj) continue;
-    yield obj;
-  }
+  // A well-formed ledger ends in LF, so any trailing partial line is malformed
+  // and is not yielded.
 }

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -1,0 +1,334 @@
+// thread-ledger.mjs — Clotho's signed, append-only thread ledger (plan v12
+// Task 3). Zero dependencies: Node stdlib only.
+//
+// A weave owns ONE timestamp and ONE Ed25519 keypair, and owns every envelope
+// and accounting fact (D5): weavers never emit time, signatures, hashes, chain
+// fields, or counts. Records are canonical-JSON lines chained by hash and signed
+// over the raw record-hash digest.
+//
+// Signing uses node:crypto directly rather than merkle-dag/crypto.mjs, whose
+// envelope (sig:{alg,value,signed_fields}) and non-chained records do not
+// implement the normative bytes here (v12 Task 3). The single-writer append +
+// fsync discipline follows the proposal-ledger pattern in merkle-dag/crypto.mjs.
+//
+// Task 3 validates GENERIC ledger integrity only — schema, signatures, chain,
+// content-reference shapes, published states, record/coverage consistency —
+// against injected fixture coverage; it depends on no committed inventory (D19),
+// which cannot exist until Task 4a.
+
+import { createHash, generateKeyPairSync, sign as edSign, verify as edVerify, createPublicKey, createPrivateKey } from "node:crypto";
+import { openSync, writeSync, fsyncSync, closeSync, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+import {
+  canonicalJson, validateEdgeInput, validateSourceRef, deriveRepositoryRef, ASSERTION_STATUS
+} from "./registry.mjs";
+
+const HEX40 = /^[0-9a-f]{40}$/;
+const HEX64 = /^[0-9a-f]{64}$/;
+const PUBLISHED_STATES = new Set(["executed", "skipped"]);
+const STATUS_TRANSITIONS = new Set(["human-authorized", "rejected", "superseded"]);
+const FILE_REF = /^file:(.+)@([0-9a-f]{40})$/;
+
+// ---- crypto helpers ----------------------------------------------------------
+
+function digestOf(str) {
+  return createHash("sha256").update(Buffer.from(str, "utf8")).digest(); // 32-byte Buffer
+}
+function hexOf(str) {
+  return createHash("sha256").update(Buffer.from(str, "utf8")).digest("hex");
+}
+function publicKeyB64(publicKey) {
+  return publicKey.export({ type: "spki", format: "der" }).toString("base64");
+}
+function publicKeyFromB64(b64) {
+  return createPublicKey({ key: Buffer.from(b64, "base64"), format: "der", type: "spki" });
+}
+
+// ---- default git identity (injected in tests / by the Task 5 driver) --------
+// The weaver-facing no-shell git wrapper is a separate Task 4a deliverable; here
+// we only need the ledger's own identity when the caller does not inject it.
+function defaultGit(args) {
+  return execFileSync("git", args, { shell: false, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+}
+
+// ---- validation helpers ------------------------------------------------------
+
+function requireFileRef(ref, label) {
+  if (typeof ref !== "string" || !FILE_REF.test(ref)) {
+    throw new TypeError(`${label}: expected 'file:<path>@<40-hex>', got ${JSON.stringify(ref)}`);
+  }
+}
+
+function requireInspectedSourceCounts(counts, state, label) {
+  if (!Array.isArray(counts)) throw new TypeError(`${label}: inspected_source_counts must be an array`);
+  let prevId = null;
+  for (const entry of counts) {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) throw new TypeError(`${label}: count entry must be an object`);
+    const keys = Object.keys(entry);
+    if (keys.length !== 2 || !("inventory_id" in entry) || !("count" in entry)) {
+      throw new TypeError(`${label}: count entry must be exactly {inventory_id, count}`);
+    }
+    if (typeof entry.inventory_id !== "string" || entry.inventory_id.length === 0) throw new TypeError(`${label}: inventory_id must be a nonempty string`);
+    if (!Number.isSafeInteger(entry.count) || entry.count < 0) throw new TypeError(`${label}: count must be a nonnegative safe integer`);
+    if (prevId !== null && entry.inventory_id <= prevId) throw new TypeError(`${label}: inspected_source_counts must be sorted and unique by inventory_id`);
+    prevId = entry.inventory_id;
+    if (state === "skipped" && entry.count !== 0) throw new TypeError(`${label}: skipped weaver must carry zero counts`);
+  }
+}
+
+// Validate the structure of a coverage object (D19: generic — no committed
+// inventory dependency). `weaverEdgeIds` is the set of weaver ids that actually
+// asserted an edge in this ledger; a skipped weaver may not have produced edges.
+function validateCoverage(coverage, weaverEdgeIds) {
+  if (coverage === null || typeof coverage !== "object" || Array.isArray(coverage)) throw new TypeError("coverage: must be an object");
+  const keys = Object.keys(coverage);
+  const expected = ["weavers", "orchestrator_refs", "inventories_consumed"];
+  for (const k of keys) if (!expected.includes(k)) throw new TypeError(`coverage: unexpected field '${k}'`);
+  for (const k of expected) if (!(k in coverage)) throw new TypeError(`coverage: missing field '${k}'`);
+
+  const { weavers, orchestrator_refs, inventories_consumed } = coverage;
+  if (!Array.isArray(weavers) || weavers.length !== 5) throw new TypeError("coverage.weavers: must be exactly five entries");
+  const seenIds = new Set();
+  for (const w of weavers) {
+    if (w === null || typeof w !== "object" || Array.isArray(w)) throw new TypeError("coverage weaver: must be an object");
+    const wkeys = Object.keys(w);
+    const wexpected = ["id", "version", "implementation_refs", "state", "inspected_source_counts"];
+    for (const k of wkeys) if (!wexpected.includes(k)) throw new TypeError(`coverage weaver: unexpected field '${k}'`);
+    for (const k of wexpected) if (!(k in w)) throw new TypeError(`coverage weaver: missing field '${k}'`);
+    if (typeof w.id !== "string" || w.id.length === 0) throw new TypeError("coverage weaver.id: nonempty string");
+    if (seenIds.has(w.id)) throw new TypeError(`coverage weaver.id: duplicate ${w.id}`);
+    seenIds.add(w.id);
+    if (!Number.isSafeInteger(w.version)) throw new TypeError("coverage weaver.version: safe integer");
+    if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver.state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
+    if (!Array.isArray(w.implementation_refs) || w.implementation_refs.length === 0) throw new TypeError("coverage weaver.implementation_refs: nonempty array");
+    for (const r of w.implementation_refs) requireFileRef(r, "coverage weaver.implementation_refs");
+    requireInspectedSourceCounts(w.inspected_source_counts, w.state, `coverage weaver[${w.id}]`);
+    // A weaver that produced edges in this ledger cannot be recorded skipped.
+    if (w.state === "skipped" && weaverEdgeIds.has(w.id)) {
+      throw new TypeError(`coverage weaver[${w.id}]: recorded 'skipped' but produced edges in this ledger`);
+    }
+  }
+  if (!Array.isArray(orchestrator_refs) || orchestrator_refs.length === 0) throw new TypeError("coverage.orchestrator_refs: nonempty array");
+  for (const r of orchestrator_refs) requireFileRef(r, "coverage.orchestrator_refs");
+  if (!Array.isArray(inventories_consumed)) throw new TypeError("coverage.inventories_consumed: must be an array");
+  for (const inv of inventories_consumed) {
+    if (inv === null || typeof inv !== "object" || Array.isArray(inv)) throw new TypeError("inventories_consumed entry: object");
+    const ikeys = Object.keys(inv);
+    if (ikeys.length !== 2 || !("id" in inv) || !("source_ref" in inv)) throw new TypeError("inventories_consumed entry: exactly {id, source_ref}");
+    if (typeof inv.id !== "string" || inv.id.length === 0) throw new TypeError("inventories_consumed.id: nonempty string");
+    requireFileRef(inv.source_ref, "inventories_consumed.source_ref");
+  }
+}
+
+// ---- createLedger ------------------------------------------------------------
+
+export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositoryRef, git = defaultGit } = {}) {
+  if (existsSync(ledgerPath)) throw new Error(`createLedger: refusing to overwrite existing path ${ledgerPath}`);
+
+  // one signing keypair
+  let privateKey;
+  if (signKey !== undefined) {
+    privateKey = typeof signKey === "string" || Buffer.isBuffer(signKey) ? createPrivateKey(signKey) : signKey;
+    if (!privateKey || privateKey.asymmetricKeyType !== "ed25519") throw new TypeError("createLedger: signKey must be an Ed25519 private key");
+  } else {
+    privateKey = generateKeyPairSync("ed25519").privateKey;
+  }
+  const publicKey = createPublicKey(privateKey);
+  const pubB64 = publicKeyB64(publicKey);
+
+  // one canonical timestamp, one head, one ref
+  const woven_at = new Date(wovenAt ?? Date.now()).toISOString();
+  const repo_head = (repoHead ?? String(git(["rev-parse", "HEAD"])).trim());
+  if (!HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit, got ${JSON.stringify(repo_head)}`);
+  const repo_ref = repositoryRef ?? deriveRepositoryRef(git);
+
+  mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
+  const fd = openSync(ledgerPath, "wx");
+
+  const state = { fd, open: true, closed: false, poisoned: false, prevLine: null, edgeHashes: new Set(), weaverEdgeIds: new Set(), woven_at, repo_ref };
+
+  function closeFd() {
+    if (state.open) { try { closeSync(fd); } finally { state.open = false; } }
+  }
+  function poison(err) {
+    state.poisoned = true;
+    closeFd();
+    return err;
+  }
+  function guard() {
+    if (state.poisoned) throw new Error("ledger is poisoned/aborted");
+    if (state.closed) throw new Error("ledger is closed");
+  }
+  function writeLine(obj) {
+    const line = canonicalJson(obj);
+    writeSync(fd, line + "\n");
+    fsyncSync(fd);
+    state.prevLine = line;
+  }
+  function chainAndSign(payload) {
+    const prev_hash = hexOf(state.prevLine);
+    const record_hash = hexOf(canonicalJson({ ...payload, prev_hash }));
+    const signature = edSign(null, Buffer.from(record_hash, "hex"), privateKey).toString("base64");
+    return { ...payload, prev_hash, record_hash, signature };
+  }
+
+  // header — first line, immediately
+  const header = { clotho_weave_header: { pub_key: pubB64, woven_at, repo_head, repository_ref: repo_ref, weave_version: 1 } };
+  try {
+    writeLine(header);
+  } catch (e) { throw poison(e); }
+
+  return {
+    header,
+    appendEdge(edgeInput) {
+      guard();
+      try {
+        validateEdgeInput(edgeInput, { repositoryRef: repo_ref });
+        const payload = { ...edgeInput, woven_at };
+        const record = chainAndSign(payload);
+        writeLine(record);
+        state.edgeHashes.add(record.record_hash);
+        if (edgeInput.assertion_status === "deterministic-extraction") state.weaverEdgeIds.add(edgeInput.asserted_by);
+        return record;
+      } catch (e) { throw poison(e); }
+    },
+    appendStatus(statusInput) {
+      guard();
+      try {
+        if (statusInput === null || typeof statusInput !== "object" || Array.isArray(statusInput)) throw new TypeError("statusInput: object");
+        const keys = Object.keys(statusInput);
+        const expected = ["status_of", "new_status", "asserted_by", "assertion_status", "source_ref"];
+        for (const k of keys) if (!expected.includes(k)) throw new TypeError(`statusInput: unexpected field '${k}'`);
+        for (const k of expected) if (!(k in statusInput)) throw new TypeError(`statusInput: missing field '${k}'`);
+        if (typeof statusInput.status_of !== "string" || !HEX64.test(statusInput.status_of)) throw new TypeError("statusInput.status_of: 64-hex record hash");
+        if (!state.edgeHashes.has(statusInput.status_of)) throw new TypeError("statusInput.status_of: must reference an earlier edge record in this ledger");
+        if (!STATUS_TRANSITIONS.has(statusInput.new_status)) throw new TypeError(`statusInput.new_status: must be one of ${[...STATUS_TRANSITIONS].join("|")}`);
+        if (statusInput.asserted_by !== "human") throw new TypeError("statusInput.asserted_by: status transitions must be asserted by 'human'");
+        if (statusInput.assertion_status !== "human-authorized") throw new TypeError("statusInput.assertion_status: must be 'human-authorized'");
+        validateSourceRef(statusInput.source_ref);
+        const payload = { ...statusInput, woven_at };
+        const record = chainAndSign(payload);
+        writeLine(record);
+        return record;
+      } catch (e) { throw poison(e); }
+    },
+    close(coverage) {
+      guard();
+      try {
+        validateCoverage(coverage, state.weaverEdgeIds);
+        const payload = { clotho_weave_trailer: coverage, woven_at };
+        const record = chainAndSign(payload);
+        writeLine(record);
+        state.closed = true;
+        closeFd();
+        return record;
+      } catch (e) { throw poison(e); }
+    },
+    abort() {
+      if (state.closed) return; // no-op after a successful close
+      state.poisoned = true;
+      closeFd();
+    }
+  };
+}
+
+// ---- verifyLedger ------------------------------------------------------------
+
+export async function verifyLedger(ledgerPath) {
+  const errors = [];
+  const records = [];
+  let header = null;
+  let manifest = null;
+  const push = (m) => errors.push(m);
+
+  let raw;
+  try { raw = readFileSync(ledgerPath, "utf8"); } catch (e) { return { ok: false, records, errors: [`read failed: ${e.message}`] }; }
+
+  if (raw.includes("\r")) push("CRLF is not permitted; lines must end in LF");
+  if (raw.length === 0 || !raw.endsWith("\n")) push("ledger must end with a final LF");
+  const lines = raw.length ? raw.replace(/\n$/, "").split("\n") : [];
+
+  let pubKey = null;
+  let repoRef = null;
+  let prevLine = null;
+  const edgeHashes = new Set();
+  let trailerSeen = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let obj;
+    try { obj = JSON.parse(line); } catch { push(`line ${i + 1}: not valid JSON`); continue; }
+    if (canonicalJson(obj) !== line) { push(`line ${i + 1}: not canonical JSON`); continue; }
+
+    if (i === 0) {
+      if (!obj.clotho_weave_header) { push("line 1: missing header"); break; }
+      const h = obj.clotho_weave_header;
+      header = h;
+      try {
+        pubKey = publicKeyFromB64(h.pub_key);
+        repoRef = h.repository_ref;
+        if (h.weave_version !== 1) push("header: weave_version must be 1");
+        if (!HEX40.test(h.repo_head)) push("header: repo_head must be 40-hex");
+        if (new Date(h.woven_at).toISOString() !== h.woven_at) push("header: woven_at not canonical ISO");
+      } catch (e) { push(`header: ${e.message}`); }
+      prevLine = line;
+      continue;
+    }
+    if (obj.clotho_weave_header) { push(`line ${i + 1}: duplicate header`); continue; }
+    if (trailerSeen) { push(`line ${i + 1}: record after trailer (trailer must be final)`); continue; }
+
+    // chain + signature envelope
+    const { prev_hash, record_hash, signature, ...payload } = obj;
+    if (typeof prev_hash !== "string" || prev_hash !== hexOf(prevLine)) push(`line ${i + 1}: broken chain (prev_hash mismatch)`);
+    if (typeof record_hash !== "string" || record_hash !== hexOf(canonicalJson({ ...payload, prev_hash }))) push(`line ${i + 1}: record_hash mismatch`);
+    let sigOk = false;
+    try { sigOk = typeof signature === "string" && pubKey && edVerify(null, Buffer.from(record_hash, "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
+    if (!sigOk) push(`line ${i + 1}: invalid signature`);
+
+    if (obj.clotho_weave_trailer) {
+      manifest = obj.clotho_weave_trailer;
+      try { validateCoverage(manifest, new Set()); } catch (e) { push(`trailer: ${e.message}`); }
+      trailerSeen = true;
+    } else if ("status_of" in payload) {
+      if (!edgeHashes.has(payload.status_of)) push(`line ${i + 1}: status_of does not reference an earlier edge`);
+      if (payload.asserted_by !== "human" || payload.assertion_status !== "human-authorized") push(`line ${i + 1}: status must be human-authorized adjudication`);
+      if (!STATUS_TRANSITIONS.has(payload.new_status)) push(`line ${i + 1}: invalid new_status`);
+    } else {
+      // edge record: re-validate structure/endpoints against the header repo ref
+      try {
+        const { woven_at, ...edgeInput } = payload;
+        validateEdgeInput(edgeInput, { repositoryRef: repoRef });
+      } catch (e) { push(`line ${i + 1}: ${e.message}`); }
+      edgeHashes.add(record_hash);
+    }
+    records.push(obj);
+    prevLine = line;
+  }
+
+  if (lines.length > 0 && !trailerSeen) push("ledger has no final trailer");
+  return { ok: errors.length === 0, header, manifest, records, errors };
+}
+
+// ---- readEdges ---------------------------------------------------------------
+// Yields edge records structurally (not trust-conferring — callers verify).
+
+export async function* readEdges(ledgerPath, { openReadStream } = {}) {
+  let text;
+  if (openReadStream) {
+    let buf = "";
+    for await (const chunk of openReadStream(ledgerPath)) buf += chunk.toString("utf8");
+    text = buf;
+  } else {
+    text = readFileSync(ledgerPath, "utf8");
+  }
+  const lines = text.length ? text.replace(/\n$/, "").split("\n") : [];
+  for (const line of lines) {
+    let obj;
+    try { obj = JSON.parse(line); } catch { continue; }
+    if (obj.clotho_weave_header || obj.clotho_weave_trailer) continue;
+    if ("status_of" in obj) continue;
+    yield obj;
+  }
+}

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -34,6 +34,17 @@ const STATUS_TRANSITIONS = new Set(["human-authorized", "rejected", "superseded"
 // The five weaver ids in their stable declared (inventory) order. Task 3's
 // coverage carries exactly these five, in this order (v12 Task 3).
 const WEAVER_ORDER = ["clotho-git-weaver", "clotho-code-weaver", "clotho-test-weaver", "clotho-doc-weaver", "clotho-ledger-weaver"];
+// The frozen per-weaver required inventory-id table (v12 D24/D26/D31), sorted.
+// Task 3 requires each weaver's inspected_source_counts to carry EXACTLY these
+// ids (structure only — count cardinalities and committed-inventory equality are
+// the Task 5 driver's job, D19/D26/D29).
+const REQUIRED_INVENTORY_IDS = {
+  "clotho-git-weaver": ["package-files", "package-symbols"],
+  "clotho-code-weaver": ["package-modules"],
+  "clotho-test-weaver": ["package-manifests", "test-files"],
+  "clotho-doc-weaver": ["doc-files"],
+  "clotho-ledger-weaver": ["contract-files", "ledger-sources", "run-sources"]
+};
 
 // ---- crypto + line helpers ---------------------------------------------------
 
@@ -67,7 +78,7 @@ function requireFileRef(ref, label) {
   if (typeof ref !== "string" || !FILE_REF.test(ref)) throw new TypeError(`${label}: expected 'file:<path>@<40-hex>', got ${JSON.stringify(ref)}`);
 }
 
-function requireInspectedSourceCounts(counts, state, label) {
+function requireInspectedSourceCounts(counts, state, requiredIds, label) {
   if (!Array.isArray(counts)) throw new TypeError(`${label}: inspected_source_counts must be an array`);
   let prevId = null;
   for (const entry of counts) {
@@ -79,6 +90,13 @@ function requireInspectedSourceCounts(counts, state, label) {
     if (prevId !== null && entry.inventory_id <= prevId) throw new TypeError(`${label}: inspected_source_counts must be sorted and unique by inventory_id`);
     prevId = entry.inventory_id;
     if (state === "skipped" && entry.count !== 0) throw new TypeError(`${label}: skipped weaver must carry zero counts`);
+  }
+  // Exactly the weaver's frozen required inventory ids — no missing, no extra
+  // (the ids are already proven sorted+unique above, so a length + positional
+  // match is exact). Count cardinalities remain out of scope here (Task 5).
+  const ids = counts.map((e) => e.inventory_id);
+  if (ids.length !== requiredIds.length || ids.some((id, i) => id !== requiredIds[i])) {
+    throw new TypeError(`${label}: inspected_source_counts must carry exactly [${requiredIds.join(", ")}], got [${ids.join(", ")}]`);
   }
 }
 
@@ -103,7 +121,7 @@ function validateCoverage(coverage, weaverEdgeIds) {
     if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver[${w.id}].state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
     if (!Array.isArray(w.implementation_refs) || w.implementation_refs.length === 0) throw new TypeError(`coverage weaver[${w.id}].implementation_refs: nonempty array`);
     for (const r of w.implementation_refs) requireFileRef(r, `coverage weaver[${w.id}].implementation_refs`);
-    requireInspectedSourceCounts(w.inspected_source_counts, w.state, `coverage weaver[${w.id}]`);
+    requireInspectedSourceCounts(w.inspected_source_counts, w.state, REQUIRED_INVENTORY_IDS[w.id], `coverage weaver[${w.id}]`);
     if (w.state === "skipped" && weaverEdgeIds.has(w.id)) throw new TypeError(`coverage weaver[${w.id}]: recorded 'skipped' but asserted an edge in this ledger`);
   }
   if (!Array.isArray(orchestrator_refs) || orchestrator_refs.length === 0) throw new TypeError("coverage.orchestrator_refs: nonempty array");
@@ -266,6 +284,8 @@ export async function verifyLedger(ledgerPath) {
     let sigOk = false;
     try { sigOk = typeof signature === "string" && !!pubKey && edVerify(null, Buffer.from(record_hash || "", "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
     if (!sigOk) bad(`line ${i + 1}: invalid signature`);
+    // every record's woven_at must equal the header's single canonical timestamp
+    if (payload.woven_at !== header.woven_at) bad(`line ${i + 1}: woven_at does not equal the header woven_at`);
 
     if (obj.clotho_weave_trailer) {
       manifest = obj.clotho_weave_trailer;

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -28,7 +28,9 @@ import {
 
 const HEX40 = /^[0-9a-f]{40}$/;
 const HEX64 = /^[0-9a-f]{64}$/;
+const REPO_REF = /^git-root:[0-9a-f]{40}$/;
 const FILE_REF = /^file:(.+)@([0-9a-f]{40})$/;
+const HEADER_FIELDS = ["pub_key", "woven_at", "repo_head", "repository_ref", "weave_version"];
 const PUBLISHED_STATES = new Set(["executed", "skipped"]);
 const STATUS_TRANSITIONS = new Set(["human-authorized", "rejected", "superseded"]);
 // The five weaver ids in their stable declared (inventory) order. Task 3's
@@ -165,6 +167,7 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
   const repo_head = repoHead ?? String(git(["rev-parse", "HEAD"])).trim();
   if (!HEX40.test(repo_head)) throw new TypeError(`createLedger: repo_head must be a 40-hex commit, got ${JSON.stringify(repo_head)}`);
   const repo_ref = repositoryRef ?? deriveRepositoryRef(git);
+  if (!REPO_REF.test(repo_ref)) throw new TypeError(`createLedger: repository_ref must be 'git-root:<40-hex>', got ${JSON.stringify(repo_ref)}`);
 
   if (openFile === defaultOpenFile) mkdirSync(path.dirname(path.resolve(ledgerPath)), { recursive: true });
   const handle = openFile(ledgerPath); // wx is the atomic existence gate
@@ -261,14 +264,19 @@ export async function verifyLedger(ledgerPath) {
     if (canonicalJson(obj) !== line) { fail(`line ${i + 1}: not canonical JSON`); continue; }
 
     if (i === 0) {
-      if (!obj.clotho_weave_header) { fail("line 1: missing header"); break; }
+      if (Object.keys(obj).length !== 1 || !obj.clotho_weave_header) { fail("line 1: header envelope must be exactly {clotho_weave_header}"); break; }
       header = obj.clotho_weave_header;
       try {
+        if (header === null || typeof header !== "object" || Array.isArray(header)) throw new Error("must be an object");
+        for (const k of Object.keys(header)) if (!HEADER_FIELDS.includes(k)) throw new Error(`unexpected field '${k}'`);
+        for (const k of HEADER_FIELDS) if (!(k in header)) throw new Error(`missing field '${k}'`);
+        if (typeof header.repository_ref !== "string" || !REPO_REF.test(header.repository_ref)) throw new Error("repository_ref must be 'git-root:<40-hex>'");
         pubKey = publicKeyFromB64(header.pub_key);
+        if (pubKey.asymmetricKeyType !== "ed25519") throw new Error("pub_key must be an Ed25519 SPKI key");
         repoRef = header.repository_ref;
-        if (header.weave_version !== 1) fail("header: weave_version must be 1");
-        if (!HEX40.test(header.repo_head)) fail("header: repo_head must be 40-hex");
-        if (new Date(header.woven_at).toISOString() !== header.woven_at) fail("header: woven_at not canonical ISO");
+        if (header.weave_version !== 1) throw new Error("weave_version must be 1");
+        if (!HEX40.test(header.repo_head)) throw new Error("repo_head must be 40-hex");
+        if (new Date(header.woven_at).toISOString() !== header.woven_at) throw new Error("woven_at not canonical ISO");
       } catch (e) { fail(`header: ${e.message}`); }
       prevLine = line;
       continue;
@@ -288,28 +296,30 @@ export async function verifyLedger(ledgerPath) {
     if (payload.woven_at !== header.woven_at) bad(`line ${i + 1}: woven_at does not equal the header woven_at`);
 
     if (obj.clotho_weave_trailer) {
-      manifest = obj.clotho_weave_trailer;
-      try { validateCoverage(manifest, weaverEdgeIds); } catch (e) { bad(`trailer: ${e.message}`); }
+      if (Object.keys(payload).length !== 2 || !("clotho_weave_trailer" in payload) || !("woven_at" in payload)) bad(`line ${i + 1}: trailer envelope must be exactly {clotho_weave_trailer, woven_at}`);
+      try { validateCoverage(obj.clotho_weave_trailer, weaverEdgeIds); } catch (e) { bad(`trailer: ${e.message}`); }
+      // trust is not conferred on a manifest that appears after a failing line
+      if (lineOk && !trustBroken) manifest = obj.clotho_weave_trailer;
       trailerSeen = true;
-      // trailer is never added to `records`
+      // the trailer is never added to `records`
     } else if ("status_of" in payload) {
       try { validateStatusInput(payload_forStatus(payload), edgeHashes); } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
       if (lineOk && !trustBroken) records.push(obj);
     } else {
-      try {
-        const edgeInput = withoutWovenAt(payload);
-        validateEdgeInput(edgeInput, { repositoryRef: repoRef });
-        if (lineOk) {
-          edgeHashes.add(record_hash);
-          if (payload.assertion_status === "deterministic-extraction") weaverEdgeIds.add(payload.asserted_by);
-        }
-      } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
-      if (lineOk && !trustBroken) records.push(obj);
+      try { validateEdgeInput(withoutWovenAt(payload), { repositoryRef: repoRef }); } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
+      if (lineOk && !trustBroken) {          // freeze ALL trust state at the first failure
+        edgeHashes.add(record_hash);
+        if (payload.assertion_status === "deterministic-extraction") weaverEdgeIds.add(payload.asserted_by);
+        records.push(obj);
+      }
     }
     prevLine = line;
   }
 
   if (!trailerSeen) errors.push("ledger has no final trailer");
+  // never confer trust on a manifest from an invalid ledger (e.g. a non-final
+  // trailer): a record after the trailer breaks trust and nulls the manifest.
+  if (errors.length > 0) manifest = null;
   return { ok: errors.length === 0, header, manifest, records, errors };
 }
 

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -18,7 +18,7 @@
 // driver's job.
 
 import { createHash, generateKeyPairSync, sign as edSign, verify as edVerify, createPublicKey, createPrivateKey } from "node:crypto";
-import { openSync, writeSync, fsyncSync, closeSync, readFileSync, mkdirSync, createReadStream } from "node:fs";
+import { openSync, writeSync, fsyncSync, closeSync, mkdirSync, createReadStream } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
@@ -234,7 +234,7 @@ export function createLedger(ledgerPath, { signKey, wovenAt, repoHead, repositor
 // header or trailer). On the first failing line it stops conferring trust: no
 // record on or after that line is added, and ok is false.
 
-export async function verifyLedger(ledgerPath) {
+export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
   const errors = [];
   const records = [];
   let header = null;
@@ -242,66 +242,64 @@ export async function verifyLedger(ledgerPath) {
   let trustBroken = false;
   const fail = (m) => { errors.push(m); trustBroken = true; };
 
-  let raw;
-  try { raw = readFileSync(ledgerPath, "utf8"); } catch (e) { return { ok: false, header: null, manifest: null, records, errors: [`read failed: ${e.message}`] }; }
-
-  if (raw.length === 0) return { ok: false, header: null, manifest: null, records, errors: ["empty ledger"] };
-  if (raw.includes("\r")) errors.push("CRLF is not permitted; lines must end in LF");
-  if (!raw.endsWith("\n")) errors.push("ledger must end with a final LF");
-  const lines = raw.replace(/\n$/, "").split("\n");
-
   let pubKey = null;
   let repoRef = null;
   let prevLine = null;
+  let lineIndex = 0;
+  let sawCR = false;
   const edgeHashes = new Set();
   const weaverEdgeIds = new Set();
   let trailerSeen = false;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
+  // Process exactly one complete line (no trailing LF). Never throws.
+  const processLine = (line) => {
+    const i = lineIndex++;
     let obj;
-    try { obj = JSON.parse(line); } catch { fail(`line ${i + 1}: not valid JSON`); continue; }
-    if (canonicalJson(obj) !== line) { fail(`line ${i + 1}: not canonical JSON`); continue; }
+    try { obj = JSON.parse(line); } catch { fail(`line ${i + 1}: not valid JSON`); prevLine = line; return; }
+    if (obj === null || typeof obj !== "object" || Array.isArray(obj)) { fail(`line ${i + 1}: record must be a JSON object`); prevLine = line; return; }
+    let canon;
+    try { canon = canonicalJson(obj); } catch { fail(`line ${i + 1}: not canonicalizable`); prevLine = line; return; }
+    if (canon !== line) { fail(`line ${i + 1}: not canonical JSON`); prevLine = line; return; }
 
     if (i === 0) {
-      if (Object.keys(obj).length !== 1 || !obj.clotho_weave_header) { fail("line 1: header envelope must be exactly {clotho_weave_header}"); break; }
-      header = obj.clotho_weave_header;
+      const h = obj.clotho_weave_header;
+      if (Object.keys(obj).length !== 1 || h === null || typeof h !== "object" || Array.isArray(h)) { fail("line 1: header envelope must be exactly {clotho_weave_header:{...}}"); prevLine = line; return; }
       try {
-        if (header === null || typeof header !== "object" || Array.isArray(header)) throw new Error("must be an object");
-        for (const k of Object.keys(header)) if (!HEADER_FIELDS.includes(k)) throw new Error(`unexpected field '${k}'`);
-        for (const k of HEADER_FIELDS) if (!(k in header)) throw new Error(`missing field '${k}'`);
-        if (typeof header.repository_ref !== "string" || !REPO_REF.test(header.repository_ref)) throw new Error("repository_ref must be 'git-root:<40-hex>'");
-        pubKey = publicKeyFromB64(header.pub_key);
+        for (const k of Object.keys(h)) if (!HEADER_FIELDS.includes(k)) throw new Error(`unexpected field '${k}'`);
+        for (const k of HEADER_FIELDS) if (!(k in h)) throw new Error(`missing field '${k}'`);
+        if (typeof h.repository_ref !== "string" || !REPO_REF.test(h.repository_ref)) throw new Error("repository_ref must be 'git-root:<40-hex>'");
+        pubKey = publicKeyFromB64(h.pub_key);
         if (pubKey.asymmetricKeyType !== "ed25519") throw new Error("pub_key must be an Ed25519 SPKI key");
-        repoRef = header.repository_ref;
-        if (header.weave_version !== 1) throw new Error("weave_version must be 1");
-        if (!HEX40.test(header.repo_head)) throw new Error("repo_head must be 40-hex");
-        if (new Date(header.woven_at).toISOString() !== header.woven_at) throw new Error("woven_at not canonical ISO");
+        if (h.weave_version !== 1) throw new Error("weave_version must be 1");
+        if (!HEX40.test(h.repo_head)) throw new Error("repo_head must be 40-hex");
+        if (new Date(h.woven_at).toISOString() !== h.woven_at) throw new Error("woven_at not canonical ISO");
+        header = h; repoRef = h.repository_ref;
       } catch (e) { fail(`header: ${e.message}`); }
       prevLine = line;
-      continue;
+      return;
     }
-    if (obj.clotho_weave_header) { fail(`line ${i + 1}: duplicate header`); continue; }
-    if (trailerSeen) { fail(`line ${i + 1}: record after trailer (trailer must be final)`); continue; }
+
+    if (header === null) { fail(`line ${i + 1}: record precedes a valid header`); prevLine = line; return; }
+    if (obj.clotho_weave_header) { fail(`line ${i + 1}: duplicate header`); prevLine = line; return; }
+    if (trailerSeen) { fail(`line ${i + 1}: record after trailer (trailer must be final)`); prevLine = line; return; }
 
     const { prev_hash, record_hash, signature, ...payload } = obj;
     let lineOk = true;
     const bad = (m) => { fail(m); lineOk = false; };
     if (typeof prev_hash !== "string" || prev_hash !== hexOf(prevLine)) bad(`line ${i + 1}: broken chain (prev_hash mismatch)`);
-    if (typeof record_hash !== "string" || record_hash !== hexOf(canonicalJson({ ...payload, prev_hash }))) bad(`line ${i + 1}: record_hash mismatch`);
+    let expectHash = null;
+    try { expectHash = hexOf(canonicalJson({ ...payload, prev_hash })); } catch { /* payload not canonicalizable */ }
+    if (typeof record_hash !== "string" || record_hash !== expectHash) bad(`line ${i + 1}: record_hash mismatch`);
     let sigOk = false;
     try { sigOk = typeof signature === "string" && !!pubKey && edVerify(null, Buffer.from(record_hash || "", "hex"), pubKey, Buffer.from(signature, "base64")); } catch { sigOk = false; }
     if (!sigOk) bad(`line ${i + 1}: invalid signature`);
-    // every record's woven_at must equal the header's single canonical timestamp
     if (payload.woven_at !== header.woven_at) bad(`line ${i + 1}: woven_at does not equal the header woven_at`);
 
     if (obj.clotho_weave_trailer) {
       if (Object.keys(payload).length !== 2 || !("clotho_weave_trailer" in payload) || !("woven_at" in payload)) bad(`line ${i + 1}: trailer envelope must be exactly {clotho_weave_trailer, woven_at}`);
       try { validateCoverage(obj.clotho_weave_trailer, weaverEdgeIds); } catch (e) { bad(`trailer: ${e.message}`); }
-      // trust is not conferred on a manifest that appears after a failing line
       if (lineOk && !trustBroken) manifest = obj.clotho_weave_trailer;
-      trailerSeen = true;
-      // the trailer is never added to `records`
+      trailerSeen = true; // the trailer is never added to `records`
     } else if ("status_of" in payload) {
       try { validateStatusInput(payload_forStatus(payload), edgeHashes); } catch (e) { bad(`line ${i + 1}: ${e.message}`); }
       if (lineOk && !trustBroken) records.push(obj);
@@ -314,11 +312,32 @@ export async function verifyLedger(ledgerPath) {
       }
     }
     prevLine = line;
+  };
+
+  // Consume the ledger incrementally; buffer only a partial line. Never throws.
+  let buf = "";
+  try {
+    const stream = openReadStream ? openReadStream(ledgerPath) : createReadStream(ledgerPath, { encoding: "utf8" });
+    for await (const chunk of stream) {
+      const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      if (s.includes("\r")) sawCR = true;
+      buf += s;
+      let nl;
+      while ((nl = buf.indexOf("\n")) !== -1) {
+        processLine(buf.slice(0, nl));
+        buf = buf.slice(nl + 1);
+      }
+    }
+  } catch (e) {
+    return { ok: false, header, manifest: null, records, errors: [...errors, `read failed: ${e.message}`] };
   }
 
+  if (sawCR) errors.push("CRLF is not permitted; lines must end in LF");
+  if (buf.length > 0) errors.push("ledger must end with a final LF"); // an unterminated final record is never trusted
+  if (lineIndex === 0 && buf.length === 0) errors.push("empty ledger");
   if (!trailerSeen) errors.push("ledger has no final trailer");
-  // never confer trust on a manifest from an invalid ledger (e.g. a non-final
-  // trailer): a record after the trailer breaks trust and nulls the manifest.
+  // never confer trust on a manifest from an invalid ledger (non-final trailer,
+  // trailing garbage, any failure): null it whenever any error was recorded.
   if (errors.length > 0) manifest = null;
   return { ok: errors.length === 0, header, manifest, records, errors };
 }

--- a/clotho/thread-ledger.mjs
+++ b/clotho/thread-ledger.mjs
@@ -96,6 +96,27 @@ function defaultOpenFile(ledgerPath) {
 
 // ---- schema validators -------------------------------------------------------
 
+function isPlainObject(v) {
+  if (v === null || typeof v !== "object" || Array.isArray(v)) return false;
+  const p = Object.getPrototypeOf(v);
+  return p === Object.prototype || p === null;
+}
+
+// Exactly the expected OWN ENUMERABLE string keys — rejects own symbols, own
+// non-enumerable fields, extra fields, and enumerable fields inherited through a
+// polluted prototype (matching registry.requireExactKeys' rigor).
+function requireExactOwnKeys(obj, expected, label) {
+  if (!isPlainObject(obj)) throw new TypeError(`${label}: expected a plain object`);
+  if (Object.getOwnPropertySymbols(obj).length > 0) throw new TypeError(`${label}: symbol-keyed fields are not permitted`);
+  for (const k of Object.getOwnPropertyNames(obj)) if (!expected.includes(k)) throw new TypeError(`${label}: unexpected field '${k}'`);
+  for (const k of expected) {
+    const d = Object.getOwnPropertyDescriptor(obj, k);
+    if (!d) throw new TypeError(`${label}: missing field '${k}'`);
+    if (!d.enumerable) throw new TypeError(`${label}: field '${k}' must be own-enumerable`);
+  }
+  for (const k in obj) if (!Object.prototype.hasOwnProperty.call(obj, k)) throw new TypeError(`${label}: inherited enumerable field '${k}' is not permitted`);
+}
+
 // A content-address ref must be a 'file:<repo-relative-path>@<40-hex>' with a
 // canonical POSIX path (no absolute/traversal/backslash/NUL) — delegated to
 // registry.validateSourceRef, the single authoritative source-ref validator.
@@ -108,9 +129,7 @@ function requireInspectedSourceCounts(counts, state, requiredIds, label) {
   if (!Array.isArray(counts)) throw new TypeError(`${label}: inspected_source_counts must be an array`);
   let prevId = null;
   for (const entry of counts) {
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) throw new TypeError(`${label}: count entry must be an object`);
-    const keys = Object.keys(entry);
-    if (keys.length !== 2 || !("inventory_id" in entry) || !("count" in entry)) throw new TypeError(`${label}: count entry must be exactly {inventory_id, count}`);
+    requireExactOwnKeys(entry, ["inventory_id", "count"], `${label} count entry`);
     if (typeof entry.inventory_id !== "string" || entry.inventory_id.length === 0) throw new TypeError(`${label}: inventory_id must be a nonempty string`);
     if (!Number.isSafeInteger(entry.count) || entry.count < 0) throw new TypeError(`${label}: count must be a nonnegative safe integer`);
     if (prevId !== null && entry.inventory_id <= prevId) throw new TypeError(`${label}: inspected_source_counts must be sorted and unique by inventory_id`);
@@ -129,19 +148,13 @@ function requireInspectedSourceCounts(counts, state, requiredIds, label) {
 // Structure-only coverage validation (D19). `weaverEdgeIds` is the set of weaver
 // ids that asserted an edge; a weaver with edges may not be recorded 'skipped'.
 function validateCoverage(coverage, weaverEdgeIds) {
-  if (coverage === null || typeof coverage !== "object" || Array.isArray(coverage)) throw new TypeError("coverage: must be an object");
-  const expected = ["weavers", "orchestrator_refs", "inventories_consumed"];
-  for (const k of Object.keys(coverage)) if (!expected.includes(k)) throw new TypeError(`coverage: unexpected field '${k}'`);
-  for (const k of expected) if (!(k in coverage)) throw new TypeError(`coverage: missing field '${k}'`);
+  requireExactOwnKeys(coverage, ["weavers", "orchestrator_refs", "inventories_consumed"], "coverage");
 
   const { weavers, orchestrator_refs, inventories_consumed } = coverage;
   if (!Array.isArray(weavers) || weavers.length !== 5) throw new TypeError("coverage.weavers: must be exactly five entries");
   for (let i = 0; i < 5; i++) {
     const w = weavers[i];
-    if (w === null || typeof w !== "object" || Array.isArray(w)) throw new TypeError("coverage weaver: must be an object");
-    const wexpected = ["id", "version", "implementation_refs", "state", "inspected_source_counts"];
-    for (const k of Object.keys(w)) if (!wexpected.includes(k)) throw new TypeError(`coverage weaver: unexpected field '${k}'`);
-    for (const k of wexpected) if (!(k in w)) throw new TypeError(`coverage weaver: missing field '${k}'`);
+    requireExactOwnKeys(w, ["id", "version", "implementation_refs", "state", "inspected_source_counts"], "coverage weaver");
     if (w.id !== WEAVER_ORDER[i]) throw new TypeError(`coverage weaver[${i}]: expected id ${WEAVER_ORDER[i]}, got ${JSON.stringify(w.id)}`);
     if (!Number.isSafeInteger(w.version)) throw new TypeError(`coverage weaver[${w.id}].version: safe integer`);
     if (!PUBLISHED_STATES.has(w.state)) throw new TypeError(`coverage weaver[${w.id}].state: must be executed|skipped, got ${JSON.stringify(w.state)}`);
@@ -154,19 +167,14 @@ function validateCoverage(coverage, weaverEdgeIds) {
   for (const r of orchestrator_refs) requireFileRef(r, "coverage.orchestrator_refs");
   if (!Array.isArray(inventories_consumed)) throw new TypeError("coverage.inventories_consumed: must be an array");
   for (const inv of inventories_consumed) {
-    if (inv === null || typeof inv !== "object" || Array.isArray(inv)) throw new TypeError("inventories_consumed entry: object");
-    const ikeys = Object.keys(inv);
-    if (ikeys.length !== 2 || !("id" in inv) || !("source_ref" in inv)) throw new TypeError("inventories_consumed entry: exactly {id, source_ref}");
+    requireExactOwnKeys(inv, ["id", "source_ref"], "inventories_consumed entry");
     if (typeof inv.id !== "string" || inv.id.length === 0) throw new TypeError("inventories_consumed.id: nonempty string");
     requireFileRef(inv.source_ref, "inventories_consumed.source_ref");
   }
 }
 
 function validateStatusInput(statusInput, edgeHashes) {
-  if (statusInput === null || typeof statusInput !== "object" || Array.isArray(statusInput)) throw new TypeError("statusInput: object");
-  const expected = ["status_of", "new_status", "asserted_by", "assertion_status", "source_ref"];
-  for (const k of Object.keys(statusInput)) if (!expected.includes(k)) throw new TypeError(`statusInput: unexpected field '${k}'`);
-  for (const k of expected) if (!(k in statusInput)) throw new TypeError(`statusInput: missing field '${k}'`);
+  requireExactOwnKeys(statusInput, ["status_of", "new_status", "asserted_by", "assertion_status", "source_ref"], "statusInput");
   if (typeof statusInput.status_of !== "string" || !HEX64.test(statusInput.status_of)) throw new TypeError("statusInput.status_of: 64-hex record hash");
   if (!edgeHashes.has(statusInput.status_of)) throw new TypeError("statusInput.status_of: must reference an earlier edge record in this ledger");
   if (!STATUS_TRANSITIONS.has(statusInput.new_status)) throw new TypeError(`statusInput.new_status: must be one of ${[...STATUS_TRANSITIONS].join("|")}`);
@@ -339,7 +347,7 @@ export async function verifyLedger(ledgerPath, { openReadStream } = {}) {
     if (payload.woven_at !== header.woven_at) bad(`line ${i + 1}: woven_at does not equal the header woven_at`);
 
     if (obj.clotho_weave_trailer) {
-      if (Object.keys(payload).length !== 2 || !("clotho_weave_trailer" in payload) || !("woven_at" in payload)) bad(`line ${i + 1}: trailer envelope must be exactly {clotho_weave_trailer, woven_at}`);
+      try { requireExactOwnKeys(payload, ["clotho_weave_trailer", "woven_at"], `line ${i + 1}: trailer envelope`); } catch (e) { bad(e.message); }
       try { validateCoverage(obj.clotho_weave_trailer, weaverEdgeIds); } catch (e) { bad(`trailer: ${e.message}`); }
       if (lineOk && !trustBroken) manifest = obj.clotho_weave_trailer;
       trailerSeen = true; // the trailer is never added to `records`


### PR DESCRIPTION
> **HELD — implementation PR (Task 3).** Awaits deterministic gate + required-seat review + The Eye's acceptance (per-task cadence, #109).

## Traceability
- Plan v12 `sha256:bdc93901…`; authz-005; Eye decision #109. Decisions **D5/D19/D20/D22/D24/D28/D29**.

## What this builds (v12 Task 3)
`clotho/thread-ledger.mjs` — signed, append-only, hash-chained canonical-JSONL ledger (zero-dependency; `node:crypto` Ed25519 — merkle-dag/crypto.mjs implements a different envelope + no chaining, so per v12 signing is done directly; `canonicalJson`/validators reused from `registry.mjs`):
- `createLedger(path, {signKey?, wovenAt?, repoHead?, repositoryRef?})` → `{header, appendEdge, appendStatus, close, abort}`
- Header (SPKI-b64 pub_key, one `woven_at`/`repo_head`/`repository_ref`, `weave_version:1`); edge/status records = payload + `prev_hash` (sha256 of prior line) + `record_hash` (sha256 of `canonicalJson(payload+prev_hash)`) + Ed25519 signature over the raw 32-byte digest; LF-terminated; chain over the complete signed line.
- `close(coverage)` — **D19 generic** validation against injected fixture coverage (5 weavers, `executed|skipped`, **D24** `inspected_source_counts` schema, `file:` content-address refs); rejects `failed` and a skipped weaver that produced edges; **no committed-inventory dependency**.
- `abort()` idempotent; every append/close failure poisons + closes the descriptor (**D22**); exclusive `wx` creation.
- `verifyLedger` — canonical encoding, single header, chain + signature, human-only status adjudication, endpoint re-validation, D24 schema, one final trailer, CRLF/missing-LF errors. `readEdges` yields edges structurally.

## Acceptance criteria (v12 Task 3 exit — verified)
- [x] ledger tests green against injected fixture coverage
- [x] every failure path closes its descriptor (abort/poison)
- [x] references no committed inventory (D19)
- [x] `npm test` green; diff confined to `clotho/`; zero deps; no spine change
- [x] deterministic gate `meets` (11/11)

Note: atomic no-replace publication (D20/D28) is the driver's job (Task 5 `weave.mjs`), not this ledger primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)