### PR TITLE
Clotho authz-008: TELOS re-authorization of plan v15 (AUTHORIZED)

### DIFF
--- a/docs/runs/clotho-authorization-8/agy.json
+++ b/docs/runs/clotho-authorization-8/agy.json
@@ -1,0 +1,31 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "model": "agy",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "provenance": {
+    "provider": "local",
+    "model": "agy-checkpoint",
+    "source": "ai-peer-mcp/agy_checkpoint",
+    "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+    "answered_at": null,
+    "attestation": "local-deterministic",
+    "engine_version": "agy-checkpoint/1",
+    "tool": "agy_checkpoint"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "378cb0d1af963cec4f0c103501c8a2dba35e36d138171e6ce50c06d05e9715df",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-8/authorization-summary.json
+++ b/docs/runs/clotho-authorization-8/authorization-summary.json
@@ -1,0 +1,139 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "objective": "Re-authorize Argo execution of the Clotho Phase 1 implementation plan v15 (content address sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3; released by The Eye via PR #121, squash-merge bb265b9; extends authz-006 which authorized v13; SUPERSEDES the NOT_AUTHORIZED authz-007). v15 = v14 + The Eye's AM-41 SHEBANG CARVE-OUT. v14 carried AM-41 (the enforced closed source profile: the shared D33 scanner is required correct ONLY over a closed, mechanically enforced module-lexical source profile, rejecting every out-of-profile construct deterministically with 'unsupported-module-lexical-profile'). authz-007 correctly returned NOT_AUTHORIZED because AM-41's blanket hashbang rejection contradicted Task 5's requirement that clotho/weave.mjs (a closure entry point) carry a Node shebang. AM-41 is now refined: the scanner admits AT MOST ONE optional leading shebang line, permitted ONLY when '#!' begins at byte offset 0, is the first line, and terminates with LF or CRLF (removed before lexical classification, per Node's executable-module convention); a raw '#!' in code position ANYWHERE ELSE (preceding whitespace, not byte-0/not-line-1, or a second '#!' line) fails closed. Per The Eye's explicit ruling, a '#!' occurring inside a recognized string literal or comment is NOT a hashbang (it is ordinary string/comment content, in-profile) — this is deliberate and authorized, not an out-of-profile case. This resolves the authz-007 contradiction (weave.mjs keeps its shebang and derives its closure) WITHOUT broadening the scanner into a full ES parser and WITHOUT overriding the codex seat. v15 differs from the already-reviewed v14 at EXACTLY the two AM-41-block edits (the accepted-grammar leading-shebang admission + the b2 hashbang carve-out; 20 lines); the rest of AM-41 and every other frozen decision is reaffirmed unchanged (AM-40 PACKAGE_ROOTS; advisory / non-sandboxed posture per AM-35..AM-39; D17/AM-17; D24/D26/D31; D32; the D33 accepted-form set; zero-dependency; spine read-only). Judge v15 on ITS OWN advisory/non-sandbox terms — do NOT require it to prove loader isolation, and do NOT require a full ES parser beyond the frozen closed-profile bar. Approve ONLY if the plan is implementation-ready and consistent with its governing spec (v2.8, advisory posture), the repository's trust model (fail-closed, closed sets, spine read-only, advisory-only Clotho), and its own decisions and exit criteria — with AM-41 (incl. the shebang carve-out) correctly defining the scanner's enforced correctness domain and NO remaining plan contradiction.",
+  "plan_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "merge_anchor": "bb265b9",
+  "reviewed_head": "bb265b9",
+  "extends": "authz-006",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "trust_mode": "signed",
+  "ephemeral_signers": [
+    "claude",
+    "agy",
+    "codex"
+  ],
+  "seats": [
+    {
+      "model": "claude",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "anthropic",
+        "model": "claude-fable-5",
+        "response_id": "msg_011Cd6teRvrpEcXoWrEY5wnD",
+        "source": "ai-peer-mcp/claude_ask",
+        "answered_at": "2026-07-17T03:07:02.184Z",
+        "tool": "claude_ask"
+      }
+    },
+    {
+      "model": "agy",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "local",
+        "model": "agy-checkpoint",
+        "source": "ai-peer-mcp/agy_checkpoint",
+        "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+        "answered_at": null,
+        "attestation": "local-deterministic",
+        "engine_version": "agy-checkpoint/1",
+        "tool": "agy_checkpoint"
+      }
+    },
+    {
+      "model": "codex",
+      "role": "approver",
+      "ok": true,
+      "signed": true,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "openai",
+        "model": "gpt-5.6-sol",
+        "response_id": "chatcmpl-E2TCO8xdtafkjLDqsFbfjImjVh4h6",
+        "source": "ai-peer-mcp/codex_ask",
+        "answered_at": "2026-07-17T03:07:27.047Z",
+        "tool": "codex_ask"
+      }
+    },
+    {
+      "model": "grok",
+      "role": "advisory",
+      "ok": true,
+      "signed": false,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "xai",
+        "model": "grok-4.5",
+        "response_id": "46195833-3bd3-99e1-a9d5-0836797e9b22",
+        "source": "ai-peer-mcp/grok_ask",
+        "answered_at": "2026-07-17T03:06:56.030Z",
+        "tool": "grok_ask"
+      }
+    },
+    {
+      "model": "gemini",
+      "role": "advisory",
+      "ok": true,
+      "signed": false,
+      "decision": "approve",
+      "confidence": "high",
+      "provenance": {
+        "provider": "google",
+        "model": "gemini-3.1-pro-preview",
+        "response_id": "RJxZaq5kuYbPsg_QwLrZAg",
+        "source": "ai-peer-mcp/gemini_ask",
+        "answered_at": "2026-07-17T03:06:52.056Z",
+        "tool": "gemini_ask"
+      }
+    }
+  ],
+  "gate": {
+    "gate_status": "pass",
+    "signing_enforced": true,
+    "provenance_enforced": true,
+    "blockers": [],
+    "warnings": [],
+    "provenance": [
+      {
+        "model": "claude",
+        "has_provenance": true,
+        "provider": "anthropic",
+        "response_model": "claude-fable-5",
+        "response_id": "msg_011Cd6teRvrpEcXoWrEY5wnD",
+        "source": "ai-peer-mcp/claude_ask"
+      },
+      {
+        "model": "agy",
+        "has_provenance": true,
+        "provider": "local",
+        "response_model": "agy-checkpoint",
+        "response_id": "agy-8da53012afb65f4f76c6c26f201d7099bbea1a80",
+        "source": "ai-peer-mcp/agy_checkpoint"
+      },
+      {
+        "model": "codex",
+        "has_provenance": true,
+        "provider": "openai",
+        "response_model": "gpt-5.6-sol",
+        "response_id": "chatcmpl-E2TCO8xdtafkjLDqsFbfjImjVh4h6",
+        "source": "ai-peer-mcp/codex_ask"
+      }
+    ]
+  },
+  "authorized": true,
+  "authorization": {
+    "status": "AUTHORIZED",
+    "plan_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+    "note": "Argo execution of Clotho Phase 1 plan v13 is authorized by the signed council under the TELOS gate; extends authz-006."
+  }
+}

