### PR TITLE
docs: link live demo and seat-run evidence; clarify Narcissus naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ held by **The Eye**.
 
 Core packages: **Node ≥18 · zero runtime dependencies · MIT**
 
+**Live demo:** [dsmcewan.github.io/TELOS](https://dsmcewan.github.io/TELOS/) verifies the committed Ed25519 evidence in your browser, including the signed needs-human record that halted an over-cap ads-budget action.
+
 ## Two-minute fail-closed proof
 
 From a fresh clone—no install, API key, service, or network access:
@@ -422,9 +424,12 @@ npm --prefix narcissus/flagship run test:e2e
 
 ## Provenance
 
-TELOS is architected and governed by Drason McEwan (**The Eye**); the required
-model seats — `claude`, `agy`, `codex` — and the advisory seats — `grok`,
-`gemini` — collaborate under the deterministic gate described above. The
+TELOS is architected and governed by Drason McEwan, who holds **The Eye**.
+The required seats (`claude`, `agy`, `codex`) and advisory seats (`grok`,
+`gemini`) collaborate under the deterministic gate described above. Seat
+fallibility is kept as committed evidence, not cleaned up: see the confident
+domain hallucination from a live `gemini` seat preserved verbatim in
+[docs/runs/plugin-seats/summary.json](docs/runs/plugin-seats/summary.json). The
 repository dogfoods its own deterministic review, evidence, signature,
 negative-control, and institutional-memory mechanisms; generated text or code
 is still data, not authority or certification.

--- a/docs/mythological-vocabulary.md
+++ b/docs/mythological-vocabulary.md
@@ -53,3 +53,9 @@ blame or credit land on a component that did nothing (chat-rendering corruption 
 unless Hermes handled that transport path). That is the content-address rule one layer up — a mutable
 label standing where an identity belongs. A name drifting from its referent is the same defect whether
 it keys an enforcement decision or an attribution.
+
+Note on Narcissus: the shipped `narcissus/flagship` package is a product
+built under the Narcissus banner and enrolled as such in the Iliad registry;
+the Narcissus *role* above (the reflection-loop module) remains
+registered-unimplemented. The enrollment registry and `verify-contracts`
+keep the two distinct.


### PR DESCRIPTION
- README links the live demo page and a committed seat-run sample (docs/runs/plugin-seats/summary.json) alongside the existing local proof.
- Provenance section now names the maintainer and the seat roster in prose.
- mythological-vocabulary.md gains a note distinguishing the Narcissus role from the narcissus/flagship product.

verify-contracts: 301/301 locally.