### PR TITLE
docs: add evidence-backed README and fail-closed proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,25 @@ jobs:
         working-directory: ${{ matrix.package }}
         run: npm test
 
+  fail-closed-proof:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20']
+    name: fail-closed proof (node ${{ matrix.node-version }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run the public fail-closed proof
+        run: node docs/runs/fail-closed-demo/run.mjs
+
   repository-portability:
     runs-on: ubuntu-latest
     name: repository paths are portable
@@ -155,6 +174,7 @@ jobs:
     if: ${{ always() }}
     needs:
       - test
+      - fail-closed-proof
       - repository-portability
       - institutional-memory
       - narcissus-flagship
@@ -164,11 +184,13 @@ jobs:
       - name: Require every CI job group to succeed
         env:
           TEST_RESULT: ${{ needs.test.result }}
+          PROOF_RESULT: ${{ needs.fail-closed-proof.result }}
           PORTABILITY_RESULT: ${{ needs.repository-portability.result }}
           MEMORY_RESULT: ${{ needs.institutional-memory.result }}
           NARCISSUS_RESULT: ${{ needs.narcissus-flagship.result }}
         run: |
           test "$TEST_RESULT" = "success"
+          test "$PROOF_RESULT" = "success"
           test "$PORTABILITY_RESULT" = "success"
           test "$MEMORY_RESULT" = "success"
           test "$NARCISSUS_RESULT" = "success"

--- a/README.md
+++ b/README.md
@@ -6,16 +6,43 @@
 > makes the thing that *builds* never be the thing that *certifies*: a build's
 > claim is data; the disk is the truth.
 
-**A multi-model build system where nothing merges on a model's say-so.**
-Independent AI model **seats** (claude / grok / codex / agy / gemini) produce
-signed, provenance-bound approval packets; a deterministic **gate** certifies
-merge-readiness from disk + signatures + provenance — never from a model's
-self-report. The same trust spine drives software from idea to merged, verified
-artifacts, and now governs the plan *before* it runs (see **Proposal Lifecycle**
-below): a candidate must survive adversarial cold review and produce a verified
-implementation contract before any irreversible step.
+**AI-native systems engineering with a deterministic trust spine.** Models may
+propose, implement, and review, but merge-readiness comes from disk evidence,
+content hashes, signatures, provenance, and reproducible checks—not a model's
+self-report.
 
-## How it works
+The required council is exactly `claude`, `agy`, and `codex`; `grok` and
+`gemini` are advisory. `agy` is a deterministic local governance attestation,
+not a remote model. A gate result can certify `merge_status: "ready"`.
+Implementation authority, acceptance, and merge remain separate human decisions
+held by **The Eye**.
+
+Core packages: **Node ≥18 · zero runtime dependencies · MIT**
+
+## Two-minute fail-closed proof
+
+From a fresh clone—no install, API key, service, or network access:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected:
+
+```text
+BLOCKED  tampered required-seat packet: signature invalid
+HALTED   out-of-bounds action: not executed; needs-human recorded
+VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected
+{"ok":true,"gate":{"status":"blocked","reason":"invalid-signature","tampered_packet_rejected":true},"operator":{"status":"needs-human","action_executed":false,"inbox_open":1,"ledger_verified":true,"tampered_ledger_rejected":true,"signature_algorithm":"Ed25519"}}
+```
+
+The script signs a valid required-seat trio, changes one signed field, and
+requires the real gate to reject it specifically for signature invalidity. It
+then proposes an over-cap operator action, proves the action was never called,
+records `needs-human`, verifies the Ed25519 decision ledger, changes one ledger
+field, and requires verification to fail.
+
+## Governed build path
 
 ```mermaid
 flowchart TD
@@ -57,74 +84,95 @@ flowchart TD
     class SPINE spine;
 ```
 
-Read it two ways: the top half (seats → approval gate) is TELOS deciding
-*whether* work is merge-ready; the whole pipeline is the **autonomous builder**
-taking an idea to verified, merged artifacts. The thing that *builds* is never the
-thing that *certifies* — a team's claim is data; the disk is truth.
+The diagram is the **governed build path**, not the complete repository map. The
+required seats produce HMAC-signed, provenance-bound packets; the gate blocks or
+certifies merge-readiness; build workers write and self-correct; independent
+verification re-derives disk state; and the controller records settlement in an
+Ed25519 ledger. The terminal is `merge_status: "ready"`, never an autonomous
+merge.
 
-## Components
+## From authority to implementation
 
-For the current authoritative classification—including implemented components,
-registered role modules, products, and deferred enrollment—start with
-`AI-START-HERE.md` and `repository-manifest.json`. This section is a working
-overview, not an authority record.
+TELOS inherits an institution before it executes a plan:
 
-**The substrate (engine):**
+1. [`CURRENT-AUTHORITY.json`](CURRENT-AUTHORITY.json) names the one active plan
+   and authorization; superseded records cannot govern new work.
+2. Institutional memory and the applicable comprehension gate establish what a
+   worker must understand before implementation.
+3. **Daedalus** matures implementation plans. Convergence is submission, not
+   authorization.
+4. **TELOS** governs review evidence and records the model council's
+   authorization outcome.
+5. **The Eye** grants non-delegable implementation authority and accepts or
+   refuses completed slices.
+6. **Argo** is the implementation role carrying authorized work through code,
+   verification, and documentation. No autonomous Argo service exists.
+7. **Clotho** creates and maintains graph threads, **Lachesis** measures
+   dependency and blast radius, and **Atropos** currently verifies recorded
+   supersession consistency. Retirement action remains human-governed.
 
-- **`build-gate/`** — the gate (`gate.mjs`), per-model HMAC signing (`sign.mjs`), the
-  dynamic-workflow council orchestrator (`council.mjs`: per-job seat sizing +
-  CPU-bounded fan-out + `liveSeatCaller`), strict-mode JSON Schemas for the three
-  contracts (`schemas.mjs`), per-model strength profiles (`model-profiles.mjs`),
-  and the seat→backend registry (`seat-registry.mjs`: routes each council tool to
-  ai-peer-mcp or a claude-plugins seat server, `TELOS_PLUGINS_DIR`-configurable).
-- **`breakout/`** — self-challenge with verdict-on-facts (`verifier.mjs`, `live.mjs`),
-  a minimal MCP stdio client (`mcp_client.mjs`: Content-Length or ndjson framing),
-  and the multi-server seat router (`seat_router.mjs`: same `callTool` surface
-  `liveSeatCaller` already consumes, fail-closed on unrouted tools).
-- **`connectors/ai-peer-mcp/`** — MCP server exposing the model backends
-  (`claude_ask` / `grok_ask` / `codex_ask` / `gemini_ask` / `agy_checkpoint`) with
-  **real per-seat provenance** and **provider-native structured output** (each
-  contract schema is translated to that provider's native form — OpenAI/xAI
-  `json_schema` strict, Anthropic forced tool call, Gemini `responseSchema`).
-- **`merkle-dag/`** — content-addressed planning + verified delegation + a pure
-  `done()` evaluator (`ledger-gate.mjs`): immutable `plan.json`, append-only signed
-  `ledger.jsonl`, Ed25519 settlement, forward-invalidation by hash. Also
-  **verification obligations** (`obligation.mjs`: content-addressed obligation
-  identity, done()-time discharge) and the **signed proposal-lifecycle ledger**
-  (`proposal-ledger.mjs`: hash-chained `.telos/proposal.jsonl`, atomic single-lock
-  append, `POLICY_CONTRACT_V1` + layered authorization verifiers).
+Start with [`AI-START-HERE.md`](AI-START-HERE.md) for the exact load order and
+[`repository-manifest.json`](repository-manifest.json) for the architectural
+map.
 
-**The autonomous layers (composed on the substrate, no new trust surface):**
+## When automation must stop
 
-- **`build-gate/` agentic-teams** — `teams.mjs` (the team roster as data),
-  `decompose.mjs` (idea → validated task DAG), `build-orchestrator.mjs`
-  (`buildProject` — the full lifecycle), `teamPrompts.mjs` (live wiring over
-  `ai-peer-mcp`), `situation.mjs` (project sense), `test-runner.mjs` (runtime
-  self-correction).
-- **`build-gate/` proposal-lifecycle (Daedalus)** — audited-judgment governance
-  BEFORE execution (opt-in `dossier.proposal_lifecycle === true`; legacy advisory
-  mode is byte-identical). `daedalus.mjs` (the bounded claude/codex planning
-  workshop), `concerns.mjs` (typed concerns/holds/controller-only dispositions),
-  `risk-policy.mjs`, `evidence.mjs` (closed-whitelist sandboxed verifier),
-  `proposal-gate.mjs` (reconstructs proposal state from the ledger),
-  `proposal-recorder.mjs` (sole-writer), `standing.mjs` (pure calibration). See
-  `contracts/Proposal Lifecycle.md`.
-- **`saas-forge/`** — a 7-team SaaS generator that drives a project to
-  market-ready, each team put through an adversarial breakout-on-facts.
-- **`ai-forge/`** — pattern-library-driven forge for AI architectures; Phase A: the
-  RAG pattern (7 workstreams, fully converged over the real gate + Ed25519 ledger).
-- **`forge/`** — reusable ratchet/driver/manifest/claims/operator package.
-- **`clotho/`** — provenance-aware knowledge-graph weaver with a signed,
-  append-only thread ledger and deterministic query surface.
-- **`lachesis/`** and **`atropos/`** — consciously enrolled, zero-dependency
-  spine packages for dependency/relevance/risk/blast-radius measurement and
-  read-only supersession consistency, respectively.
-- **`ai-native-memory/`** — implemented portable institutional-memory
-  plugin/product with dogfood records; it has no mythological role and remains
-  deferred for conscious Iliad enrollment.
-- **`narcissus/flagship/`** — implemented React/TypeScript/Vite front-end product.
-  It is distinct from the registered Narcissus role module, which remains
-  unimplemented; product enrollment is also deferred.
+The crossroad-ads Phase 2 operator is deliberately **ARMED, awaiting go-live**:
+it can create only `PAUSED` campaign objects, while activation remains a human
+action. Missing credentials, quota failures, and out-of-bounds budget changes
+become `needs-human` records and halt instead of fabricating success.
+
+The mechanism and keyless negative controls are committed in
+[`OPS-README.md`](docs/runs/crossroad-ads/OPS-README.md),
+[`test-ads-ops.mjs`](docs/runs/crossroad-ads/test-ads-ops.mjs),
+[`operator.mjs`](forge/operator.mjs), and
+[`test-operator.mjs`](forge/scripts/test-operator.mjs). The live
+`workdir/needs-human.jsonl`, `workdir/INBOX.md`, and operator ledger are
+runtime/gitignored artifacts; this README does not pretend a particular signed
+go-live refusal is committed.
+
+## System map
+
+The complete package classification comes from
+[`package-roots.json`](clotho/memory/CONTRACTS/package-roots.json) and the
+[`Iliad enrollment contract`](docs/institutional-memory/iliad/CONTRACTS/enrollment.json).
+
+| Boundary | Current members | Status |
+| --- | --- | --- |
+| Enrolled TELOS spine | `atropos`, `breakout`, `build-gate`, `clotho`, `connectors/ai-peer-mcp`, `lachesis`, `merkle-dag` | Implemented and consciously enrolled |
+| Products beside the spine | `ai-forge`, `ai-native-memory`, `forge`, `narcissus/flagship`, `saas-forge` | Implemented; Iliad enrollment deferred |
+| Active role/capability modules | Daedalus, TELOS, Argo, The Iliad, `loadout` | Protocol/code/run lineage; no autonomous role services |
+| Registered future roles | Hermes, Medusa, Narcissus | Meanings reserved; unimplemented |
+
+`contracts/` contains the human-readable protocols; it is a reference boundary,
+not another package root. The implemented `narcissus/flagship` product is
+distinct from the registered, unimplemented Narcissus role.
+
+### AI-native memory
+
+[`ai-native-memory/`](ai-native-memory/) packages the repository's
+institutional-memory discipline as a portable, zero-dependency Claude Code
+plugin/product. It ships `/memory-init`, `/memory-audit`, `/memory-verify`, and
+`/memory-gate`; memory-standard, authoring, and lifecycle skills; and auditor,
+comprehension, and adversarial-review agents. Its own authority and `memory/`
+records dogfood the same audit, verification, and comprehension oracles.
+
+`memory-init` scaffolds host-local authority and record files, so a fresh host
+does not need TELOS paths. The TELOS dogfood authority path is evidence for this
+repository, not a portability requirement. See the
+[`plugin metadata`](ai-native-memory/.claude-plugin/plugin.json) and
+[`dogfood evidence`](ai-native-memory/memory/EVIDENCE/README.md). Marketplace
+publication and Iliad enrollment remain deferred.
+
+## Terminology
+
+| Term | Meaning here |
+| --- | --- |
+| **telos** | The goal or contract being pursued. **TELOS** is the registered governance role and repository name. |
+| **seat** | One independently routed build or review participant with its own packet and provenance. |
+| **gate** | Deterministic validation that blocks on missing, invalid, or contradictory evidence. |
+| **breakout** | Adversarial self-challenge plus verification against facts on disk. |
+| **agy** | The deterministic local governance checkpoint/attestation occupying one required seat. |
 
 ## Autonomous builder (agentic-teams)
 

--- a/README.md
+++ b/README.md
@@ -206,25 +206,32 @@ idea + telos
   to self-correct (bounded), then the substrate's halt → mutate → re-dispatch gives
   a second, outer adaptation level.
 
-## Proposal Lifecycle (Daedalus)
+## Proposal lifecycle: Daedalus → TELOS → Argo
 
-The agentic-teams path answers *whether work is merge-ready*. The proposal
-lifecycle answers a prior question — *is this plan mature enough to authorize?* —
-by putting a candidate through audited judgment before any irreversible step. It
-implements `contracts/Proposal Lifecycle.md` and adds **no new root of trust**:
-every decision reduces to the existing primitives (content hashes, signatures,
-provenance, deterministic policy, re-verifiable evidence, disk as ground truth).
+The agentic-teams path answers whether built evidence is merge-ready. The
+proposal lifecycle begins earlier and keeps three events separate:
 
-```
+1. **Daedalus convergence** — planning seats stop objecting and submit a frozen
+   candidate.
+2. **TELOS authorization** — required model seats review the exact candidate;
+   one required dissent blocks and the signed run records `AUTHORIZED` or
+   `NOT_AUTHORIZED`.
+3. **The Eye's implementation authority** — the human authority holder decides
+   whether Argo may carry that plan through implementation, verification, and
+   documentation.
+
+Model convergence does not authorize. A TELOS council result does not execute.
+Argo does not choose scope, and no autonomous Argo service exists.
+
+```text
 idea + telos
-  → draft
-  → Daedalus workshop (claude/codex negotiation; content-addressed rounds)
-  → compileAndHashPlan() → immutable candidate (obligations + lifecycle bound into plan_hash)
-  → COLD REVIEW of the exact written plan hash (creation/review lineage disjoint, provider-scoped)
-  → typed concerns → holds / dispositions / verification obligations
-  → deterministic decision: authorized | revise | blocked | human-review-required
-  → runBuild(): reads the authorized decision + closed policy certificate FROM DISK, keyed by the
-       recomputed plan hash — then Rule-3 execution + obligation discharge
+  → Daedalus workshop → converged candidate with content-addressed rounds
+  → compileAndHashPlan() → immutable candidate + obligations
+  → TELOS cold review of the exact plan hash
+  → typed concerns + deterministic gate → AUTHORIZED | NOT_AUTHORIZED
+  → The Eye grants or refuses implementation authority
+  → Argo carries the authorized plan through code + verification + documentation
+  → The Eye accepts or refuses the slice; maintainers decide merge
 ```
 
 The governing rule, and the one most likely to catch a design flaw: **no mutable
@@ -317,55 +324,108 @@ and the gate independently re-verifies every team's record on disk.
   secrets. Runtime `.telos/` artifacts (plan/ledger) are created ephemerally in the
   build tree.
 
-## Test
+## Honest boundaries
 
-The core, forge, plugin, and enrolled spine packages are Node ≥ 18 ESM with zero
-dependencies; CI runs them on Ubuntu under Node 18 and 20. The
+- The gate, ledgers, metrics, supersession verifier, plugin oracles, forges, and
+  their tests run locally. Provider-backed council calls require the provider's
+  configured credentials.
+- TELOS authorization certifies only the checked merge-readiness predicates. It
+  does not execute code or merge a branch.
+- No autonomous Argo or Iliad service exists. Those names describe governed
+  roles and lifecycle protocols.
+- Model consensus is not human authority. The Eye's implementation and
+  acceptance authority is non-delegable.
+- Per-seat HMAC is an integrity and binding floor for the honest-but-careless
+  threat model. One owner holding every seat secret can forge those packets; it
+  is not non-repudiation.
+- The gate checks provenance shape, uniqueness, and signature binding from disk.
+  It cannot prove a well-formed response id was genuinely issued without
+  re-contacting the provider.
+- Clotho is advisory and non-sandboxed. Green checks prove only the predicates
+  they execute.
+- Implemented sibling products are not thereby enrolled in the TELOS spine.
+
+## Verification
+
+The core, forge, plugin, and enrolled spine packages are Node ≥18 ESM with zero
+runtime dependencies. CI runs them under Node 18 and 20. The
 `narcissus/flagship` product is the explicit exception: it requires Node
-`^20.19.0 || >=22.12.0`, uses a tracked npm lockfile, and runs in a separate
-Node-20 CI job with install, audit, unit, evidence, coverage, build, and browser
-tests.
+`^20.19.0 || >=22.12.0`, uses a tracked npm lockfile, and has its own install,
+audit, unit, evidence, graph, build, and browser pipeline.
+
+Fast public proof:
 
 ```bash
-cd build-gate            && npm test   # gate, sign, trust, council, teams, decompose,
-                                       #   build-orchestrator, schemas, situation, concerns,
-                                       #   proposal-gate, check-registry, proposal-orchestrator,
-                                       #   daedalus, proposal-lifecycle, standing, + breakout
-cd breakout              && npm test
-cd connectors/ai-peer-mcp && npm test  # provenance, structured requests, smoke
-cd merkle-dag            && npm test   # 10 suites incl. obligations + proposal-ledger + end-to-end harness
-cd saas-forge            && npm test   # 7 teams generate + breakout-survive + gate pass
-cd ai-forge              && npm test
-cd forge                 && npm test
-cd clotho                && npm test   # 14 tests incl. real-repository flagship
-cd ai-native-memory      && npm run check && npm test
-cd lachesis              && npm test
-cd atropos               && npm test
-cd narcissus/flagship    && npm ci && npm test && npm run verify:evidence \
-                           && npm run verify:coverage && npm run build && npm run test:e2e
+node docs/runs/fail-closed-demo/run.mjs
+node docs/institutional-memory/verify-contracts.mjs
+node docs/runs/clotho-self-weave/run.mjs --verify-committed
+```
+
+Complete local package suite, with every command safe to paste independently
+from the repository root:
+
+```bash
+npm --prefix build-gate test
+npm --prefix breakout test
+npm --prefix connectors/ai-peer-mcp test
+npm --prefix merkle-dag test
+npm --prefix saas-forge test
+npm --prefix ai-forge test
+npm --prefix forge test
+npm --prefix clotho test
+npm --prefix ai-native-memory run check
+npm --prefix ai-native-memory test
+npm --prefix lachesis test
+npm --prefix atropos test
+```
+
+Flagship pipeline under Node 20:
+
+```bash
+npm --prefix narcissus/flagship ci
+npm --prefix narcissus/flagship audit --audit-level=moderate
+npm --prefix narcissus/flagship test
+npm --prefix narcissus/flagship run verify:evidence
+npm --prefix narcissus/flagship run verify:coverage
+npm --prefix narcissus/flagship run check:live-graph
+npm --prefix narcissus/flagship run build
+(cd narcissus/flagship && npx playwright install --with-deps chromium)
+npm --prefix narcissus/flagship run test:e2e
 ```
 
 ## Docs & evidence
 
-- `docs/STATUS.md` — current status.
-- `docs/proposal-lifecycle-implementation.md` — implementation reference for the audited-judgment
-  proposal-lifecycle subsystem (composed flow, module map, enforcement mechanisms, trust boundaries).
-- `docs/history/` — superseded dated records (design specs, plans, apply-instructions) from earlier
-  phases, kept for provenance; not maintained against the shipping code.
-- `docs/runs/` — runnable evidence: `live-council/` (distinct per-seat provenance;
-  fail-closed without a key; signed-mode pass), `agentic-teams/` +
-  `agentic-teams-live/` + `agentic-teams-situational/` + `agentic-teams-market/`
-  (idea → `merge_status: "ready"` over the real gate + Ed25519 ledger + merkle-dag),
-  and `proposal-lifecycle/` (keyless audited-judgment evidence: `run-lifecycle-e2e.mjs`
-  drives revise→authorize→discharge→ready through `buildProject`, with a negative
-  control proving the verification obligation is load-bearing at Rule 3).
-- `contracts/` — the human-readable protocols the gate enforces (build gate,
-  prototype workflow, hierarchical workflow, agentic-teams autonomous builder,
-  proposal lifecycle — audited judgment + cold review + verification obligations).
+- [`AI-START-HERE.md`](AI-START-HERE.md) — onboarding order and component routing.
+- [`CURRENT-AUTHORITY.json`](CURRENT-AUTHORITY.json) — the one active plan,
+  authorization, implementation holder, and superseded chain.
+- [`repository-manifest.json`](repository-manifest.json) — architectural map,
+  role ownership, claims, and explicit non-claims.
+- [`docs/institutional-memory/`](docs/institutional-memory/) — machine-first
+  authority, invariants, decisions, comprehension gates, and executable
+  contract verification.
+- [`docs/runs/clotho-self-weave/`](docs/runs/clotho-self-weave/) — committed,
+  signed knowledge-graph snapshot and read-only reproduction verifier.
+- [`ai-native-memory/memory/EVIDENCE/README.md`](ai-native-memory/memory/EVIDENCE/README.md)
+  — portable plugin dogfood and inheritance evidence.
+- [`docs/runs/crossroad-ads/`](docs/runs/crossroad-ads/) — bounded `PAUSED` ads
+  operator, `needs-human` behavior, and keyless negative controls.
+- [`narcissus/flagship/src/evidence-ledger.json`](narcissus/flagship/src/evidence-ledger.json),
+  [`live-graph.json`](narcissus/flagship/src/live-graph.json), and
+  [`screenshots/`](narcissus/flagship/screenshots/) — the implemented “Loom on
+  Trial” product's evidence, graph, and visual proof.
+- [`docs/runs/`](docs/runs/) — authorization refusals and successes, Argo slice
+  evidence, proposal-lifecycle runs, Clotho evidence, and product runs.
+- [`contracts/`](contracts/) — human-readable protocols enforced by the gate.
+- [`docs/history/`](docs/history/) — superseded records retained for provenance;
+  they do not govern current work.
 
-## Provenance / layout note
+## Provenance
 
-Extracted from a larger multi-model vault, where the live deployment runs under a
-`me/codex/` tree wired into an MCP client. `validateProtectedPaths` derives its
-root from the deployment layout; in this standalone repo the engine is primarily a
-reference + evidence artifact. Authored by `claude-code`.
+TELOS is human-directed and developed with multiple model seats. The repository
+dogfoods its own deterministic review, evidence, signature, negative-control,
+and institutional-memory mechanisms; generated text or code is still data, not
+authority or certification.
+
+The project began inside a larger multi-model vault. This repository now
+contains standalone executable packages and committed evidence, while live
+provider wiring remains credential-dependent and environment-specific.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The complete package classification comes from
 | Enrolled TELOS spine | `atropos`, `breakout`, `build-gate`, `clotho`, `connectors/ai-peer-mcp`, `lachesis`, `merkle-dag` | Implemented and consciously enrolled |
 | Products beside the spine | `ai-forge`, `ai-native-memory`, `forge`, `narcissus/flagship`, `saas-forge` | Implemented; Iliad enrollment deferred |
 | Active role/capability modules | Daedalus, TELOS, Argo, The Iliad, `loadout` | Protocol/code/run lineage; no autonomous role services |
-| Registered future roles | Hermes, Medusa, Narcissus | Meanings reserved; unimplemented |
+| Registered future roles | [Hermes, Medusa, Narcissus](docs/mythological-vocabulary.md#registered-terms) | Meanings reserved; unimplemented |
 
 `contracts/` contains the human-readable protocols; it is a reference boundary,
 not another package root. The implemented `narcissus/flagship` product is
@@ -160,7 +160,8 @@ records dogfood the same audit, verification, and comprehension oracles.
 `memory-init` scaffolds host-local authority and record files, so a fresh host
 does not need TELOS paths. The TELOS dogfood authority path is evidence for this
 repository, not a portability requirement. See the
-[`plugin metadata`](ai-native-memory/.claude-plugin/plugin.json) and
+[`package metadata`](ai-native-memory/package.json),
+[`plugin metadata`](ai-native-memory/.claude-plugin/plugin.json), and
 [`dogfood evidence`](ai-native-memory/memory/EVIDENCE/README.md). Marketplace
 publication and Iliad enrollment remain deferred.
 

--- a/docs/runs/fail-closed-demo/run.mjs
+++ b/docs/runs/fail-closed-demo/run.mjs
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { validateRecords } from "../../../build-gate/gate.mjs";
 import { signPacket } from "../../../build-gate/sign.mjs";
+import { createOperator, renderInbox } from "../../../forge/operator.mjs";
 
 const FIXTURE_SECRETS = Object.freeze({
   claude: "fixture-only-claude-secret",
@@ -68,10 +72,98 @@ function runGateProof() {
   };
 }
 
+async function runOperatorProof() {
+  const workdir = mkdtempSync(path.join(os.tmpdir(), "telos-fail-closed-demo-"));
+  let actionCalls = 0;
+
+  try {
+    const op = createOperator({
+      workdir,
+      signerName: "fail-closed-demo",
+      rulebook: [{
+        id: "overspend",
+        when: () => true,
+        act: () => ({
+          action: "update_budget",
+          args: { campaign_id: "fixture-campaign", daily_budget_cents: 2501 }
+        })
+      }],
+      bounds: {
+        update_budget: (args) => args.daily_budget_cents <= 2000
+          ? true
+          : `daily_budget_cents ${args.daily_budget_cents} over cap 2000`
+      },
+      actions: {
+        update_budget: async () => {
+          actionCalls += 1;
+          return { ok: true };
+        }
+      }
+    });
+
+    const result = await op.runPass({ source: "fixture" });
+    assert.equal(result.halted, true, "out-of-bounds pass must halt");
+    assert.equal(actionCalls, 0, "out-of-bounds action must never execute");
+    assert.equal(result.decisions.length, 1, "one rule must produce one decision");
+
+    const decision = result.decisions[0];
+    assert.equal(decision.outcome, "needs-human", "decision must require a human");
+    assert.equal(decision.sig?.alg, "Ed25519", "decision must use Ed25519");
+
+    const inboxRecords = readFileSync(op.inboxPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.equal(inboxRecords.length, 1, "one needs-human record must exist");
+    assert.equal(inboxRecords[0].resolution, null, "needs-human record must remain open");
+    assert.match(inboxRecords[0].question, /over cap 2000/, "record must name the bound");
+
+    const inbox = renderInbox(workdir);
+    assert.equal(inbox.open, 1, "rendered inbox must report one open item");
+    assert.match(
+      readFileSync(path.join(workdir, "INBOX.md"), "utf8"),
+      /\*\*1 open\*\*/,
+      "human inbox must render the open decision"
+    );
+
+    const cleanAudit = op.verifyLedger();
+    assert.deepEqual(
+      cleanAudit,
+      { total: 1, invalid: 0, ok: true },
+      "untouched Ed25519 ledger must verify"
+    );
+
+    const ledgerRecord = JSON.parse(readFileSync(op.ledgerPath, "utf8").trim());
+    const tampered = { ...ledgerRecord, reason: `${ledgerRecord.reason} [tampered]` };
+    writeFileSync(op.ledgerPath, JSON.stringify(tampered) + "\n");
+    const tamperedAudit = op.verifyLedger();
+    assert.deepEqual(
+      tamperedAudit,
+      { total: 1, invalid: 1, ok: false },
+      "one-field ledger mutation must fail verification"
+    );
+
+    return {
+      status: "needs-human",
+      action_executed: actionCalls !== 0,
+      inbox_open: inbox.open,
+      ledger_verified: cleanAudit.ok,
+      tampered_ledger_rejected: !tamperedAudit.ok && tamperedAudit.invalid === 1,
+      signature_algorithm: decision.sig.alg
+    };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+
 async function main() {
   const gate = runGateProof();
+  const operator = await runOperatorProof();
   process.stdout.write("BLOCKED  tampered required-seat packet: signature invalid\n");
-  process.stdout.write(JSON.stringify({ ok: true, gate }) + "\n");
+  process.stdout.write("HALTED   out-of-bounds action: not executed; needs-human recorded\n");
+  process.stdout.write("VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected\n");
+  process.stdout.write(JSON.stringify({ ok: true, gate, operator }) + "\n");
 }
 
 if (process.argv.length !== 2) {

--- a/docs/runs/fail-closed-demo/run.mjs
+++ b/docs/runs/fail-closed-demo/run.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import { validateRecords } from "../../../build-gate/gate.mjs";
+import { signPacket } from "../../../build-gate/sign.mjs";
+
+const FIXTURE_SECRETS = Object.freeze({
+  claude: "fixture-only-claude-secret",
+  agy: "fixture-only-agy-secret",
+  codex: "fixture-only-codex-secret"
+});
+
+Object.assign(process.env, {
+  TELOS_SECRET_CLAUDE: FIXTURE_SECRETS.claude,
+  TELOS_SECRET_AGY: FIXTURE_SECRETS.agy,
+  TELOS_SECRET_CODEX: FIXTURE_SECRETS.codex
+});
+
+const DOSSIER = Object.freeze({
+  build_id: "fail-closed-demo",
+  use_case: "portfolio-proof",
+  objective: "Prove a changed required-seat packet cannot settle.",
+  required_docs: ["docs/design.md"],
+  write_targets: ["shared/Coordination/fail-closed-demo.md"],
+  protected_paths: [],
+  trust_mode: "signed"
+});
+
+function approval(model) {
+  return {
+    build_id: DOSSIER.build_id,
+    use_case: DOSSIER.use_case,
+    model,
+    role: "approver",
+    docs_reviewed: [...DOSSIER.required_docs],
+    proposal_ref: "fixture-plan-ref",
+    decision: "approve",
+    required_edits: [],
+    hard_stops: [],
+    confidence: "high",
+    timestamp: "2026-07-19T00:00:00.000Z",
+    provenance: {
+      model: `real-${model}`,
+      source: "ai-peer-mcp",
+      response_id: `resp_${model}_fail_closed_demo`
+    }
+  };
+}
+
+function runGateProof() {
+  const packets = ["claude", "agy", "codex"]
+    .map((model) => signPacket(approval(model), FIXTURE_SECRETS[model]));
+
+  packets[0] = { ...packets[0], confidence: "low" };
+  const report = validateRecords(DOSSIER, packets);
+  const signatureBlockers = report.blockers
+    .filter((blocker) => blocker.includes("signature invalid"));
+
+  assert.equal(report.gate_status, "blocked", "tampered packet must block");
+  assert.equal(signatureBlockers.length, 1, "exactly one signature discriminator must fire");
+  assert.equal(report.blockers.length, 1, "fixture must not create unrelated blockers");
+
+  return {
+    status: "blocked",
+    reason: "invalid-signature",
+    tampered_packet_rejected: true
+  };
+}
+
+async function main() {
+  const gate = runGateProof();
+  process.stdout.write("BLOCKED  tampered required-seat packet: signature invalid\n");
+  process.stdout.write(JSON.stringify({ ok: true, gate }) + "\n");
+}
+
+if (process.argv.length !== 2) {
+  process.stderr.write("Usage: node docs/runs/fail-closed-demo/run.mjs\n");
+  process.exit(2);
+}
+
+try {
+  await main();
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`fail-closed-demo: ${detail}\n`);
+  process.exitCode = 1;
+}

--- a/docs/superpowers/plans/2026-07-19-readme-v0.2-refresh.md
+++ b/docs/superpowers/plans/2026-07-19-readme-v0.2-refresh.md
@@ -1,0 +1,1236 @@
+# Evidence-Backed README Refresh Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refresh the TELOS GitHub landing page and add one keyless public proof that a tampered required-seat packet is blocked and an out-of-bounds operator action becomes a signed, tamper-detecting `needs-human` halt.
+
+**Architecture:** A single zero-dependency Node entry point under `docs/runs/` composes the existing `build-gate` HMAC validator and `forge` Ed25519 operator without duplicating either implementation. A dedicated Node 18/20 CI matrix runs that same public command, while the root README presents the proof, the exact authority boundaries, the complete package classification, and paste-safe verification commands.
+
+**Tech Stack:** Node.js ESM (`node:` built-ins only), existing TELOS `build-gate` and `forge` modules, GitHub Actions YAML, Markdown, Mermaid.
+
+## Global Constraints
+
+- Governing design: `docs/superpowers/specs/2026-07-19-readme-v0.2-refresh-design.md` at commit `4423beb`.
+- Repository baseline: `git:c807334992cf82ca2fab3df6bed86cc259324fda`; active Clotho authority remains v15, `sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3`, `authz-008`.
+- The design approval selects this scope; it does not merge work or delegate The Eye's implementation, acceptance, or merge authority.
+- Core runtime floor is Node.js 18; the public proof must pass under both Node 18 and Node 20.
+- Add no runtime or development dependency and no lockfile. Demo imports are limited to `node:` built-ins and relative repository modules.
+- The public proof performs no package install, network call, provider call, provider-credential lookup, or tracked write.
+- Unconditionally replace inherited `TELOS_SECRET_*` values inside the demo process with fixture-only HMAC values; never print either inherited or fixture secret values.
+- Use the real `validateRecords`, `signPacket`, `createOperator`, `renderInbox`, and `verifyLedger` paths. Never copy or weaken production validation logic.
+- HMAC authenticates required-seat packets; Ed25519 signs operator ledger records. Never conflate the two mechanisms.
+- Required seats are exactly `claude`, `agy`, and `codex`; advisory seats are exactly `grok` and `gemini`. `agy` is a deterministic local attestation, not a remote model.
+- Deterministic evidence, signatures, and provenance produce merge-readiness. Implementation authority, acceptance, and merge remain separate human decisions held by The Eye.
+- The demo must mutate only `confidence: "high"` to `"low"` after packet signing, then block specifically on the invalid HMAC signature with no unrelated fixture blocker.
+- The operator action must never execute, must create exactly one open `needs-human` record, and must halt.
+- Verify the untouched one-line Ed25519 ledger, then mutate only its `reason` field without re-signing and require exactly one invalid line.
+- Create operator artifacts only below `os.tmpdir()`. Remove the temporary work directory before printing success; cleanup failure exits nonzero.
+- Public demo exit codes are exactly `0` success, `1` assertion/cannot-run/cleanup failure, and `2` invalid command-line use.
+- The public JSON result fields are exactly those frozen in the design. No timestamp, key, signature, secret, or temporary path appears in public output.
+- Keep the existing Mermaid build-path block byte-identical and preserve its accurate `merge_status: ready` terminal.
+- Preserve the registered mythological vocabulary and its exact role meanings. Unregistered mythology remains prohibited.
+- Describe runtime/gitignored crossroad-ads records honestly; do not claim a committed signed go-live refusal that is not on disk.
+- `ai-native-memory` remains an implemented, portable, zero-dependency product with deferred Iliad enrollment and deferred marketplace publication.
+- This scope does not create a release, tag, package version, marketplace publication, component README, GIF, GitHub About change, or ruleset mutation.
+- Implementation files are limited to `README.md`, `docs/runs/fail-closed-demo/run.mjs`, and `.github/workflows/ci.yml`.
+- Every README command must be independently paste-safe from the repository root.
+- Green checks prove only their asserted predicates. Preserve every applicable `NON-CLAIMS` boundary.
+
+---
+
+## File Structure
+
+- Create `docs/runs/fail-closed-demo/run.mjs`
+  - One public CLI and executable test.
+  - Owns fixture-only packet construction, two discriminating negative controls, normalized JSON output, exit codes, and temporary cleanup.
+- Modify `.github/workflows/ci.yml`
+  - Adds the `fail-closed-proof` Node 18/20 matrix and makes `required CI` depend on it.
+- Modify `README.md`
+  - Owns public positioning, two-minute proof instructions, system map, terminology, honest limits, verification commands, evidence links, and provenance framing.
+
+No helper or fixture file is necessary: the production APIs support the complete proof in one focused script.
+
+---
+
+## Execution Preconditions
+
+This is a bounded documentation, CI, and runnable-evidence change. It does not
+enroll a new subsystem or alter Iliad governance. Before Task 1 edits any file:
+
+1. Read `docs/institutional-memory/telos/INVARIANTS.md`,
+   `docs/institutional-memory/telos/NON-CLAIMS.md`, both TELOS decision files,
+   `docs/institutional-memory/argo/INVARIANTS.md`,
+   `docs/institutional-memory/argo/NON-CLAIMS.md`, and both Argo decision files.
+2. Run the reviewed TELOS entry fixture:
+
+   ```bash
+   node docs/institutional-memory/comprehension-gate.mjs \
+     docs/institutional-memory/telos/comprehension-queries.json \
+     docs/institutional-memory/examples/reader-telos-correct.json
+   ```
+
+   Require exit `0`, `passed: 19`, `failed: 0`, and
+   `result: "COMPREHENSION_PASSED"`.
+3. Run the reviewed Argo entry fixture:
+
+   ```bash
+   node docs/institutional-memory/comprehension-gate.mjs \
+     docs/institutional-memory/argo/comprehension-queries.json \
+     docs/institutional-memory/examples/reader-argo-correct.json
+   ```
+
+   Require exit `0`, `passed: 18`, `failed: 0`, and
+   `result: "COMPREHENSION_PASSED"`.
+4. Run `node docs/institutional-memory/verify-contracts.mjs` and require
+   `301/301`.
+5. Record explicitly that the gates' legacy `implementation_authority:
+   "GRANTED"` label is an entry precondition, not human authority. Begin Task 1
+   only after The Eye selects an execution mode and thereby directs
+   implementation of this approved plan.
+
+---
+
+### Task 1: Public HMAC Tamper Proof
+
+**Files:**
+- Create: `docs/runs/fail-closed-demo/run.mjs`
+- Test: `docs/runs/fail-closed-demo/run.mjs` (the CLI is its own assertion harness)
+
+**Interfaces:**
+- Consumes: `signPacket(packet: object, secret: string): object` from `build-gate/sign.mjs`.
+- Consumes: `validateRecords(dossier: object, packets: object[]): {gate_status: string, blockers: string[], warnings: string[]}` from `build-gate/gate.mjs`.
+- Produces: internal `runGateProof(): {status: "blocked", reason: "invalid-signature", tampered_packet_rejected: true}`.
+- Produces temporarily: a gate-only public CLI result that Task 2 extends without changing `runGateProof`.
+
+- [ ] **Step 1: Run the missing public command to establish the red state**
+
+Run from the repository root:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected: nonzero exit with `MODULE_NOT_FOUND` naming `docs/runs/fail-closed-demo/run.mjs`.
+
+- [ ] **Step 2: Create the gate-only assertion harness**
+
+Create `docs/runs/fail-closed-demo/run.mjs` with exactly:
+
+```js
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+
+import { validateRecords } from "../../../build-gate/gate.mjs";
+import { signPacket } from "../../../build-gate/sign.mjs";
+
+const FIXTURE_SECRETS = Object.freeze({
+  claude: "fixture-only-claude-secret",
+  agy: "fixture-only-agy-secret",
+  codex: "fixture-only-codex-secret"
+});
+
+Object.assign(process.env, {
+  TELOS_SECRET_CLAUDE: FIXTURE_SECRETS.claude,
+  TELOS_SECRET_AGY: FIXTURE_SECRETS.agy,
+  TELOS_SECRET_CODEX: FIXTURE_SECRETS.codex
+});
+
+const DOSSIER = Object.freeze({
+  build_id: "fail-closed-demo",
+  use_case: "portfolio-proof",
+  objective: "Prove a changed required-seat packet cannot settle.",
+  required_docs: ["docs/design.md"],
+  write_targets: ["shared/Coordination/fail-closed-demo.md"],
+  protected_paths: [],
+  trust_mode: "signed"
+});
+
+function approval(model) {
+  return {
+    build_id: DOSSIER.build_id,
+    use_case: DOSSIER.use_case,
+    model,
+    role: "approver",
+    docs_reviewed: [...DOSSIER.required_docs],
+    proposal_ref: "fixture-plan-ref",
+    decision: "approve",
+    required_edits: [],
+    hard_stops: [],
+    confidence: "high",
+    timestamp: "2026-07-19T00:00:00.000Z",
+    provenance: {
+      model: `real-${model}`,
+      source: "ai-peer-mcp",
+      response_id: `resp_${model}_fail_closed_demo`
+    }
+  };
+}
+
+function runGateProof() {
+  const packets = ["claude", "agy", "codex"]
+    .map((model) => signPacket(approval(model), FIXTURE_SECRETS[model]));
+
+  packets[0] = { ...packets[0], confidence: "low" };
+  const report = validateRecords(DOSSIER, packets);
+  const signatureBlockers = report.blockers
+    .filter((blocker) => blocker.includes("signature invalid"));
+
+  assert.equal(report.gate_status, "blocked", "tampered packet must block");
+  assert.equal(signatureBlockers.length, 1, "exactly one signature discriminator must fire");
+  assert.equal(report.blockers.length, 1, "fixture must not create unrelated blockers");
+
+  return {
+    status: "blocked",
+    reason: "invalid-signature",
+    tampered_packet_rejected: true
+  };
+}
+
+async function main() {
+  const gate = runGateProof();
+  process.stdout.write("BLOCKED  tampered required-seat packet: signature invalid\n");
+  process.stdout.write(JSON.stringify({ ok: true, gate }) + "\n");
+}
+
+if (process.argv.length !== 2) {
+  process.stderr.write("Usage: node docs/runs/fail-closed-demo/run.mjs\n");
+  process.exit(2);
+}
+
+try {
+  await main();
+} catch (error) {
+  const detail = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`fail-closed-demo: ${detail}\n`);
+  process.exitCode = 1;
+}
+```
+
+- [ ] **Step 3: Run the gate-only proof**
+
+Run:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected exit `0` and exactly:
+
+```text
+BLOCKED  tampered required-seat packet: signature invalid
+{"ok":true,"gate":{"status":"blocked","reason":"invalid-signature","tampered_packet_rejected":true}}
+```
+
+- [ ] **Step 4: Prove invalid arguments use exit 2**
+
+Run:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs unexpected
+```
+
+Expected exit `2`, stderr `Usage: node docs/runs/fail-closed-demo/run.mjs`, and no success JSON.
+
+- [ ] **Step 5: Run the production gate regression suite**
+
+Run:
+
+```bash
+npm --prefix build-gate test
+```
+
+Expected: exit `0`; `test-trust.mjs OK` appears and the complete build-gate suite finishes successfully.
+
+- [ ] **Step 6: Commit the gate proof**
+
+```bash
+git add docs/runs/fail-closed-demo/run.mjs
+git diff --cached --check
+git commit -m "feat: add public fail-closed gate proof"
+```
+
+Expected: one created file and a clean staged diff.
+
+---
+
+### Task 2: `needs-human` Halt and Ed25519 Tamper Negative Control
+
+**Files:**
+- Modify: `docs/runs/fail-closed-demo/run.mjs`
+- Test: `docs/runs/fail-closed-demo/run.mjs`
+
+**Interfaces:**
+- Consumes: `runGateProof()` from Task 1 unchanged.
+- Consumes: `createOperator({workdir, rulebook, bounds, actions, signerName})` and `renderInbox(workdir)` from `forge/operator.mjs`.
+- Produces: internal `runOperatorProof(): Promise<{status: "needs-human", action_executed: false, inbox_open: 1, ledger_verified: true, tampered_ledger_rejected: true, signature_algorithm: "Ed25519"}>`.
+- Produces: final public CLI output and JSON contract consumed by README and CI.
+
+- [ ] **Step 1: Add the operator call with an explicit red stub**
+
+Add these built-in and repository imports below the existing `assert` import:
+
+```js
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { createOperator, renderInbox } from "../../../forge/operator.mjs";
+```
+
+Add this function immediately before `main()`:
+
+```js
+async function runOperatorProof() {
+  throw new Error("operator proof not implemented");
+}
+```
+
+Replace `main()` with:
+
+```js
+async function main() {
+  const gate = runGateProof();
+  const operator = await runOperatorProof();
+  process.stdout.write("BLOCKED  tampered required-seat packet: signature invalid\n");
+  process.stdout.write("HALTED   out-of-bounds action: not executed; needs-human recorded\n");
+  process.stdout.write("VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected\n");
+  process.stdout.write(JSON.stringify({ ok: true, gate, operator }) + "\n");
+}
+```
+
+- [ ] **Step 2: Run the public command and verify the new branch is red**
+
+Run:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected exit `1`, stderr `fail-closed-demo: operator proof not implemented`, and no success JSON.
+
+- [ ] **Step 3: Replace the stub with the complete operator proof**
+
+Replace the stubbed `runOperatorProof()` with:
+
+```js
+async function runOperatorProof() {
+  const workdir = mkdtempSync(path.join(os.tmpdir(), "telos-fail-closed-demo-"));
+  let actionCalls = 0;
+
+  try {
+    const op = createOperator({
+      workdir,
+      signerName: "fail-closed-demo",
+      rulebook: [{
+        id: "overspend",
+        when: () => true,
+        act: () => ({
+          action: "update_budget",
+          args: { campaign_id: "fixture-campaign", daily_budget_cents: 2501 }
+        })
+      }],
+      bounds: {
+        update_budget: (args) => args.daily_budget_cents <= 2000
+          ? true
+          : `daily_budget_cents ${args.daily_budget_cents} over cap 2000`
+      },
+      actions: {
+        update_budget: async () => {
+          actionCalls += 1;
+          return { ok: true };
+        }
+      }
+    });
+
+    const result = await op.runPass({ source: "fixture" });
+    assert.equal(result.halted, true, "out-of-bounds pass must halt");
+    assert.equal(actionCalls, 0, "out-of-bounds action must never execute");
+    assert.equal(result.decisions.length, 1, "one rule must produce one decision");
+
+    const decision = result.decisions[0];
+    assert.equal(decision.outcome, "needs-human", "decision must require a human");
+    assert.equal(decision.sig?.alg, "Ed25519", "decision must use Ed25519");
+
+    const inboxRecords = readFileSync(op.inboxPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+    assert.equal(inboxRecords.length, 1, "one needs-human record must exist");
+    assert.equal(inboxRecords[0].resolution, null, "needs-human record must remain open");
+    assert.match(inboxRecords[0].question, /over cap 2000/, "record must name the bound");
+
+    const inbox = renderInbox(workdir);
+    assert.equal(inbox.open, 1, "rendered inbox must report one open item");
+    assert.match(
+      readFileSync(path.join(workdir, "INBOX.md"), "utf8"),
+      /\*\*1 open\*\*/,
+      "human inbox must render the open decision"
+    );
+
+    const cleanAudit = op.verifyLedger();
+    assert.deepEqual(
+      cleanAudit,
+      { total: 1, invalid: 0, ok: true },
+      "untouched Ed25519 ledger must verify"
+    );
+
+    const ledgerRecord = JSON.parse(readFileSync(op.ledgerPath, "utf8").trim());
+    const tampered = { ...ledgerRecord, reason: `${ledgerRecord.reason} [tampered]` };
+    writeFileSync(op.ledgerPath, JSON.stringify(tampered) + "\n");
+    const tamperedAudit = op.verifyLedger();
+    assert.deepEqual(
+      tamperedAudit,
+      { total: 1, invalid: 1, ok: false },
+      "one-field ledger mutation must fail verification"
+    );
+
+    return {
+      status: "needs-human",
+      action_executed: actionCalls !== 0,
+      inbox_open: inbox.open,
+      ledger_verified: cleanAudit.ok,
+      tampered_ledger_rejected: !tamperedAudit.ok && tamperedAudit.invalid === 1,
+      signature_algorithm: decision.sig.alg
+    };
+  } finally {
+    rmSync(workdir, { recursive: true, force: true });
+  }
+}
+```
+
+- [ ] **Step 4: Run the complete proof in a controlled temporary root**
+
+Run:
+
+```bash
+(
+  set -e
+  sandbox="$(mktemp -d)"
+  trap 'rm -rf -- "$sandbox"' EXIT
+  TMPDIR="$sandbox" node docs/runs/fail-closed-demo/run.mjs
+  test -z "$(find "$sandbox" -mindepth 1 -print -quit)"
+  rmdir "$sandbox"
+  trap - EXIT
+)
+```
+
+Expected exit `0`, an empty controlled temporary root after the run, and exactly:
+
+```text
+BLOCKED  tampered required-seat packet: signature invalid
+HALTED   out-of-bounds action: not executed; needs-human recorded
+VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected
+{"ok":true,"gate":{"status":"blocked","reason":"invalid-signature","tampered_packet_rejected":true},"operator":{"status":"needs-human","action_executed":false,"inbox_open":1,"ledger_verified":true,"tampered_ledger_rejected":true,"signature_algorithm":"Ed25519"}}
+```
+
+- [ ] **Step 5: Prove the public command leaves the tracked checkout untouched**
+
+Run:
+
+```bash
+(
+  set -e
+  output="$(mktemp)"
+  trap 'rm -f -- "$output"' EXIT
+  before="$(git status --porcelain=v1)"
+  node docs/runs/fail-closed-demo/run.mjs >"$output"
+  after="$(git status --porcelain=v1)"
+  test "$before" = "$after"
+)
+```
+
+Expected: exit `0`; the before/after status strings are identical.
+
+- [ ] **Step 6: Run the production operator regression suite**
+
+Run:
+
+```bash
+npm --prefix forge test
+```
+
+Expected: exit `0` and final marker `test-operator: all assertions passed`.
+
+- [ ] **Step 7: Commit the complete public proof**
+
+```bash
+git add docs/runs/fail-closed-demo/run.mjs
+git diff --cached --check
+git commit -m "feat: prove signed needs-human halt"
+```
+
+Expected: only the demo script changes.
+
+---
+
+### Task 3: Required Node 18/20 CI Proof
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:18-174`
+- Test: `.github/workflows/ci.yml` structural assertions plus the public CLI
+
+**Interfaces:**
+- Consumes: `node docs/runs/fail-closed-demo/run.mjs` from Task 2.
+- Produces: GitHub Actions job group `fail-closed-proof`.
+- Produces: `needs.fail-closed-proof.result`, required by the aggregate `required-ci` job.
+
+- [ ] **Step 1: Run a structural assertion before the CI job exists**
+
+Run:
+
+```bash
+node --input-type=module <<'NODE'
+import { readFileSync } from "node:fs";
+const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+const required = [
+  "  fail-closed-proof:",
+  "name: fail-closed proof (node ${{ matrix.node-version }})",
+  "run: node docs/runs/fail-closed-demo/run.mjs",
+  "      - fail-closed-proof",
+  "PROOF_RESULT: ${{ needs.fail-closed-proof.result }}",
+  "test \"$PROOF_RESULT\" = \"success\""
+];
+for (const text of required) {
+  if (!workflow.includes(text)) throw new Error(`missing CI proof contract: ${text}`);
+}
+console.log("ci-proof-contract: OK");
+NODE
+```
+
+Expected: nonzero exit with `missing CI proof contract:   fail-closed-proof:`.
+
+- [ ] **Step 2: Add the dedicated proof matrix**
+
+Insert this job between `test` and `repository-portability`:
+
+```yaml
+  fail-closed-proof:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['18', '20']
+    name: fail-closed proof (node ${{ matrix.node-version }})
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run the public fail-closed proof
+        run: node docs/runs/fail-closed-demo/run.mjs
+```
+
+Add the new job group to `required-ci.needs`:
+
+```yaml
+      - fail-closed-proof
+```
+
+Add this environment value to `required-ci`:
+
+```yaml
+          PROOF_RESULT: ${{ needs.fail-closed-proof.result }}
+```
+
+Add this assertion immediately after the existing `TEST_RESULT` assertion:
+
+```yaml
+          test "$PROOF_RESULT" = "success"
+```
+
+- [ ] **Step 3: Re-run the CI structural assertion**
+
+Run the exact Node stdin command from Step 1.
+
+Expected: exit `0` and `ci-proof-contract: OK`.
+
+- [ ] **Step 4: Exercise the public command at the CI version floor and ceiling**
+
+Run:
+
+```bash
+nvm exec 18 node docs/runs/fail-closed-demo/run.mjs
+nvm exec 20 node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected: both commands exit `0` and print the same frozen JSON result.
+
+- [ ] **Step 5: Run workflow-adjacent repository oracles**
+
+Run:
+
+```bash
+node .github/scripts/check-portable-paths.mjs
+node docs/institutional-memory/verify-contracts.mjs
+```
+
+Expected: `portable-paths: 0 violation(s)` and `301/301 contracts match system reality`.
+
+- [ ] **Step 6: Commit the required CI job**
+
+```bash
+git add .github/workflows/ci.yml
+git diff --cached --check
+git commit -m "ci: require fail-closed public proof"
+```
+
+Expected: only `.github/workflows/ci.yml` changes.
+
+---
+
+### Task 4: README First Screen, Human Boundary, and System Map
+
+**Files:**
+- Modify: `README.md:5-128`
+- Test: `README.md` content assertions, path checks, and Mermaid byte comparison
+
+**Interfaces:**
+- Consumes: the exact command and output contract from Task 2.
+- Consumes: the Node 18/20 guarantee from Task 3.
+- Produces: the portfolio-first landing sequence and authoritative classification used by Task 5.
+
+- [ ] **Step 1: Run the first-screen contract before the new sections exist**
+
+Run:
+
+```bash
+node --input-type=module <<'NODE'
+import { readFileSync } from "node:fs";
+const readme = readFileSync("README.md", "utf8");
+const required = [
+  "## Two-minute fail-closed proof",
+  "## Governed build path",
+  "## From authority to implementation",
+  "## When automation must stop",
+  "## System map",
+  "## Terminology",
+  "tampered_ledger_rejected"
+];
+for (const text of required) {
+  if (!readme.includes(text)) throw new Error(`missing README contract: ${text}`);
+}
+if (/idea to merged,\s+verified artifacts/.test(readme)) {
+  throw new Error("README still overclaims autonomous merging");
+}
+console.log("readme-first-screen-contract: OK");
+NODE
+```
+
+Expected: nonzero exit with `missing README contract: ## Two-minute fail-closed proof`.
+
+- [ ] **Step 2: Replace the opening through the architecture heading**
+
+Keep the title and CI badge. Replace `README.md:5-18` with:
+
+````markdown
+> An AI agent that grades its own work can rubber-stamp its own mistakes. TELOS
+> makes the thing that *builds* never be the thing that *certifies*: a build's
+> claim is data; the disk is the truth.
+
+**AI-native systems engineering with a deterministic trust spine.** Models may
+propose, implement, and review, but merge-readiness comes from disk evidence,
+content hashes, signatures, provenance, and reproducible checks—not a model's
+self-report.
+
+The required council is exactly `claude`, `agy`, and `codex`; `grok` and
+`gemini` are advisory. `agy` is a deterministic local governance attestation,
+not a remote model. A gate result can certify `merge_status: "ready"`.
+Implementation authority, acceptance, and merge remain separate human decisions
+held by **The Eye**.
+
+Core packages: **Node ≥18 · zero runtime dependencies · MIT**
+
+## Two-minute fail-closed proof
+
+From a fresh clone—no install, API key, service, or network access:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected:
+
+```text
+BLOCKED  tampered required-seat packet: signature invalid
+HALTED   out-of-bounds action: not executed; needs-human recorded
+VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected
+{"ok":true,"gate":{"status":"blocked","reason":"invalid-signature","tampered_packet_rejected":true},"operator":{"status":"needs-human","action_executed":false,"inbox_open":1,"ledger_verified":true,"tampered_ledger_rejected":true,"signature_algorithm":"Ed25519"}}
+```
+
+The script signs a valid required-seat trio, changes one signed field, and
+requires the real gate to reject it specifically for signature invalidity. It
+then proposes an over-cap operator action, proves the action was never called,
+records `needs-human`, verifies the Ed25519 decision ledger, changes one ledger
+field, and requires verification to fail.
+
+## Governed build path
+````
+
+Leave the existing Mermaid fence and every byte inside it unchanged.
+
+- [ ] **Step 3: Replace the post-diagram explanation and component overview**
+
+Replace the current post-diagram paragraph and entire `## Components` section
+through the `narcissus/flagship` bullet with:
+
+````markdown
+The diagram is the **governed build path**, not the complete repository map. The
+required seats produce HMAC-signed, provenance-bound packets; the gate blocks or
+certifies merge-readiness; build workers write and self-correct; independent
+verification re-derives disk state; and the controller records settlement in an
+Ed25519 ledger. The terminal is `merge_status: "ready"`, never an autonomous
+merge.
+
+## From authority to implementation
+
+TELOS inherits an institution before it executes a plan:
+
+1. [`CURRENT-AUTHORITY.json`](CURRENT-AUTHORITY.json) names the one active plan
+   and authorization; superseded records cannot govern new work.
+2. Institutional memory and the applicable comprehension gate establish what a
+   worker must understand before implementation.
+3. **Daedalus** matures implementation plans. Convergence is submission, not
+   authorization.
+4. **TELOS** governs review evidence and records the model council's
+   authorization outcome.
+5. **The Eye** grants non-delegable implementation authority and accepts or
+   refuses completed slices.
+6. **Argo** is the implementation role carrying authorized work through code,
+   verification, and documentation. No autonomous Argo service exists.
+7. **Clotho** creates and maintains graph threads, **Lachesis** measures
+   dependency and blast radius, and **Atropos** currently verifies recorded
+   supersession consistency. Retirement action remains human-governed.
+
+Start with [`AI-START-HERE.md`](AI-START-HERE.md) for the exact load order and
+[`repository-manifest.json`](repository-manifest.json) for the architectural
+map.
+
+## When automation must stop
+
+The crossroad-ads Phase 2 operator is deliberately **ARMED, awaiting go-live**:
+it can create only `PAUSED` campaign objects, while activation remains a human
+action. Missing credentials, quota failures, and out-of-bounds budget changes
+become `needs-human` records and halt instead of fabricating success.
+
+The mechanism and keyless negative controls are committed in
+[`OPS-README.md`](docs/runs/crossroad-ads/OPS-README.md),
+[`test-ads-ops.mjs`](docs/runs/crossroad-ads/test-ads-ops.mjs),
+[`operator.mjs`](forge/operator.mjs), and
+[`test-operator.mjs`](forge/scripts/test-operator.mjs). The live
+`workdir/needs-human.jsonl`, `workdir/INBOX.md`, and operator ledger are
+runtime/gitignored artifacts; this README does not pretend a particular signed
+go-live refusal is committed.
+
+## System map
+
+The complete package classification comes from
+[`package-roots.json`](clotho/memory/CONTRACTS/package-roots.json) and the
+[`Iliad enrollment contract`](docs/institutional-memory/iliad/CONTRACTS/enrollment.json).
+
+| Boundary | Current members | Status |
+| --- | --- | --- |
+| Enrolled TELOS spine | `atropos`, `breakout`, `build-gate`, `clotho`, `connectors/ai-peer-mcp`, `lachesis`, `merkle-dag` | Implemented and consciously enrolled |
+| Products beside the spine | `ai-forge`, `ai-native-memory`, `forge`, `narcissus/flagship`, `saas-forge` | Implemented; Iliad enrollment deferred |
+| Active role/capability modules | Daedalus, TELOS, Argo, The Iliad, `loadout` | Protocol/code/run lineage; no autonomous role services |
+| Registered future roles | Hermes, Medusa, Narcissus | Meanings reserved; unimplemented |
+
+`contracts/` contains the human-readable protocols; it is a reference boundary,
+not another package root. The implemented `narcissus/flagship` product is
+distinct from the registered, unimplemented Narcissus role.
+
+### AI-native memory
+
+[`ai-native-memory/`](ai-native-memory/) packages the repository's
+institutional-memory discipline as a portable, zero-dependency Claude Code
+plugin/product. It ships `/memory-init`, `/memory-audit`, `/memory-verify`, and
+`/memory-gate`; memory-standard, authoring, and lifecycle skills; and auditor,
+comprehension, and adversarial-review agents. Its own authority and `memory/`
+records dogfood the same audit, verification, and comprehension oracles.
+
+`memory-init` scaffolds host-local authority and record files, so a fresh host
+does not need TELOS paths. The TELOS dogfood authority path is evidence for this
+repository, not a portability requirement. See the
+[`plugin metadata`](ai-native-memory/.claude-plugin/plugin.json) and
+[`dogfood evidence`](ai-native-memory/memory/EVIDENCE/README.md). Marketplace
+publication and Iliad enrollment remain deferred.
+
+## Terminology
+
+| Term | Meaning here |
+| --- | --- |
+| **telos** | The goal or contract being pursued. **TELOS** is the registered governance role and repository name. |
+| **seat** | One independently routed build or review participant with its own packet and provenance. |
+| **gate** | Deterministic validation that blocks on missing, invalid, or contradictory evidence. |
+| **breakout** | Adversarial self-challenge plus verification against facts on disk. |
+| **agy** | The deterministic local governance checkpoint/attestation occupying one required seat. |
+````
+
+Keep the existing `## Autonomous builder (agentic-teams)` and all later content
+for Task 5.
+
+- [ ] **Step 4: Re-run the first-screen contract**
+
+Run the exact Node stdin command from Step 1.
+
+Expected: exit `0` and `readme-first-screen-contract: OK`.
+
+- [ ] **Step 5: Prove the Mermaid block stayed byte-identical**
+
+Run:
+
+```bash
+node --input-type=module <<'NODE'
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+const before = execFileSync("git", ["show", "HEAD:README.md"], { encoding: "utf8" });
+const after = readFileSync("README.md", "utf8");
+const block = (text) => text.match(/```mermaid\n[\s\S]*?\n```/)?.[0];
+if (!block(before) || block(before) !== block(after)) {
+  throw new Error("Mermaid build-path block changed");
+}
+console.log("mermaid-block: unchanged");
+NODE
+```
+
+Expected: exit `0` and `mermaid-block: unchanged`.
+
+- [ ] **Step 6: Verify every newly linked path is tracked**
+
+Run:
+
+```bash
+git ls-files --error-unmatch \
+  AI-START-HERE.md \
+  CURRENT-AUTHORITY.json \
+  repository-manifest.json \
+  clotho/memory/CONTRACTS/package-roots.json \
+  docs/institutional-memory/iliad/CONTRACTS/enrollment.json \
+  docs/runs/crossroad-ads/OPS-README.md \
+  docs/runs/crossroad-ads/test-ads-ops.mjs \
+  forge/operator.mjs \
+  forge/scripts/test-operator.mjs \
+  ai-native-memory/.claude-plugin/plugin.json \
+  ai-native-memory/memory/EVIDENCE/README.md
+```
+
+Expected: exit `0` and every path printed.
+
+- [ ] **Step 7: Commit the portfolio-first landing sequence**
+
+```bash
+git add README.md
+git diff --cached --check
+git commit -m "docs: lead README with fail-closed proof"
+```
+
+Expected: only `README.md` changes.
+
+---
+
+### Task 5: README Lifecycle Accuracy, Verification, Evidence, and Provenance
+
+**Files:**
+- Modify: `README.md` sections `Proposal Lifecycle`, `Trust model`, `Test`, `Docs & evidence`, and `Provenance / layout note`
+- Test: `README.md` stale-claim scan and relative-link resolver
+
+**Interfaces:**
+- Consumes: the classified map and public proof wording from Task 4.
+- Produces: the final README required by the design.
+
+- [ ] **Step 1: Run the stale-copy assertion before correction**
+
+Run:
+
+```bash
+node --input-type=module <<'NODE'
+import { readFileSync } from "node:fs";
+const readme = readFileSync("README.md", "utf8");
+const forbidden = [
+  "## Proposal Lifecycle (Daedalus)",
+  "cd build-gate",
+  "reference + evidence artifact",
+  "Authored by `claude-code`"
+];
+for (const text of forbidden) {
+  if (readme.includes(text)) throw new Error(`stale README claim remains: ${text}`);
+}
+for (const text of ["## Honest boundaries", "## Verification", "## Provenance"]) {
+  if (!readme.includes(text)) throw new Error(`missing final README section: ${text}`);
+}
+console.log("readme-final-contract: OK");
+NODE
+```
+
+Expected: nonzero exit with `stale README claim remains: ## Proposal Lifecycle (Daedalus)`.
+
+- [ ] **Step 2: Correct the Daedalus/TELOS/Argo lifecycle boundary**
+
+Replace the `## Proposal Lifecycle (Daedalus)` heading, its opening paragraphs,
+and its ASCII flow through the closing code fence with:
+
+````markdown
+## Proposal lifecycle: Daedalus → TELOS → Argo
+
+The agentic-teams path answers whether built evidence is merge-ready. The
+proposal lifecycle begins earlier and keeps three events separate:
+
+1. **Daedalus convergence** — planning seats stop objecting and submit a frozen
+   candidate.
+2. **TELOS authorization** — required model seats review the exact candidate;
+   one required dissent blocks and the signed run records `AUTHORIZED` or
+   `NOT_AUTHORIZED`.
+3. **The Eye's implementation authority** — the human authority holder decides
+   whether Argo may carry that plan through implementation, verification, and
+   documentation.
+
+Model convergence does not authorize. A TELOS council result does not execute.
+Argo does not choose scope, and no autonomous Argo service exists.
+
+```text
+idea + telos
+  → Daedalus workshop → converged candidate with content-addressed rounds
+  → compileAndHashPlan() → immutable candidate + obligations
+  → TELOS cold review of the exact plan hash
+  → typed concerns + deterministic gate → AUTHORIZED | NOT_AUTHORIZED
+  → The Eye grants or refuses implementation authority
+  → Argo carries the authorized plan through code + verification + documentation
+  → The Eye accepts or refuses the slice; maintainers decide merge
+```
+````
+
+Keep the existing enforcement-detail paragraphs and bullets that follow this
+flow.
+
+- [ ] **Step 3: Add an explicit honest-boundaries section**
+
+Insert this section between the existing `## Trust model (fail-closed)` content
+and the test/verification section:
+
+```markdown
+## Honest boundaries
+
+- The gate, ledgers, metrics, supersession verifier, plugin oracles, forges, and
+  their tests run locally. Provider-backed council calls require the provider's
+  configured credentials.
+- TELOS authorization certifies only the checked merge-readiness predicates. It
+  does not execute code or merge a branch.
+- No autonomous Argo or Iliad service exists. Those names describe governed
+  roles and lifecycle protocols.
+- Model consensus is not human authority. The Eye's implementation and
+  acceptance authority is non-delegable.
+- Per-seat HMAC is an integrity and binding floor for the honest-but-careless
+  threat model. One owner holding every seat secret can forge those packets; it
+  is not non-repudiation.
+- The gate checks provenance shape, uniqueness, and signature binding from disk.
+  It cannot prove a well-formed response id was genuinely issued without
+  re-contacting the provider.
+- Clotho is advisory and non-sandboxed. Green checks prove only the predicates
+  they execute.
+- Implemented sibling products are not thereby enrolled in the TELOS spine.
+```
+
+- [ ] **Step 4: Replace the stateful test block with root-safe verification**
+
+Replace the entire current `## Test` section with:
+
+````markdown
+## Verification
+
+The core, forge, plugin, and enrolled spine packages are Node ≥18 ESM with zero
+runtime dependencies. CI runs them under Node 18 and 20. The
+`narcissus/flagship` product is the explicit exception: it requires Node
+`^20.19.0 || >=22.12.0`, uses a tracked npm lockfile, and has its own install,
+audit, unit, evidence, graph, build, and browser pipeline.
+
+Fast public proof:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+node docs/institutional-memory/verify-contracts.mjs
+node docs/runs/clotho-self-weave/run.mjs --verify-committed
+```
+
+Complete local package suite, with every command safe to paste independently
+from the repository root:
+
+```bash
+npm --prefix build-gate test
+npm --prefix breakout test
+npm --prefix connectors/ai-peer-mcp test
+npm --prefix merkle-dag test
+npm --prefix saas-forge test
+npm --prefix ai-forge test
+npm --prefix forge test
+npm --prefix clotho test
+npm --prefix ai-native-memory run check
+npm --prefix ai-native-memory test
+npm --prefix lachesis test
+npm --prefix atropos test
+```
+
+Flagship pipeline under Node 20:
+
+```bash
+npm --prefix narcissus/flagship ci
+npm --prefix narcissus/flagship audit --audit-level=moderate
+npm --prefix narcissus/flagship test
+npm --prefix narcissus/flagship run verify:evidence
+npm --prefix narcissus/flagship run verify:coverage
+npm --prefix narcissus/flagship run check:live-graph
+npm --prefix narcissus/flagship run build
+(cd narcissus/flagship && npx playwright install --with-deps chromium)
+npm --prefix narcissus/flagship run test:e2e
+```
+````
+
+- [ ] **Step 5: Replace the evidence index**
+
+Replace the entire `## Docs & evidence` section with:
+
+````markdown
+## Docs & evidence
+
+- [`AI-START-HERE.md`](AI-START-HERE.md) — onboarding order and component routing.
+- [`CURRENT-AUTHORITY.json`](CURRENT-AUTHORITY.json) — the one active plan,
+  authorization, implementation holder, and superseded chain.
+- [`repository-manifest.json`](repository-manifest.json) — architectural map,
+  role ownership, claims, and explicit non-claims.
+- [`docs/institutional-memory/`](docs/institutional-memory/) — machine-first
+  authority, invariants, decisions, comprehension gates, and executable
+  contract verification.
+- [`docs/runs/clotho-self-weave/`](docs/runs/clotho-self-weave/) — committed,
+  signed knowledge-graph snapshot and read-only reproduction verifier.
+- [`ai-native-memory/memory/EVIDENCE/README.md`](ai-native-memory/memory/EVIDENCE/README.md)
+  — portable plugin dogfood and inheritance evidence.
+- [`docs/runs/crossroad-ads/`](docs/runs/crossroad-ads/) — bounded `PAUSED` ads
+  operator, `needs-human` behavior, and keyless negative controls.
+- [`narcissus/flagship/src/evidence-ledger.json`](narcissus/flagship/src/evidence-ledger.json),
+  [`live-graph.json`](narcissus/flagship/src/live-graph.json), and
+  [`screenshots/`](narcissus/flagship/screenshots/) — the implemented “Loom on
+  Trial” product's evidence, graph, and visual proof.
+- [`docs/runs/`](docs/runs/) — authorization refusals and successes, Argo slice
+  evidence, proposal-lifecycle runs, Clotho evidence, and product runs.
+- [`contracts/`](contracts/) — human-readable protocols enforced by the gate.
+- [`docs/history/`](docs/history/) — superseded records retained for provenance;
+  they do not govern current work.
+````
+
+- [ ] **Step 6: Replace the obsolete provenance/layout note**
+
+Replace `## Provenance / layout note` and its paragraph with:
+
+```markdown
+## Provenance
+
+TELOS is human-directed and developed with multiple model seats. The repository
+dogfoods its own deterministic review, evidence, signature, negative-control,
+and institutional-memory mechanisms; generated text or code is still data, not
+authority or certification.
+
+The project began inside a larger multi-model vault. This repository now
+contains standalone executable packages and committed evidence, while live
+provider wiring remains credential-dependent and environment-specific.
+```
+
+- [ ] **Step 7: Re-run the final README contract**
+
+Run the exact Node stdin command from Step 1.
+
+Expected: exit `0` and `readme-final-contract: OK`.
+
+- [ ] **Step 8: Resolve every repository-relative Markdown link**
+
+Run:
+
+```bash
+node --input-type=module <<'NODE'
+import { existsSync, readFileSync } from "node:fs";
+const readme = readFileSync("README.md", "utf8");
+const targets = [...readme.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)]
+  .map((match) => match[1])
+  .filter((target) => !/^(https?:|#)/.test(target))
+  .map((target) => target.split("#", 1)[0]);
+const missing = [...new Set(targets)].filter((target) => !existsSync(target));
+if (missing.length) throw new Error(`missing README targets: ${missing.join(", ")}`);
+console.log(`readme-links: ${targets.length} local links resolve`);
+NODE
+```
+
+Expected: exit `0` and a positive resolved-link count.
+
+- [ ] **Step 9: Scan for the corrected overclaims**
+
+Run:
+
+```bash
+if rg -n \
+  -e 'idea to merged, verified artifacts' \
+  -e 'verified, merged artifacts' \
+  -e 'Authored by `claude-code`' \
+  -e 'reference \+ evidence artifact' \
+  -e 'Independent AI model .*agy' \
+  README.md; then
+  exit 1
+fi
+echo "readme-overclaims: none"
+```
+
+Expected: exit `0` and `readme-overclaims: none`.
+
+- [ ] **Step 10: Commit the final README accuracy pass**
+
+```bash
+git add README.md
+git diff --cached --check
+git commit -m "docs: align README with current authority"
+```
+
+Expected: only `README.md` changes.
+
+---
+
+### Task 6: Whole-Branch Verification and Handoff
+
+**Files:**
+- Verify only: `README.md`
+- Verify only: `docs/runs/fail-closed-demo/run.mjs`
+- Verify only: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: all earlier task outputs.
+- Produces: evidence-backed branch status for review. It does not push, merge, tag, or publish.
+
+- [ ] **Step 1: Re-run the public proof under both supported CI versions**
+
+Run:
+
+```bash
+nvm exec 18 node docs/runs/fail-closed-demo/run.mjs
+nvm exec 20 node docs/runs/fail-closed-demo/run.mjs
+```
+
+Expected: both exit `0` with identical frozen JSON and all three human lines.
+
+- [ ] **Step 2: Run every zero-dependency package job under Node 18 and Node 20**
+
+Run:
+
+```bash
+for version in 18 20; do
+  for package in \
+    build-gate \
+    breakout \
+    connectors/ai-peer-mcp \
+    merkle-dag \
+    saas-forge \
+    ai-forge \
+    forge \
+    clotho \
+    ai-native-memory \
+    lachesis \
+    atropos
+  do
+    nvm exec "$version" npm --prefix "$package" test
+  done
+  nvm exec "$version" npm --prefix ai-native-memory run check
+done
+```
+
+Expected: all 22 package matrix entries plus both plugin syntax checks exit `0`.
+
+- [ ] **Step 3: Run the repository truth and portability oracles**
+
+Run:
+
+```bash
+nvm exec 20 node docs/institutional-memory/verify-contracts.mjs
+nvm exec 20 node docs/runs/clotho-self-weave/run.mjs --verify-committed
+nvm exec 20 node .github/scripts/check-portable-paths.mjs
+```
+
+Expected:
+
+```text
+-> 301/301 contracts match system reality
+{"edge_count":4463,"mode":"verify-committed","ok":true,...,"trusted_record_count":4463}
+portable-paths: 0 violation(s)
+```
+
+The JSON may contain the existing repository and snapshot hashes between the
+shown fields; counts and `ok: true` must match.
+
+- [ ] **Step 4: Run the complete flagship CI-equivalent pipeline under Node 20**
+
+Run:
+
+```bash
+nvm exec 20 npm --prefix narcissus/flagship ci
+nvm exec 20 npm --prefix narcissus/flagship audit --audit-level=moderate
+nvm exec 20 npm --prefix narcissus/flagship test
+nvm exec 20 npm --prefix narcissus/flagship run verify:evidence
+nvm exec 20 npm --prefix narcissus/flagship run verify:coverage
+nvm exec 20 npm --prefix narcissus/flagship run check:live-graph
+nvm exec 20 npm --prefix narcissus/flagship run build
+(cd narcissus/flagship && nvm exec 20 npx playwright install --with-deps chromium)
+nvm exec 20 npm --prefix narcissus/flagship run test:e2e
+```
+
+Expected: audit has no moderate-or-higher finding; unit, evidence, coverage,
+live-graph, production build, and browser tests all exit `0`.
+
+- [ ] **Step 5: Re-run README and workflow structural checks**
+
+Run all Node stdin checks from Tasks 3, 4, and 5.
+
+Expected:
+
+```text
+ci-proof-contract: OK
+readme-first-screen-contract: OK
+readme-final-contract: OK
+readme-links: <positive integer> local links resolve
+```
+
+- [ ] **Step 6: Verify final scope, formatting, and clean tracked state**
+
+Run:
+
+```bash
+git diff --check main...HEAD
+git diff --name-only main...HEAD
+git status --short --branch
+```
+
+Expected complete branch path set:
+
+```text
+.github/workflows/ci.yml
+README.md
+docs/runs/fail-closed-demo/run.mjs
+docs/superpowers/plans/2026-07-19-readme-v0.2-refresh.md
+docs/superpowers/specs/2026-07-19-readme-v0.2-refresh-design.md
+```
+
+The two `docs/superpowers/` planning records are intentional. No other path may
+appear. `git status` must show no tracked or untracked change after
+verification.
+
+- [ ] **Step 7: Present the branch for review**
+
+Report:
+
+- the final commit list;
+- the exact Node 18/20 demo result;
+- package matrix totals;
+- institutional contract, self-weave, portability, and flagship results;
+- the clean worktree;
+- that no push, PR, merge, tag, release, or publication occurred.
+
+Do not describe the branch as merged or release-ready. Await The Eye's review
+and integration instruction.

--- a/docs/superpowers/specs/2026-07-19-readme-v0.2-refresh-design.md
+++ b/docs/superpowers/specs/2026-07-19-readme-v0.2-refresh-design.md
@@ -1,0 +1,527 @@
+# Design: evidence-backed README refresh and two-minute fail-closed proof
+
+**Date:** 2026-07-19
+**Status:** Design direction selected by The Eye in this session; implementation
+planning and implementation authority remain separate later steps.
+**Working label:** “v0.2 README refresh” is a scope label, not a release, package
+version, tag, or publication decision.
+**Repository baseline:** `git:c807334992cf82ca2fab3df6bed86cc259324fda`
+**Existing authority context:** Clotho v15,
+`sha256:05a48700f92938e5fe1cf42199434ec163c86c9bda4f637d669fa89d5867f1c3`,
+authorized by `authz-008`, is complete. It does not silently authorize this new
+scope.
+
+## Problem
+
+The repository baseline already opens with the right core observation: an agent
+that grades its own work can rubber-stamp its own mistakes. It also cleanly
+distinguishes per-seat HMAC from the Ed25519 settlement ledger, and its Mermaid
+diagram makes the fail-closed build path visible. Those are strengths to
+preserve.
+
+The first screen then moves quickly into dense architecture and says the trust
+spine drives work to “merged” artifacts even though the enforced terminal is
+`merge_status: "ready"`. The value proposition should stay ahead of the
+mechanics and retain this precise boundary:
+
+> In an ordinary agentic build, the system that produces “done” can also assert
+> that it is done. TELOS separates generation from certification so a
+> hallucinated completion claim cannot settle without independent evidence.
+
+The README also makes the reader infer the most persuasive safety behavior. The
+repository already contains executable proof that:
+
+1. a required seat packet changed after signing is rejected by the real build
+   gate; and
+2. an action outside declared bounds is not executed, becomes a `needs-human`
+   record, halts the pass, and is preserved in a verifiable Ed25519 ledger.
+
+Those facts are dispersed across tests and run documentation. The landing page
+does not give a reader one keyless command that demonstrates both behaviors.
+
+Finally, parts of the current prose lag the repository’s machine records. It
+overstates autonomous merging, blurs the Daedalus/TELOS/Argo boundaries, presents
+deferred products as though they were enrolled spine packages, leaves terms
+unanchored, and ends by calling an active codebase primarily a reference artifact.
+
+## Decision
+
+Perform an evidence-backed portfolio refresh rather than a cosmetic README edit
+or a full documentation migration.
+
+The refresh will:
+
+- retain and sharpen the existing problem statement and trust boundary;
+- preserve and relabel the existing Mermaid build-path diagram;
+- add one deterministic, keyless, two-part demo using the production gate and
+  operator modules;
+- tell the real `needs-human` go-live story without claiming that a runtime,
+  gitignored refusal artifact is committed;
+- correct the repository and role classifications against machine records;
+- define the small set of terms a first-time reader needs;
+- state the standalone and human-authority boundaries precisely; and
+- replace the blanket model-authorship disclaimer with accurate historical
+  provenance and dogfooding language.
+
+This is intentionally smaller than a landing-page/documentation split. Deep
+architecture remains in the existing documents. A later release may add
+component READMEs, screenshots, a GIF, or a shortened root landing page after the
+plain command-line proof has survived CI.
+
+## Audience and reading contract
+
+The primary audience is a hiring engineer giving the repository roughly 90
+seconds before deciding whether to inspect it further. Secondary audiences are
+AI-systems engineers evaluating the trust model and contributors trying to run
+or modify the code.
+
+The top of the README must answer, in order:
+
+1. What failure does TELOS prevent?
+2. What is structurally different about it?
+3. Can I see that behavior without credentials?
+4. What is implemented, and what remains human or deferred?
+5. Where do I go for architecture, authority, and complete verification?
+
+The page must remain useful after the first screen. Portfolio clarity cannot come
+at the cost of making a load-bearing claim less precise.
+
+## Goals
+
+1. Make the value proposition legible before the architecture.
+2. Let a fresh clone demonstrate fail-closed behavior in under two minutes with
+   Node 18 or newer and no network access, credentials, install step, or runtime
+   dependencies.
+3. Ensure every prominent trust claim points to executable code, committed
+   evidence, a machine record, or a stable commit.
+4. Describe current package, product, and role boundaries consistently with
+   `repository-manifest.json`, AM-40, and the Iliad enrollment contract.
+5. Preserve the honest limits in the system and component `NON-CLAIMS` records.
+6. Keep the README commands paste-safe from the repository root.
+
+## Non-goals
+
+- No npm publication, marketplace publication, GitHub release, tag, or version
+  bump.
+- No claim that `ai-native-memory` is already marketplace-installable.
+- No implementation of an autonomous Argo, Iliad, or merge runner.
+- No component-level README campaign in this slice.
+- No redesign of the flagship application and no generated GIF.
+- No GitHub About/ruleset mutation in this slice.
+- No committed live-ad credentials, live Meta call, or runtime `workdir/`
+  artifact.
+- No assertion that a cryptographic signature proves prose truth, provider
+  identity, human approval, or correctness beyond the checked predicate.
+- No change to the registered mythological vocabulary.
+
+## README information architecture
+
+### 1. Identity, badges, and problem statement
+
+Keep the title, CI signal, Node support, license, zero-runtime-dependency
+signals, and current rubber-stamp problem statement. Shape the remainder of the
+first screen around four compact ideas:
+
+- agentic builds are unsafe when the builder can self-certify completion;
+- TELOS allows proposals and implementations to be model-assisted, but makes
+  merge-readiness depend on deterministic evidence, signatures, and provenance;
+- implementation authority, acceptance, and merge remain separate human
+  decisions held by The Eye; and
+- the result is merge-ready evidence, not autonomous merging.
+
+The required/advisory distinction appears on first use:
+
+- required seats: `claude`, `agy`, and `codex`;
+- advisory seats: `grok` and `gemini`;
+- `agy` is a deterministic local governance attestation, not a remote model.
+
+### 2. Two-minute proof
+
+Place a “Run the fail-closed proof” block before the detailed architecture:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+```
+
+The README will show a short representative output shape, not a copied
+timestamp, key, hash, temporary path, or other unstable value. The output must
+make both stopped actions visible:
+
+```text
+BLOCKED  tampered required-seat packet: signature invalid
+HALTED   out-of-bounds action: not executed; needs-human recorded
+VERIFIED HMAC gate + Ed25519 decision ledger; tamper rejected
+```
+
+The script’s JSON summary is the authoritative machine-readable result. The
+human lines exist for a quick portfolio demonstration.
+
+### 3. Architecture
+
+Preserve the current Mermaid diagram because it makes the normal build path and
+red fail-closed branch easy to understand. Relabel it explicitly as the
+**governed build path**, not the complete repository map.
+
+Preserve the diagram’s accurate `merge_status: ready` terminal. Correct the
+surrounding “autonomous builder” prose so it does not convert merge-readiness
+into autonomous merging.
+
+Accompany it with a compact lifecycle explanation:
+
+- institutional authority and memory establish what may govern;
+- comprehension is checked before implementation work;
+- Daedalus matures plans;
+- TELOS certifies review evidence and merge-readiness;
+- The Eye grants non-delegable implementation and acceptance authority;
+- Argo is the implementation role that carries authorized work through code,
+  verification, and documentation; there is no autonomous Argo service;
+- Clotho creates and maintains graph threads, Lachesis measures dependency and
+  blast radius, and Atropos currently verifies recorded supersession
+  consistency; retirement action remains human-governed.
+
+The README must not imply that Daedalus authorizes or implements, that TELOS
+executes, or that any model vote substitutes for The Eye.
+
+### 4. The `needs-human` boundary
+
+Add a short narrative anchored in the existing crossroad-ads run:
+
+- campaign objects are constrained to `PAUSED`;
+- go-live remains a human action;
+- missing credentials, quota failures, and out-of-bounds changes create a
+  `needs-human` record and halt instead of fabricating success;
+- the keyless test proves the over-cap action is not called and the operator
+  ledger verifies.
+
+Link to:
+
+- `docs/runs/crossroad-ads/OPS-README.md`;
+- `docs/runs/crossroad-ads/test-ads-ops.mjs`;
+- `forge/operator.mjs`; and
+- `forge/scripts/test-operator.mjs`.
+
+Truthfulness boundary: the repository commits the mechanism, tests, and run
+instructions. `workdir/needs-human.jsonl`, `workdir/INBOX.md`, and the live
+operator ledger are runtime/gitignored artifacts. The README must not call a
+specific signed go-live refusal “committed evidence” unless such an artifact is
+later deliberately sanitized, reviewed, and committed.
+
+### 5. Implemented system map
+
+Replace the undifferentiated “autonomous layers” presentation with four clear
+classes.
+
+**Enrolled TELOS spine**
+
+`atropos`, `breakout`, `build-gate`, `clotho`,
+`connectors/ai-peer-mcp`, `lachesis`, and `merkle-dag`.
+
+**Implemented products beside the spine; Iliad enrollment deferred**
+
+`ai-forge`, `ai-native-memory`, `forge`, `narcissus/flagship`, and
+`saas-forge`.
+
+**Active role and capability modules**
+
+Daedalus, TELOS, Argo, The Iliad, and the plain-language `loadout` capability.
+
+**Registered future role modules; unimplemented**
+
+Hermes, Medusa, and Narcissus. Link their registered meanings rather than
+improvising adjacent capabilities. The README must distinguish the implemented
+`narcissus/flagship` product from the registered but unimplemented Narcissus role
+module; filesystem proximity does not implement the role.
+
+`clotho/memory/CONTRACTS/package-roots.json` and the Iliad enrollment contract
+are the complete classification source. `repository-manifest.json` remains the
+architectural map but is not described as a complete package-root inventory
+while it omits sibling products.
+
+### 6. AI-native memory
+
+Give `ai-native-memory` enough space to be discoverable without turning the root
+README into its manual:
+
+- portable, zero-dependency institutional-memory plugin/product;
+- commands for initialization, audit, verification, and comprehension gating;
+- skills and agents that teach the same record lifecycle;
+- dogfooded against its own authority and memory records;
+- works in a fresh host repository because initialization scaffolds host-local
+  authority and records;
+- the TELOS dogfood authority path is repository-specific evidence, not a
+  portability requirement; and
+- marketplace publication and Iliad enrollment remain deferred.
+
+Link its package metadata, plugin metadata, memory evidence README, and test
+command. Do not advertise an installation channel that does not exist.
+
+### 7. Terminology
+
+Add a five-entry glossary near first use or immediately after the system map:
+
+- **telos** — the goal or contract being pursued; **TELOS** is the registered
+  governance role/repository name.
+- **seat** — one independently routed review or build participant with its own
+  packet and provenance.
+- **gate** — deterministic validation that blocks on missing or contradictory
+  evidence.
+- **breakout** — adversarial self-challenge plus fact verification before a
+  claim can settle.
+- **agy** — the deterministic local governance checkpoint/attestation that
+  occupies one required seat.
+
+Definitions must match the registered vocabulary and code. They may explain a
+term but may not broaden its ownership or capability.
+
+### 8. Standalone boundary and honest limits
+
+Replace “primarily a reference + evidence artifact” with a precise statement:
+
+- the gate, ledgers, metrics, retirement verifier, plugin oracles, forges, and
+  their tests run locally as zero-runtime-dependency packages;
+- provider-backed council/seat calls require their configured credentials;
+- no autonomous Argo or Iliad service exists;
+- authorization produces merge-readiness, not a merge;
+- model consensus is not human authority;
+- per-seat HMAC is an integrity and binding floor for the honest-but-careless
+  threat model, not non-repudiation against one owner holding every seat secret;
+- the gate validates provenance shape and binding from disk but cannot prove
+  that a provider genuinely issued a response id;
+- green checks prove only the predicates they execute;
+- Clotho is advisory and non-sandboxed; and
+- deferred products are implemented but not thereby enrolled in the TELOS
+  spine.
+
+### 9. Verification and evidence
+
+Make every command independently paste-safe from the repository root. Prefer
+subshells or npm’s `--prefix` form instead of a sequence of stateful `cd`
+commands.
+
+The short path contains:
+
+- the two-minute demo;
+- institutional contract verification;
+- committed self-weave verification; and
+- links to CI and the flagship evidence pipeline.
+
+The detailed package matrix remains available but is clearly labeled as the
+complete local suite. Counts may be shown only when they are generated by the
+current verification run or tied to a stable commit; floating counts must not be
+presented as timeless facts.
+
+Expand the evidence index to include `AI-START-HERE.md`,
+`CURRENT-AUTHORITY.json`, `repository-manifest.json`, institutional-memory
+records and oracles, Clotho self-weave evidence, AI-native-memory dogfood, the
+crossroad-ads bounded-operator proof, and Narcissus flagship evidence.
+
+### 10. Provenance
+
+Remove the closing “Authored by `claude-code`” line. Replace it with a bounded
+historical statement:
+
+- TELOS is human-directed and was developed with multiple model seats;
+- the repository dogfoods its deterministic review, evidence, and memory
+  mechanisms; and
+- generation provenance is not authority or certification.
+
+Do not make an exhaustive human/model authorship attribution unless the commit
+and run records can support it.
+
+## Demo design
+
+### Location and interface
+
+Add:
+
+```text
+docs/runs/fail-closed-demo/run.mjs
+```
+
+The script accepts no arguments in this slice. The default human-readable run is
+also the CI path. Unknown arguments fail with exit 2 and a concise usage
+message.
+
+The demo imports repository modules through relative paths and Node built-ins
+only. It does not duplicate the gate or operator algorithms.
+
+### Part A: tampered required-seat packet
+
+1. Create an in-memory signed-mode dossier fixture.
+2. Unconditionally shadow inherited `TELOS_SECRET_*` values inside the demo
+   process with clearly named fixture-only HMAC secrets. Never use or print an
+   inherited value; process exit contains the fixture environment.
+3. Construct `claude`, `agy`, and `codex` approval packets with the exact fields
+   and real-shaped per-seat provenance required by `validateRecords`.
+4. Sign all three through the existing signing primitive.
+5. Mutate only `confidence` from `"high"` to `"low"` on one required packet
+   after signing. This is the existing isolated negative control: the unsigned
+   semantics remain an approval while the signed bytes no longer match.
+6. Pass the dossier and packets to the real `build-gate/gate.mjs`
+   `validateRecords` export.
+7. Require `gate_status: "blocked"` and require the blocker to identify the
+   invalid signature. Reject any unrelated blocker produced by malformed demo
+   fixture data.
+
+The demo exits nonzero if the tampered packet passes, if the gate cannot run, or
+if the intended discriminator does not fire.
+
+### Part B: out-of-bounds operator action
+
+1. Create a temporary work directory with Node’s operating-system temp
+   facilities.
+2. Instantiate the real `forge/operator.mjs` operator with a one-rule rulebook,
+   a numeric cap, and an action function that increments an in-memory call
+   counter.
+3. Propose an action above the cap.
+4. Require the pass to halt with a `needs-human` outcome.
+5. Require the action call counter to remain zero.
+6. Read the generated `needs-human.jsonl` and rendered inbox and require the
+   expected open item.
+7. Run `verifyLedger()` and require a valid Ed25519 ledger.
+8. Preserve the original result in memory, mutate only the first decision
+   record’s `reason` field without re-signing it, rewrite that temporary ledger,
+   and require `verifyLedger()` to report exactly one invalid line. This is the
+   ledger’s negative control.
+9. Report the outcome without printing private key material or relying on a
+   stable temporary path.
+10. Remove the temporary directory in `finally`.
+
+This proves self-consistency and tamper detection of the generated decision
+ledger. It does not prove that an external platform obeyed an action that was
+never invoked, or that the signer is human authority.
+
+### Output and exit contract
+
+On success, stdout contains the three concise human lines and one JSON object:
+
+```json
+{
+  "ok": true,
+  "gate": {
+    "status": "blocked",
+    "reason": "invalid-signature",
+    "tampered_packet_rejected": true
+  },
+  "operator": {
+    "status": "needs-human",
+    "action_executed": false,
+    "inbox_open": 1,
+    "ledger_verified": true,
+    "tampered_ledger_rejected": true,
+    "signature_algorithm": "Ed25519"
+  }
+}
+```
+
+These summary field names are frozen by this design. The demo normalizes the
+production modules’ richer return structures into this small public contract.
+The human README sample may paraphrase them; CI exercises the same command and
+therefore the same assertions.
+
+Exit codes:
+
+- `0` — both protections fired and all discriminating assertions passed;
+- `1` — the demo ran but a safety assertion or cleanup failed;
+- `2` — invalid command-line use.
+
+No partial success exits zero.
+
+## Continuous integration
+
+Add a dedicated `fail-closed-proof` job with a Node `18`/`20` matrix to the
+existing CI workflow. Each matrix leg checks out the repository and runs the
+same public command shown in the README, not a test-only wrapper. Add that job
+group to `required-ci.needs` and require its aggregate result to equal `success`
+in the aggregate `required CI` job.
+
+The step must not add a package-manager install, secret, service, network call,
+or generated tracked artifact. Its job is regression protection for the public
+proof path, not a replacement for `build-gate` and `forge` package tests.
+
+## Files in scope
+
+Implementation is expected to change only:
+
+- `README.md`;
+- `docs/runs/fail-closed-demo/run.mjs`; and
+- `.github/workflows/ci.yml`.
+
+The later implementation plan may add a small fixture or test file only if the
+production APIs make a single-file demo impossible. It must explain that
+expansion before editing. Existing crossroad-ads evidence is linked, not
+rewritten.
+
+Because `docs/runs/` is deliberately excluded from the Clotho document weaver,
+the demo does not become a self-weave input merely by being placed there. The
+implementation must still run committed self-weave verification and report any
+actual freshness effect rather than assuming none.
+
+## Error handling and security
+
+- Fail closed on missing fixture inputs, malformed production return values,
+  unexpected gate blockers, ledger verification failure, action invocation, or
+  cleanup failure.
+- Use only synthetic fixture data and clearly labeled fixture secrets.
+- Never read or print user/provider credentials.
+- Never contact external services.
+- Never write below the repository except through the operating-system
+  temporary directory; always clean it.
+- Complete temporary cleanup before printing the success lines or success JSON;
+  a cleanup failure is a demo failure.
+- Never weaken a production validator to make the demo easier.
+- Keep HMAC packet authentication and Ed25519 decision-ledger signing described
+  as distinct mechanisms.
+
+## Validation
+
+Before the implementation can be called complete:
+
+```bash
+node docs/runs/fail-closed-demo/run.mjs
+npm --prefix build-gate test
+npm --prefix forge test
+node docs/institutional-memory/verify-contracts.mjs
+node docs/runs/clotho-self-weave/run.mjs --verify-committed
+node .github/scripts/check-portable-paths.mjs
+```
+
+Also:
+
+- run the complete existing CI-equivalent package and flagship suite appropriate
+  to the changed workflow;
+- confirm the demo leaves `git status --short` empty;
+- check every new README link and repository-relative path;
+- check all displayed commands from the repository root;
+- verify the Mermaid block renders;
+- search the changed prose for unregistered mythological terms and unsupported
+  claims;
+- run `git diff --check`; and
+- require the protected aggregate CI result before merge.
+
+If any existing command name differs at implementation time, the plan must use
+the package’s actual `package.json` script or documented oracle. The README and
+CI must show the same command that was verified.
+
+## Acceptance criteria
+
+The refresh is complete only when:
+
+1. the first screen states the problem, separation of duties, and
+   merge-readiness boundary;
+2. a fresh credential-free clone can run the public proof command on Node 18+
+   and observe both intended safety discriminators;
+3. the tampered required-seat packet is blocked specifically for signature
+   invalidity;
+4. the out-of-bounds action is never invoked, creates `needs-human`, halts,
+   leaves an untouched ledger that verifies, and makes a one-field ledger
+   mutation fail verification;
+5. the README does not claim a committed signed go-live refusal that is not on
+   disk;
+6. HMAC seat packets and Ed25519 ledger records remain distinct;
+7. package, product, enrollment, and role classifications match the machine
+   records;
+8. Daedalus, TELOS, Argo, and The Eye retain their exact authority boundaries;
+9. all commands and links work from a fresh repository root;
+10. the demo runs in CI and the full required verification remains green; and
+11. the tracked checkout is clean after every public verification command.


### PR DESCRIPTION
## What changed

- Add a keyless, zero-dependency public proof that a tampered required-seat HMAC packet is blocked and an out-of-bounds operator action becomes a signed `needs-human` halt.
- Run that proof in a required Node 18/20 CI matrix.
- Refresh the root README around the problem statement, two-minute proof, human-authority boundary, current system/product/role classifications, AI-native-memory, verification, evidence, and provenance.
- Commit the governing design and task-by-task implementation plan.

## Why

TELOS already enforced fail-closed behavior, but the strongest safety evidence was dispersed across tests and run records. This makes the behavior directly runnable from a fresh clone and corrects stale or overbroad landing-page claims, especially merge-ready versus merged, TELOS versus Argo execution, and runtime `needs-human` records versus committed evidence.

## User/developer impact

A reviewer can now run:

```bash
node docs/runs/fail-closed-demo/run.mjs
```

No install, credentials, network access, or runtime dependencies are required. The README commands are independently paste-safe from the repository root.

## Validation

- Public proof: identical frozen result on Node 18.20.8 and 20.20.2.
- Zero-dependency package matrix: 22/22 package tests plus 2/2 AI-native-memory checks.
- Institutional contracts: 301/301.
- Committed self-weave: 4,463 trusted records.
- Portability: 0 violations.
- AI-native-memory: 6/6 test files.
- Narcissus flagship: audit clean, unit 9/9, evidence 7, coverage 16/16, live graph 1,067 nodes / 4,463 edges, production build passed, E2E 13/13.
- Final whole-branch review: READY TO MERGE with 0 Critical, 0 Important, and 0 Minor findings.

## Boundaries

This PR does not create a tag, release, package publication, marketplace publication, autonomous merge path, or new authority grant.