--- a/docs/runs/clotho-authorization-8/claude.json
+++ b/docs/runs/clotho-authorization-8/claude.json
@@ -1,0 +1,30 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "model": "claude",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "rationale": "The single blocking defect that made authz-007 return NOT_AUTHORIZED — AM-41's blanket hashbang rejection contradicting Task 5's requirement that clotho/weave.mjs carry a Node shebang — is resolved cleanly and minimally in v15. I verified the resolution on the plan text itself: (1) AM-41(a) now admits at most one optional leading shebang line, permitted only at byte offset 0 on the first line terminated by LF/CRLF, removed before lexical classification, which matches Node's actual executable-module convention and covers exactly the weave.mjs case; (2) AM-41(b2) is correspondingly narrowed to reject '#!' anywhere OTHER than that single permitted position (preceding whitespace, non-byte-0/non-line-1, or a second '#!' line), preserving determinism and the fail-closed posture; (3) The Eye's explicit ruling that '#!' inside a recognized string literal or comment is ordinary content, not a hashbang, is lexically coherent — once the scanner correctly tracks string/comment state (which the profile already requires for every other decision, e.g. b6 unterminated constructs and the regex-vs-division rule), '#!' in those contexts is unambiguous content, so admitting it neither widens the enforcement gap nor requires parser sophistication beyond the frozen closed-profile bar. The carve-out does not weaken the closed profile: the out-of-profile set (b1–b6) remains exact and enumerable, the stable 'unsupported-module-lexical-profile' diagnostic is unchanged, and clause (d) still demands proof of both correct in-profile classification and fail-closed rejection of every enumerated out-of-profile construct, which now includes the misplaced-hashbang cases as explicit test obligations. The two edits are tightly scoped (the accepted-grammar admission plus the b2 refinement), and everything else — AM-40 PACKAGE_ROOTS, the advisory non-sandbox posture per AM-35..AM-39, D17 inventory-existence discipline, D24/D26/D31 count semantics, D32's frozen loader mapping, the D33 accepted-form set and shared classifier/resolver, D34 publication-time re-derivation, zero-dependency, and spine read-only — is reaffirmed unchanged from the already-reviewed v14. Judged on its own advisory/non-sandboxed terms as instructed, the plan is internally consistent: the scanner's correctness domain is now a well-defined closed profile with no contradiction between the profile and any file the plan itself requires to exist (weave.mjs keeps its shebang and derives its closure after shebang stripping); D14/D33/D34 provenance closure, D29 consumption accounting, D10/AM-39 attribution binding, D20/D28 publication semantics, and D35 coverage schema all compose without circularity; task ordering respects D17 (no inventory names a nonexistent file, orchestrator inventory lands with weave.mjs in Task 5); and the exit criteria are mechanically checkable. Residual risks (symlink/TOCTOU races, closure inflation, cleanup-incomplete residue) are explicitly bounded and acceptable for advisory, git-ignored output. I checked for second-order effects of the carve-out and found none: shebang stripping occurs before classification so it cannot create a false module-load edge; a shebang line cannot smuggle an accepted form since it is removed, not scanned; and the byte-0 requirement means the admission is decidable without lookahead. Implementation-ready as-is; approving unconditionally.",
+  "provenance": {
+    "provider": "anthropic",
+    "model": "claude-fable-5",
+    "response_id": "msg_011Cd6teRvrpEcXoWrEY5wnD",
+    "source": "ai-peer-mcp/claude_ask",
+    "answered_at": "2026-07-17T03:07:02.184Z",
+    "tool": "claude_ask"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "a9804a63e5d24c0cc78a5eb46a43c25055a6786b15c1091ad534eba01047d393",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-8/codex.json
+++ b/docs/runs/clotho-authorization-8/codex.json
@@ -1,0 +1,30 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "model": "codex",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "rationale": "v15 is executable as written. The AM-41 refinement resolves the prior contradiction: Task 5's byte-zero, first-line, LF/CRLF-terminated Node shebang is admitted and removed before lexical classification, while hashbang syntax elsewhere in code remains deterministically rejected. Treating `#!` inside recognized strings or comments as ordinary content is coherent with the closed lexical profile and does not broaden D33 into a full ECMAScript parser. The plan remains consistent with the governing advisory, non-sandbox posture, fail-closed trust model, spine read-only boundary, task sequencing, and exit criteria. No remaining contradiction blocks implementation, so this approval supersedes the prior NOT_AUTHORIZED determination for v14.",
+  "provenance": {
+    "provider": "openai",
+    "model": "gpt-5.6-sol",
+    "response_id": "chatcmpl-E2TCO8xdtafkjLDqsFbfjImjVh4h6",
+    "source": "ai-peer-mcp/codex_ask",
+    "answered_at": "2026-07-17T03:07:27.047Z",
+    "tool": "codex_ask"
+  },
+  "signature": {
+    "alg": "HMAC-SHA256",
+    "value": "a08e515f85d6f16ffb360cc295095583b0ee173cc7e03259917211e634429df6",
+    "signed_fields": "canonical-minus-signature"
+  }
+}

--- a/docs/runs/clotho-authorization-8/gemini.json
+++ b/docs/runs/clotho-authorization-8/gemini.json
@@ -1,0 +1,25 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "model": "gemini",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "rationale": "v15 successfully incorporates AM-41 The Eye's shebang carve-out, resolving the explicit contradiction raised in authz-007. By permitting at most one leading shebang at byte 0 and stripping it before lexical analysis, the plan accommodates Node.js executable modules (like `weave.mjs` from Task 5) without compromising the strictly enforced, mechanically verifiable closed source profile. The rejection of out-of-profile hashbangs is precise and fail-closed. The plan remains completely aligned with its advisory, zero-dependency, non-sandbox constraints and its own definitions of closure provenance. I approve execution as-is.",
+  "provenance": {
+    "provider": "google",
+    "model": "gemini-3.1-pro-preview",
+    "response_id": "RJxZaq5kuYbPsg_QwLrZAg",
+    "source": "ai-peer-mcp/gemini_ask",
+    "answered_at": "2026-07-17T03:06:52.056Z",
+    "tool": "gemini_ask"
+  }
+}

--- a/docs/runs/clotho-authorization-8/grok.json
+++ b/docs/runs/clotho-authorization-8/grok.json
@@ -1,0 +1,25 @@
+{
+  "build_id": "clotho-phase-1-authz-008",
+  "use_case": "clotho-phase-1",
+  "model": "grok",
+  "role": "approver",
+  "docs_reviewed": [
+    "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md",
+    "docs/clotho-phase-1-design.md"
+  ],
+  "proposal_ref": "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3",
+  "decision": "approve",
+  "required_edits": [],
+  "hard_stops": [],
+  "confidence": "high",
+  "timestamp": "2026-07-17T03:06:41.301Z",
+  "rationale": "v15 is implementation-ready and free of residual contradiction. The AM-41 shebang carve-out is precisely scoped (at most one leading #! only at byte-0/line-1, LF/CRLF-terminated, stripped before classification; any other raw #! fails closed with unsupported-module-lexical-profile; #! inside string/comment remains ordinary in-profile content) and directly resolves the authz-007 clash with Task 5's weave.mjs Node shebang without enlarging the scanner into a full ES parser or relaxing the closed module-lexical profile. All other frozen decisions (AM-40 PACKAGE_ROOTS, advisory/non-sandbox posture of AM-35–39, D17/AM-17, D24/D26/D31, D32, D33 accepted-form set, zero-dep, spine read-only, D34 publication-time re-derivation, D10/AM-39 producer attribution, D35 coverage schema, etc.) are reaffirmed unchanged. The plan stays strictly within its governing v2.8 advisory terms, the repository trust model (fail-closed, closed sets, content-addressed provenance, no isolation claims), and its own exit criteria. No further edits or hard stops are required; execute as-is.",
+  "provenance": {
+    "provider": "xai",
+    "model": "grok-4.5",
+    "response_id": "46195833-3bd3-99e1-a9d5-0836797e9b22",
+    "source": "ai-peer-mcp/grok_ask",
+    "answered_at": "2026-07-17T03:06:56.030Z",
+    "tool": "grok_ask"
+  }
+}

--- a/docs/runs/clotho-authorization-8/run-authorization-8.mjs
+++ b/docs/runs/clotho-authorization-8/run-authorization-8.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+// TELOS re-authorization run for Clotho Phase 1 plan v13 (authz-007).
+//
+// Sequence: Task 4a implementation surfaced a genuine frozen-scope ambiguity ->
+// The Eye ruled (PACKAGE_ROOTS = TELOS spine) -> Daedalus delta-12 integrated the
+// ruling (AM-40) into v12 -> The Eye released v13 (PR #118 squash-merged 226d18b)
+// -> TELOS RE-AUTHORIZES (this run) -> Argo resumes Task 4a. A real signed council
+// over the plan's content address: claude/agy/codex REQUIRED approvers,
+// grok/gemini advisory. Every chat seat reviews the FULL v13 plan text and returns
+// a strict JSON approval packet bound to its own real provenance; agy is the local
+// deterministic governance checkpoint derived from the dossier. The gate
+// (trust_mode "signed") certifies from packets + signatures + provenance — never a
+// seat's self-report. Fail-closed: any missing required packet, invalid signature,
+// placeholder provenance, or non-approve decision leaves v13 UNAUTHORIZED.
+//
+// v13 = v12 + AM-40 only. v12's terms are unchanged (advisory, non-sandboxed, no
+// claim of proven loader isolation). AM-40 narrows PACKAGE_ROOTS to the five
+// TELOS-spine packages with an explicit, mechanically-proven exclusion of the
+// three sibling products, deferred for conscious enrollment at the Iliad. Judge
+// v13 on ITS OWN terms.
+//
+// Run from Windows node (loadWin32Env pulls API keys + TELOS_SECRET_* from HKCU).
+
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+
+process.env.AI_PEER_LONG_TIMEOUT = "1";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "../../..");
+const imp = (rel) => import(pathToFileURL(path.join(ROOT, rel)).href);
+
+await imp("connectors/ai-peer-mcp/server.mjs");
+const { canonicalize, sha256hex } = await imp("merkle-dag/vendor.mjs");
+const { runCouncil, liveSeatCaller, agyApprovalPacket, agyCheckpointArgs } = await imp("build-gate/council.mjs");
+const { validateRecords } = await imp("build-gate/gate.mjs");
+const { spawnMcpClient } = await imp("breakout/mcp_client.mjs");
+
+// ---------- bind the exact plan under authorization ----------
+const PLAN_PATH = "docs/runs/clotho-daedalus-delta14/matured-plan-v15.md";
+const SPEC_PATH = "docs/clotho-phase-1-design.md";
+const EXPECTED_PLAN_REF = "sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3";
+const MERGE_ANCHOR = "bb265b9"; // PR #120 squash-merge commit
+const REVIEWED_HEAD = "bb265b9"; // v14 reviewed head (delta-13 release)
+const PRIOR_AUTHZ = "authz-006"; const SUPERSEDES = "authz-007"; // v13 authorization this extends
+
+const planText = readFileSync(path.join(ROOT, PLAN_PATH), "utf8");
+const planRef = "sha256:" + sha256hex(canonicalize({ kind: "candidate", plan: planText }));
+if (planRef !== EXPECTED_PLAN_REF) {
+  console.error(`PLAN DRIFT: ${PLAN_PATH} recomputes to ${planRef}, expected ${EXPECTED_PLAN_REF}. Refusing to authorize.`);
+  process.exit(1);
+}
+
+// ---------- signing secrets: real registry values when present, else ephemeral ----------
+const EPHEMERAL_SIGNERS = [];
+for (const m of ["CLAUDE", "AGY", "CODEX"]) {
+  if (!process.env[`TELOS_SECRET_${m}`]) {
+    process.env[`TELOS_SECRET_${m}`] = randomBytes(24).toString("hex");
+    EPHEMERAL_SIGNERS.push(m.toLowerCase());
+  }
+}
+
+const BUILD_ID = "clotho-phase-1-authz-008";
+const USE_CASE = "clotho-phase-1";
+const TIMESTAMP = new Date().toISOString();
+const OBJECTIVE =
+  `Re-authorize Argo execution of the Clotho Phase 1 implementation plan v15 ` +
+  `(content address ${planRef}; released by The Eye via PR #121, squash-merge ${MERGE_ANCHOR}; extends ${PRIOR_AUTHZ} which authorized v13; SUPERSEDES the NOT_AUTHORIZED ${SUPERSEDES}). ` +
+  `v15 = v14 + The Eye's AM-41 SHEBANG CARVE-OUT. v14 carried AM-41 (the enforced closed source profile: the shared D33 scanner is required correct ONLY over a closed, mechanically enforced module-lexical source profile, rejecting every out-of-profile construct deterministically with 'unsupported-module-lexical-profile'). ` +
+  `authz-007 correctly returned NOT_AUTHORIZED because AM-41's blanket hashbang rejection contradicted Task 5's requirement that clotho/weave.mjs (a closure entry point) carry a Node shebang. AM-41 is now refined: the scanner admits AT MOST ONE optional leading shebang line, permitted ONLY when '#!' begins at byte offset 0, is the first line, and terminates with LF or CRLF (removed before lexical classification, per Node's executable-module convention); a raw '#!' in code position ANYWHERE ELSE (preceding whitespace, not byte-0/not-line-1, or a second '#!' line) fails closed. Per The Eye's explicit ruling, a '#!' occurring inside a recognized string literal or comment is NOT a hashbang (it is ordinary string/comment content, in-profile) — this is deliberate and authorized, not an out-of-profile case. ` +
+  `This resolves the authz-007 contradiction (weave.mjs keeps its shebang and derives its closure) WITHOUT broadening the scanner into a full ES parser and WITHOUT overriding the codex seat. ` +
+  `v15 differs from the already-reviewed v14 at EXACTLY the two AM-41-block edits (the accepted-grammar leading-shebang admission + the b2 hashbang carve-out; 20 lines); the rest of AM-41 and every other frozen decision is reaffirmed unchanged ` +
+  `(AM-40 PACKAGE_ROOTS; advisory / non-sandboxed posture per AM-35..AM-39; D17/AM-17; D24/D26/D31; D32; the D33 accepted-form set; zero-dependency; spine read-only). ` +
+  `Judge v15 on ITS OWN advisory/non-sandbox terms — do NOT require it to prove loader isolation, and do NOT require a full ES parser beyond the frozen closed-profile bar. ` +
+  `Approve ONLY if the plan is implementation-ready and consistent with its governing spec (v2.8, advisory posture), the repository's trust model ` +
+  `(fail-closed, closed sets, spine read-only, advisory-only Clotho), and its own decisions and exit criteria — with AM-41 (incl. the shebang carve-out) correctly defining the scanner's enforced correctness domain and NO remaining plan contradiction.`;
+
+// Write targets from the plan (agy derives protected_path_check from these).
+const WRITE_TARGETS = ["clotho/", ".github/workflows/ci.yml", ".gitignore", "docs/runs/clotho-self-weave/", "docs/STATUS.md", "docs/ROADMAP.md"];
+
+const dossier = {
+  build_id: BUILD_ID,
+  use_case: USE_CASE,
+  objective: OBJECTIVE,
+  proposal_ref: planRef,
+  required_docs: [PLAN_PATH, SPEC_PATH],
+  write_targets: WRITE_TARGETS,
+  protected_paths: [],
+  trust_mode: "signed"
+};
+
+const meta = {
+  build_id: BUILD_ID,
+  use_case: USE_CASE,
+  proposal_ref: planRef,
+  timestamp: TIMESTAMP,
+  docs_reviewed: [PLAN_PATH, SPEC_PATH]
+};
+
+// ---------- strict packet schema (native structured output on every chat seat) ----------
+const PACKET_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    decision: { type: "string", enum: ["approve", "revise", "reject"] },
+    confidence: { type: "string", enum: ["low", "medium", "high"] },
+    required_edits: { type: "array", items: { type: "string" } },
+    hard_stops: { type: "array", items: { type: "string" } },
+    rationale: { type: "string" }
+  },
+  required: ["decision", "confidence", "required_edits", "hard_stops", "rationale"]
+};
+
+function parsePacket(text, model) {
+  let m = null;
+  try { m = JSON.parse(text); } catch { /* fall through */ }
+  if (m && m.phase_gate_status) return agyApprovalPacket(m, meta);
+  if (!m || typeof m !== "object") m = {};
+  return {
+    build_id: BUILD_ID,
+    use_case: USE_CASE,
+    model,
+    role: "approver",
+    docs_reviewed: meta.docs_reviewed,
+    proposal_ref: planRef,
+    decision: ["approve", "revise", "reject"].includes(m.decision) ? m.decision : "revise",
+    required_edits: Array.isArray(m.required_edits) ? m.required_edits : [],
+    hard_stops: Array.isArray(m.hard_stops) ? m.hard_stops : [],
+    confidence: ["low", "medium", "high"].includes(m.confidence) ? m.confidence : "low",
+    timestamp: TIMESTAMP,
+    rationale: typeof m.rationale === "string" ? m.rationale : "unparsable seat response (fail-closed to revise)"
+  };
+}
+
+function stripAdditionalProperties(schema) {
+  const clone = JSON.parse(JSON.stringify(schema));
+  const walk = (node) => {
+    if (!node || typeof node !== "object") return;
+    delete node.additionalProperties;
+    for (const v of Object.values(node)) walk(v);
+  };
+  walk(clone);
+  return clone;
+}
+
+const FIELD_SEMANTICS =
+  "Field semantics (STRICT): decision 'approve' means the plan may be executed AS-IS. " +
+  "hard_stops lists ONLY conditions that must BLOCK authorization right now — if you approve unconditionally, hard_stops MUST be []. " +
+  "required_edits lists ONLY concrete changes you demand before approval — if you approve, required_edits MUST be []. " +
+  "Do NOT restate the plan's invariants, strengths, or constraints in either list; put commentary in rationale.";
+
+function promptFor(model, _role, dsr) {
+  if (model === "agy") {
+    return { tool: "agy_checkpoint", args: agyCheckpointArgs(dsr, "clotho/") };
+  }
+  return {
+    tool: `${model}_ask`,
+    args: {
+      prompt: `Objective:\n${OBJECTIVE}\n\n${FIELD_SEMANTICS}\n\n=== PLAN UNDER AUTHORIZATION (${PLAN_PATH}, ${planRef}) ===\n\n${planText}`,
+      system: `You are the ${model} seat on the TELOS authorization council. Judge the plan on the merits against the objective. Approve only what you would stake your seat's signature on. ${FIELD_SEMANTICS}`,
+      model,
+      max_tokens: 60000,
+      include_provenance: true,
+      response_schema: model === "gemini" ? stripAdditionalProperties(PACKET_SCHEMA) : PACKET_SCHEMA,
+      schema_name: "telos_approval_packet"
+    }
+  };
+}
+
+const seats = [
+  { model: "claude", role: "approver" },
+  { model: "agy", role: "approver" },
+  { model: "codex", role: "approver" },
+  { model: "grok", role: "advisory" },
+  { model: "gemini", role: "advisory" }
+];
+
+const serverPath = path.join(ROOT, "connectors/ai-peer-mcp/server.mjs");
+const { client, close } = spawnMcpClient({ command: process.execPath, serverPath });
+const killer = setTimeout(() => { console.error("AUTHZ_TIMEOUT"); process.exit(2); }, 1_800_000);
+
+try {
+  const callSeat = (seatArg) =>
+    liveSeatCaller({ client, promptFor, parsePacket: (t) => parsePacket(t, seatArg.model) })(seatArg);
+
+  const results = await runCouncil({ seats, callSeat, dossier });
+
+  mkdirSync(HERE, { recursive: true });
+  const summary = { build_id: BUILD_ID, use_case: USE_CASE, objective: OBJECTIVE, plan_ref: planRef, merge_anchor: MERGE_ANCHOR, reviewed_head: REVIEWED_HEAD, extends: PRIOR_AUTHZ, timestamp: TIMESTAMP, trust_mode: "signed", ephemeral_signers: EPHEMERAL_SIGNERS, seats: [] };
+  const packetsForGate = [];
+
+  for (const r of results) {
+    if (r.ok) {
+      writeFileSync(path.join(HERE, `${r.model}.json`), JSON.stringify(r.packet, null, 2));
+      packetsForGate.push(r.packet);
+      summary.seats.push({ model: r.model, role: r.role, ok: true, signed: !!r.signed, decision: r.packet.decision, confidence: r.packet.confidence, provenance: r.packet.provenance });
+    } else {
+      summary.seats.push({ model: r.model, role: r.role, ok: false, reason: r.reason });
+    }
+  }
+
+  const gate = validateRecords(dossier, packetsForGate);
+  summary.gate = {
+    gate_status: gate.gate_status,
+    signing_enforced: gate.headline_checks?.signing_enforced,
+    provenance_enforced: gate.headline_checks?.provenance_enforced,
+    blockers: gate.blockers,
+    warnings: gate.warnings,
+    provenance: gate.provenance
+  };
+
+  const requiredSeats = seats.filter((s) => s.role === "approver").map((s) => s.model);
+  const approvals = summary.seats.filter((s) => requiredSeats.includes(s.model) && s.ok && s.decision === "approve");
+  const gatePassed = gate.gate_status === "pass";
+  summary.authorized = gatePassed && approvals.length === requiredSeats.length;
+  summary.authorization = summary.authorized
+    ? { status: "AUTHORIZED", plan_ref: planRef, note: "Argo execution of Clotho Phase 1 plan v13 is authorized by the signed council under the TELOS gate; extends authz-006." }
+    : { status: "NOT_AUTHORIZED", note: "Fail-closed: see gate.blockers and seat decisions." };
+
+  writeFileSync(path.join(HERE, "authorization-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify({ authorized: summary.authorized, gate_status: gate.gate_status, blockers: gate.blockers.length, seats: summary.seats.map((s) => ({ model: s.model, ok: s.ok, decision: s.decision ?? null })) }, null, 2));
+  process.exit(summary.authorized ? 0 : 3);
+} catch (error) {
+  console.error("AUTHZ_ERROR: " + (error?.message || String(error)));
+  process.exitCode = 1;
+} finally {
+  clearTimeout(killer);
+  close();
+}


### PR DESCRIPTION
Full signed TELOS re-authorization over **plan v15** (`sha256:05a48700…`, PR #121 squash-merge `bb265b9`; extends authz-006, **supersedes NOT_AUTHORIZED authz-007**). v15 = v14 + The Eye's AM-41 shebang carve-out.

**Result: AUTHORIZED.** Gate `pass`; signing + provenance enforced. Required claude/agy/codex all **approve/high, signed**; advisory grok/gemini approve. codex — which correctly blocked v14 at authz-007 — approved once the carve-out resolved the weave.mjs contradiction and the objective accurately reflected the Eye's ruling (string/comment `#!` is in-profile).

Evidence only. Next: The Eye's implementation authority; Task 4a corrections + resumed review vs v15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)